### PR TITLE
SSO / OIDC support (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to PriceStalker will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-21
+
+### Added
+
+- **Single Sign-On via OIDC (BETA)** — PriceStalker can now act as an OIDC
+  Relying Party against any compliant provider (Authentik, Keycloak,
+  Google, Okta, Auth0, …) using the Authorization Code + PKCE flow. Full
+  design doc at [`docs/SSO_DESIGN.md`](docs/SSO_DESIGN.md).
+
+  **Feature-flagged off by default** — set `ENABLE_SSO=true` on the
+  backend + configure a provider in Settings → Authentication before any
+  user-visible change. Existing deployments upgrading from 1.1.x see no
+  difference until they opt in.
+
+  **Admin policy options** (Settings → Authentication):
+  - `local` — current behavior, OIDC UI hidden
+  - `both` — local form + "Sign in with X" button, user picks
+  - `oidc` — SSO-only with auto-redirect; break-glass admin fallback via
+    `/login?local=1` so a misconfigured IdP can never lock you out
+
+  **Admin toggles**:
+  - JIT provisioning — auto-create PriceStalker accounts from first OIDC
+    sign-in (default on)
+  - Require verified email — enforce `email_verified=true` in ID token or
+    userinfo (default on; admins running self-hosted IdPs like Authentik
+    can disable it so they don't have to customize their scope mappings)
+  - Test discovery — one-click validation of an issuer URL before saving
+
+  **Identity resolution**: matches by stable `(oidc_issuer, oidc_subject)`
+  first, falls back to email-linking against existing local accounts, JIT-
+  creates if neither matches. First user in the DB is auto-promoted to
+  admin (same rule as local registration).
+
+  **Known limitation** (BETA): logging out of the IdP does not log you
+  out of PriceStalker. Single Logout (SLO) is on the v1.3.0 roadmap. Use
+  PriceStalker's own logout button for now.
+
+### Changed
+
+- Refactored `adminMiddleware` from `routes/admin.ts` into its own
+  `middleware/admin.ts` so it can be reused by the new admin-auth routes.
+- `users.password_hash` is now nullable (OIDC-provisioned users never had
+  one). Attempting to change a password on an SSO account returns a
+  clear error directing you to your IdP instead.
+
 ## [1.1.3] - 2026-04-21
 
 ### Fixed

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pricestalker-backend",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pricestalker-backend",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.24.0",
         "@google/generative-ai": "^0.24.1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^3.0.3",
         "openai": "^4.47.0",
+        "openid-client": "^5.7.0",
         "pg": "^8.11.3",
         "puppeteer": "^22.0.0",
         "puppeteer-extra": "^3.3.6",
@@ -2777,6 +2778,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3264,6 +3274,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3274,6 +3293,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -3341,6 +3369,33 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",
     "openai": "^4.47.0",
+    "openid-client": "^5.7.0",
     "pg": "^8.11.3",
     "puppeteer": "^22.0.0",
     "puppeteer-extra": "^3.3.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricestalker-backend",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "PriceStalker price tracking API",
   "main": "dist/index.js",
   "scripts": {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -208,9 +208,20 @@ async function runMigrations() {
         oidc_client_secret TEXT,
         oidc_scopes TEXT NOT NULL DEFAULT 'openid profile email',
         oidc_jit_enabled BOOLEAN NOT NULL DEFAULT true,
+        oidc_require_email_verified BOOLEAN NOT NULL DEFAULT true,
         updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
       );
       INSERT INTO auth_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+      -- idempotent add for existing rows
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'auth_config' AND column_name = 'oidc_require_email_verified'
+        ) THEN
+          ALTER TABLE auth_config ADD COLUMN oidc_require_email_verified BOOLEAN NOT NULL DEFAULT true;
+        END IF;
+      END $$;
     `);
 
     // Create stock_status_history table if it doesn't exist

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 
 import authRoutes from './routes/auth';
+import oidcRoutes from './routes/oidc';
 import productRoutes from './routes/products';
 import priceRoutes from './routes/prices';
 import settingsRoutes from './routes/settings';
@@ -320,6 +321,7 @@ app.get('/health', (_, res) => {
 
 // API Routes
 app.use('/api/auth', authRoutes);
+app.use('/api/auth/oidc', oidcRoutes);
 app.use('/api/products', productRoutes);
 app.use('/api/products', priceRoutes);
 app.use('/api/settings', settingsRoutes);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import priceRoutes from './routes/prices';
 import settingsRoutes from './routes/settings';
 import profileRoutes from './routes/profile';
 import adminRoutes from './routes/admin';
+import adminAuthRoutes from './routes/admin-auth';
 import notificationRoutes from './routes/notifications';
 import { startScheduler } from './services/scheduler';
 import pool from './config/database';
@@ -167,7 +168,48 @@ async function runMigrations() {
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'openrouter_model') THEN
           ALTER TABLE users ADD COLUMN openrouter_model TEXT;
         END IF;
+        -- SSO / OIDC columns (v1.2.0)
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'auth_provider') THEN
+          ALTER TABLE users ADD COLUMN auth_provider VARCHAR(20) NOT NULL DEFAULT 'local';
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'oidc_subject') THEN
+          ALTER TABLE users ADD COLUMN oidc_subject TEXT;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'oidc_issuer') THEN
+          ALTER TABLE users ADD COLUMN oidc_issuer TEXT;
+        END IF;
+        -- OIDC-provisioned users have no password; allow NULL
+        IF EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'users' AND column_name = 'password_hash' AND is_nullable = 'NO'
+        ) THEN
+          ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL;
+        END IF;
       END $$;
+    `);
+
+    // Unique index on (oidc_issuer, oidc_subject) for fast identity lookup
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS users_oidc_sub_idx
+      ON users(oidc_issuer, oidc_subject)
+      WHERE oidc_subject IS NOT NULL;
+    `);
+
+    // auth_config singleton table
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS auth_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        policy VARCHAR(20) NOT NULL DEFAULT 'local',
+        oidc_enabled BOOLEAN NOT NULL DEFAULT false,
+        oidc_provider_name TEXT,
+        oidc_issuer_url TEXT,
+        oidc_client_id TEXT,
+        oidc_client_secret TEXT,
+        oidc_scopes TEXT NOT NULL DEFAULT 'openid profile email',
+        oidc_jit_enabled BOOLEAN NOT NULL DEFAULT true,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO auth_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
     `);
 
     // Create stock_status_history table if it doesn't exist
@@ -283,6 +325,7 @@ app.use('/api/products', priceRoutes);
 app.use('/api/settings', settingsRoutes);
 app.use('/api/profile', profileRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/admin/auth', adminAuthRoutes);
 app.use('/api/notifications', notificationRoutes);
 
 // Error handling middleware

--- a/backend/src/middleware/admin.ts
+++ b/backend/src/middleware/admin.ts
@@ -1,0 +1,24 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from './auth';
+import { userQueries } from '../models';
+
+export const adminMiddleware = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const user = await userQueries.findById(userId);
+
+    if (!user || !user.is_admin) {
+      res.status(403).json({ error: 'Admin access required' });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    console.error('Admin middleware error:', error);
+    res.status(500).json({ error: 'Failed to verify admin status' });
+  }
+};

--- a/backend/src/models/auth-config.ts
+++ b/backend/src/models/auth-config.ts
@@ -1,0 +1,113 @@
+import pool from '../config/database';
+
+export type AuthPolicy = 'local' | 'oidc' | 'both';
+
+export interface AuthConfig {
+  policy: AuthPolicy;
+  oidc_enabled: boolean;
+  oidc_provider_name: string | null;
+  oidc_issuer_url: string | null;
+  oidc_client_id: string | null;
+  oidc_client_secret: string | null;
+  oidc_scopes: string;
+  oidc_jit_enabled: boolean;
+  updated_at: Date;
+}
+
+// What the admin sees — no raw secret, just a boolean
+export type AuthConfigAdminView = Omit<AuthConfig, 'oidc_client_secret' | 'updated_at'> & {
+  has_client_secret: boolean;
+  updated_at: string;
+};
+
+// What the public login page sees — enough to render the correct UI, nothing more
+export interface AuthConfigPublicView {
+  policy: AuthPolicy;
+  oidc_enabled: boolean;
+  oidc_provider_name: string | null;
+}
+
+// Mutations: undefined = unchanged, null = clear, string = set
+export interface AuthConfigUpdate {
+  policy?: AuthPolicy;
+  oidc_enabled?: boolean;
+  oidc_provider_name?: string | null;
+  oidc_issuer_url?: string | null;
+  oidc_client_id?: string | null;
+  oidc_client_secret?: string | null;
+  oidc_scopes?: string;
+  oidc_jit_enabled?: boolean;
+}
+
+export const authConfigQueries = {
+  get: async (): Promise<AuthConfig> => {
+    const result = await pool.query(
+      `SELECT policy, oidc_enabled, oidc_provider_name, oidc_issuer_url,
+              oidc_client_id, oidc_client_secret, oidc_scopes, oidc_jit_enabled,
+              updated_at
+       FROM auth_config WHERE id = 1`,
+    );
+    // The startup migration ensures a row with id=1 always exists.
+    return result.rows[0];
+  },
+
+  getAdminView: async (): Promise<AuthConfigAdminView> => {
+    const cfg = await authConfigQueries.get();
+    return {
+      policy: cfg.policy,
+      oidc_enabled: cfg.oidc_enabled,
+      oidc_provider_name: cfg.oidc_provider_name,
+      oidc_issuer_url: cfg.oidc_issuer_url,
+      oidc_client_id: cfg.oidc_client_id,
+      has_client_secret: cfg.oidc_client_secret !== null && cfg.oidc_client_secret !== '',
+      oidc_scopes: cfg.oidc_scopes,
+      oidc_jit_enabled: cfg.oidc_jit_enabled,
+      updated_at: cfg.updated_at.toISOString(),
+    };
+  },
+
+  getPublicView: async (): Promise<AuthConfigPublicView> => {
+    const cfg = await authConfigQueries.get();
+    return {
+      policy: cfg.policy,
+      oidc_enabled: cfg.oidc_enabled,
+      oidc_provider_name: cfg.oidc_provider_name,
+    };
+  },
+
+  update: async (changes: AuthConfigUpdate): Promise<AuthConfig> => {
+    const fields: string[] = [];
+    const values: (string | boolean | null)[] = [];
+    let paramIndex = 1;
+
+    const maybePush = (col: string, value: unknown) => {
+      if (value === undefined) return;
+      fields.push(`${col} = $${paramIndex++}`);
+      values.push(value as string | boolean | null);
+    };
+
+    maybePush('policy', changes.policy);
+    maybePush('oidc_enabled', changes.oidc_enabled);
+    maybePush('oidc_provider_name', changes.oidc_provider_name);
+    maybePush('oidc_issuer_url', changes.oidc_issuer_url);
+    maybePush('oidc_client_id', changes.oidc_client_id);
+    maybePush('oidc_client_secret', changes.oidc_client_secret);
+    maybePush('oidc_scopes', changes.oidc_scopes);
+    maybePush('oidc_jit_enabled', changes.oidc_jit_enabled);
+
+    if (fields.length === 0) {
+      return authConfigQueries.get();
+    }
+
+    fields.push(`updated_at = CURRENT_TIMESTAMP`);
+
+    const result = await pool.query(
+      `UPDATE auth_config SET ${fields.join(', ')} WHERE id = 1
+       RETURNING policy, oidc_enabled, oidc_provider_name, oidc_issuer_url,
+                 oidc_client_id, oidc_client_secret, oidc_scopes, oidc_jit_enabled,
+                 updated_at`,
+      values,
+    );
+    return result.rows[0];
+  },
+};

--- a/backend/src/models/auth-config.ts
+++ b/backend/src/models/auth-config.ts
@@ -11,6 +11,7 @@ export interface AuthConfig {
   oidc_client_secret: string | null;
   oidc_scopes: string;
   oidc_jit_enabled: boolean;
+  oidc_require_email_verified: boolean;
   updated_at: Date;
 }
 
@@ -37,6 +38,7 @@ export interface AuthConfigUpdate {
   oidc_client_secret?: string | null;
   oidc_scopes?: string;
   oidc_jit_enabled?: boolean;
+  oidc_require_email_verified?: boolean;
 }
 
 export const authConfigQueries = {
@@ -44,7 +46,7 @@ export const authConfigQueries = {
     const result = await pool.query(
       `SELECT policy, oidc_enabled, oidc_provider_name, oidc_issuer_url,
               oidc_client_id, oidc_client_secret, oidc_scopes, oidc_jit_enabled,
-              updated_at
+              oidc_require_email_verified, updated_at
        FROM auth_config WHERE id = 1`,
     );
     // The startup migration ensures a row with id=1 always exists.
@@ -62,6 +64,7 @@ export const authConfigQueries = {
       has_client_secret: cfg.oidc_client_secret !== null && cfg.oidc_client_secret !== '',
       oidc_scopes: cfg.oidc_scopes,
       oidc_jit_enabled: cfg.oidc_jit_enabled,
+      oidc_require_email_verified: cfg.oidc_require_email_verified,
       updated_at: cfg.updated_at.toISOString(),
     };
   },
@@ -94,6 +97,7 @@ export const authConfigQueries = {
     maybePush('oidc_client_secret', changes.oidc_client_secret);
     maybePush('oidc_scopes', changes.oidc_scopes);
     maybePush('oidc_jit_enabled', changes.oidc_jit_enabled);
+    maybePush('oidc_require_email_verified', changes.oidc_require_email_verified);
 
     if (fields.length === 0) {
       return authConfigQueries.get();
@@ -105,7 +109,7 @@ export const authConfigQueries = {
       `UPDATE auth_config SET ${fields.join(', ')} WHERE id = 1
        RETURNING policy, oidc_enabled, oidc_provider_name, oidc_issuer_url,
                  oidc_client_id, oidc_client_secret, oidc_scopes, oidc_jit_enabled,
-                 updated_at`,
+                 oidc_require_email_verified, updated_at`,
       values,
     );
     return result.rows[0];

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -1,16 +1,21 @@
 import pool from '../config/database';
 
 // User types and queries
+export type AuthProvider = 'local' | 'oidc';
+
 export interface User {
   id: number;
   email: string;
-  password_hash: string;
+  password_hash: string | null; // null for OIDC-only users
   name: string | null;
   is_admin: boolean;
   telegram_bot_token: string | null;
   telegram_chat_id: string | null;
   discord_webhook_url: string | null;
   created_at: Date;
+  auth_provider: AuthProvider;
+  oidc_subject: string | null;
+  oidc_issuer: string | null;
 }
 
 export interface UserProfile {
@@ -77,10 +82,56 @@ export const userQueries = {
 
   create: async (email: string, passwordHash: string): Promise<User> => {
     const result = await pool.query(
-      'INSERT INTO users (email, password_hash) VALUES ($1, $2) RETURNING *',
+      `INSERT INTO users (email, password_hash, auth_provider)
+       VALUES ($1, $2, 'local') RETURNING *`,
       [email, passwordHash]
     );
     return result.rows[0];
+  },
+
+  // JIT-provision a user from an OIDC identity claim set. password_hash stays
+  // NULL (they'll only ever sign in via the same provider). If name is the
+  // empty string or undefined, store NULL.
+  createOidc: async (params: {
+    email: string;
+    name: string | null;
+    issuer: string;
+    subject: string;
+  }): Promise<User> => {
+    const result = await pool.query(
+      `INSERT INTO users (email, name, auth_provider, oidc_issuer, oidc_subject)
+       VALUES ($1, $2, 'oidc', $3, $4) RETURNING *`,
+      [params.email, params.name || null, params.issuer, params.subject]
+    );
+    return result.rows[0];
+  },
+
+  findByOidcSubject: async (issuer: string, subject: string): Promise<User | null> => {
+    const result = await pool.query(
+      'SELECT * FROM users WHERE oidc_issuer = $1 AND oidc_subject = $2',
+      [issuer, subject]
+    );
+    return result.rows[0] || null;
+  },
+
+  // Link an existing local user to an OIDC identity without changing their
+  // auth_provider. This preserves the break-glass capability — they can still
+  // sign in with a password if needed.
+  linkOidcIdentity: async (
+    userId: number,
+    issuer: string,
+    subject: string,
+  ): Promise<boolean> => {
+    const result = await pool.query(
+      `UPDATE users SET oidc_issuer = $1, oidc_subject = $2 WHERE id = $3`,
+      [issuer, subject, userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  },
+
+  count: async (): Promise<number> => {
+    const result = await pool.query('SELECT COUNT(*)::int AS count FROM users');
+    return result.rows[0]?.count ?? 0;
   },
 
   getNotificationSettings: async (id: number): Promise<NotificationSettings | null> => {

--- a/backend/src/routes/admin-auth.ts
+++ b/backend/src/routes/admin-auth.ts
@@ -1,0 +1,134 @@
+import { Router, Response } from 'express';
+import { AuthRequest, authMiddleware } from '../middleware/auth';
+import { adminMiddleware } from '../middleware/admin';
+import {
+  authConfigQueries,
+  AuthPolicy,
+  AuthConfigUpdate,
+} from '../models/auth-config';
+
+const router = Router();
+
+router.use(authMiddleware);
+router.use(adminMiddleware);
+
+const VALID_POLICIES: AuthPolicy[] = ['local', 'oidc', 'both'];
+
+// GET /api/admin/auth — current config (no raw secret)
+router.get('/', async (_req: AuthRequest, res: Response) => {
+  try {
+    const config = await authConfigQueries.getAdminView();
+    res.json(config);
+  } catch (error) {
+    console.error('Error fetching auth config:', error);
+    res.status(500).json({ error: 'Failed to fetch auth config' });
+  }
+});
+
+// PUT /api/admin/auth — update config.
+// oidc_client_secret semantics: undefined = keep existing, null/"" = clear,
+// string = set to new value. Plain strings on the wire are the only way to
+// rotate the secret (admin pastes new value).
+router.put('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const body = req.body as Partial<AuthConfigUpdate>;
+
+    if (body.policy !== undefined && !VALID_POLICIES.includes(body.policy)) {
+      res.status(400).json({ error: `policy must be one of: ${VALID_POLICIES.join(', ')}` });
+      return;
+    }
+
+    // Normalize the secret field: the admin UI sends '' when the user clears
+    // the masked input; treat that as "clear it". `undefined` means the field
+    // wasn't touched and we leave the stored value alone.
+    const changes: AuthConfigUpdate = { ...body };
+    if (changes.oidc_client_secret === '') {
+      changes.oidc_client_secret = null;
+    }
+
+    // Guardrail: enabling OIDC without an issuer URL or client ID will produce
+    // a broken login page. Refuse rather than silently half-configure.
+    if (changes.oidc_enabled === true) {
+      const current = await authConfigQueries.get();
+      const nextIssuer = changes.oidc_issuer_url ?? current.oidc_issuer_url;
+      const nextClientId = changes.oidc_client_id ?? current.oidc_client_id;
+      if (!nextIssuer || !nextClientId) {
+        res.status(400).json({
+          error: 'Cannot enable OIDC without both issuer URL and client ID configured',
+        });
+        return;
+      }
+    }
+
+    await authConfigQueries.update(changes);
+    const updated = await authConfigQueries.getAdminView();
+    res.json(updated);
+  } catch (error) {
+    console.error('Error updating auth config:', error);
+    res.status(500).json({ error: 'Failed to update auth config' });
+  }
+});
+
+// POST /api/admin/auth/test-discovery — hit the provider's well-known
+// endpoint and report success/error so the admin can validate the issuer URL
+// before saving it.
+router.post('/test-discovery', async (req: AuthRequest, res: Response) => {
+  const { issuer_url } = req.body as { issuer_url?: string };
+
+  if (!issuer_url || typeof issuer_url !== 'string') {
+    res.status(400).json({ ok: false, error: 'issuer_url is required' });
+    return;
+  }
+
+  // OIDC discovery: per spec, the well-known doc lives at
+  //   {issuer}/.well-known/openid-configuration
+  // We normalize trailing slashes so users can paste the issuer URL either way.
+  const normalized = issuer_url.replace(/\/+$/, '');
+  const discoveryUrl = `${normalized}/.well-known/openid-configuration`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    const response = await fetch(discoveryUrl, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      res.status(400).json({
+        ok: false,
+        error: `Provider returned HTTP ${response.status} for ${discoveryUrl}`,
+      });
+      return;
+    }
+
+    const doc = (await response.json()) as {
+      issuer?: string;
+      authorization_endpoint?: string;
+      token_endpoint?: string;
+      jwks_uri?: string;
+    };
+
+    // Sanity: a real OIDC discovery doc must have these fields
+    const missing = (['issuer', 'authorization_endpoint', 'token_endpoint', 'jwks_uri'] as const)
+      .filter((f) => !doc[f]);
+    if (missing.length > 0) {
+      res.status(400).json({
+        ok: false,
+        error: `Discovery document missing required fields: ${missing.join(', ')}`,
+      });
+      return;
+    }
+
+    res.json({
+      ok: true,
+      issuer: doc.issuer,
+      authorization_endpoint: doc.authorization_endpoint,
+      token_endpoint: doc.token_endpoint,
+      jwks_uri: doc.jwks_uri,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(400).json({ ok: false, error: `Failed to reach ${discoveryUrl}: ${message}` });
+  }
+});
+
+export default router;

--- a/backend/src/routes/admin-auth.ts
+++ b/backend/src/routes/admin-auth.ts
@@ -6,6 +6,7 @@ import {
   AuthPolicy,
   AuthConfigUpdate,
 } from '../models/auth-config';
+import { invalidateOidcClient } from '../services/oidc';
 
 const router = Router();
 
@@ -61,6 +62,9 @@ router.put('/', async (req: AuthRequest, res: Response) => {
     }
 
     await authConfigQueries.update(changes);
+    // Any change might have rotated issuer/client/secret — force a fresh
+    // openid-client discovery on the next flow.
+    invalidateOidcClient();
     const updated = await authConfigQueries.getAdminView();
     res.json(updated);
   } catch (error) {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,31 +1,13 @@
-import { Router, Response, NextFunction } from 'express';
+import { Router, Response } from 'express';
 import bcrypt from 'bcrypt';
 import { AuthRequest, authMiddleware } from '../middleware/auth';
+import { adminMiddleware } from '../middleware/admin';
 import { userQueries, systemSettingsQueries } from '../models';
 
 const router = Router();
 
-// All routes require authentication
+// All routes require authentication + admin
 router.use(authMiddleware);
-
-// Admin middleware - checks if user is admin
-const adminMiddleware = async (req: AuthRequest, res: Response, next: NextFunction) => {
-  try {
-    const userId = req.userId!;
-    const user = await userQueries.findById(userId);
-
-    if (!user || !user.is_admin) {
-      res.status(403).json({ error: 'Admin access required' });
-      return;
-    }
-
-    next();
-  } catch (error) {
-    console.error('Admin middleware error:', error);
-    res.status(500).json({ error: 'Failed to verify admin status' });
-  }
-};
-
 router.use(adminMiddleware);
 
 // Get all users

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import bcrypt from 'bcrypt';
 import { userQueries, systemSettingsQueries } from '../models';
+import { authConfigQueries } from '../models/auth-config';
 import { generateToken } from '../middleware/auth';
 
 const router = Router();
@@ -20,6 +21,15 @@ router.get('/registration-status', async (_req: Request, res: Response) => {
 router.post('/register', async (req: Request, res: Response) => {
   try {
     const { email, password } = req.body;
+
+    // If the instance is in OIDC-only mode, public local registration is
+    // disabled — users come in via the IdP + JIT provisioning. Local
+    // registration remains open in `local` and `both` policy modes.
+    const authConfig = await authConfigQueries.get();
+    if (authConfig.policy === 'oidc') {
+      res.status(403).json({ error: 'Local registration is disabled on this instance (OIDC only)' });
+      return;
+    }
 
     // Check if registration is enabled
     const registrationEnabled = await systemSettingsQueries.get('registration_enabled');
@@ -94,9 +104,24 @@ router.post('/login', async (req: Request, res: Response) => {
       return;
     }
 
+    // OIDC users have no password. Don't leak which accounts are which —
+    // same generic error as a wrong password.
+    if (!user.password_hash) {
+      res.status(401).json({ error: 'Invalid email or password' });
+      return;
+    }
+
     const isValidPassword = await bcrypt.compare(password, user.password_hash);
     if (!isValidPassword) {
       res.status(401).json({ error: 'Invalid email or password' });
+      return;
+    }
+
+    // In OIDC-only mode, only admins with a password can sign in via the local
+    // form (break-glass). Everyone else is directed to use SSO.
+    const authConfig = await authConfigQueries.get();
+    if (authConfig.policy === 'oidc' && !user.is_admin) {
+      res.status(403).json({ error: 'Local login is disabled. Please sign in via SSO.' });
       return;
     }
 

--- a/backend/src/routes/oidc.ts
+++ b/backend/src/routes/oidc.ts
@@ -1,0 +1,191 @@
+import { Router, Request, Response } from 'express';
+import { userQueries } from '../models';
+import { authConfigQueries } from '../models/auth-config';
+import { generateToken } from '../middleware/auth';
+import {
+  isSsoEnabled,
+  startFlow,
+  completeFlow,
+  getFrontendCompleteUrl,
+  OidcClaims,
+} from '../services/oidc';
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Feature flag gate
+// ---------------------------------------------------------------------------
+
+router.use((req: Request, res: Response, next) => {
+  if (!isSsoEnabled()) {
+    res.status(404).json({ error: 'SSO is not enabled on this server' });
+    return;
+  }
+  next();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/oidc/config/public
+// The login page calls this unauthenticated to decide what to render.
+// ---------------------------------------------------------------------------
+
+router.get('/config/public', async (_req: Request, res: Response) => {
+  try {
+    const view = await authConfigQueries.getPublicView();
+    res.json(view);
+  } catch (error) {
+    console.error('Error fetching public auth config:', error);
+    res.status(500).json({ error: 'Failed to fetch auth config' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/oidc/start
+// Kicks off the Authorization Code + PKCE flow and 302s to the IdP.
+// ---------------------------------------------------------------------------
+
+router.get('/start', async (_req: Request, res: Response) => {
+  try {
+    const cfg = await authConfigQueries.get();
+    if (!cfg.oidc_enabled) {
+      res.status(400).json({ error: 'OIDC is not enabled in auth config' });
+      return;
+    }
+
+    const { authorizationUrl } = await startFlow();
+    res.redirect(302, authorizationUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Error starting OIDC flow:', error);
+    // Fail closed: redirect to frontend with a visible error rather than
+    // dumping a stack in JSON (user is mid-browser-flow, not an API call).
+    const completeUrl = tryCompleteUrl();
+    if (completeUrl) {
+      res.redirect(302, `${completeUrl}#error=${encodeURIComponent(message)}`);
+    } else {
+      res.status(500).json({ error: `Failed to start OIDC flow: ${message}` });
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/oidc/callback
+// Provider redirects here with ?code=...&state=... on success or
+// ?error=...&error_description=... on failure.
+// ---------------------------------------------------------------------------
+
+router.get('/callback', async (req: Request, res: Response) => {
+  const completeUrl = tryCompleteUrl();
+
+  const redirectWithError = (message: string) => {
+    console.error('OIDC callback error:', message);
+    if (completeUrl) {
+      res.redirect(302, `${completeUrl}#error=${encodeURIComponent(message)}`);
+    } else {
+      res.status(500).json({ error: message });
+    }
+  };
+
+  try {
+    const { code, state, error, error_description } = req.query as Record<string, string>;
+
+    // Provider-signalled error (user cancelled, policy denied, etc.)
+    if (error) {
+      redirectWithError(error_description || error);
+      return;
+    }
+
+    if (!code || !state) {
+      redirectWithError('Missing code or state in callback');
+      return;
+    }
+
+    const cfg = await authConfigQueries.get();
+    if (!cfg.oidc_enabled) {
+      redirectWithError('OIDC is not enabled in auth config');
+      return;
+    }
+
+    // The openid-client library needs the raw URLSearchParams, not Express's
+    // already-parsed req.query.
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(req.query)) {
+      if (typeof v === 'string') params.append(k, v);
+    }
+
+    const claims = await completeFlow(params, state);
+    const user = await upsertUserFromClaims(claims, cfg.oidc_jit_enabled);
+
+    if (!user) {
+      redirectWithError(
+        'No PriceStalker account for this OIDC identity and JIT provisioning is disabled. Ask an admin to create an account.',
+      );
+      return;
+    }
+
+    const token = generateToken(user.id);
+    // Hash fragment keeps the JWT out of server access logs.
+    res.redirect(302, `${completeUrl}#token=${encodeURIComponent(token)}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    redirectWithError(message);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tryCompleteUrl(): string | null {
+  try {
+    return getFrontendCompleteUrl();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Identity resolution order, per SSO_DESIGN.md:
+ *   1. Match by (oidc_issuer, oidc_subject) — returning user.
+ *   2. Match by email — existing local user, auto-link to this OIDC identity.
+ *   3. JIT-create a new OIDC user (if JIT is enabled).
+ *
+ * First user in the DB is promoted to admin regardless of the path taken,
+ * matching the first-admin rule that already applies to local registration.
+ */
+async function upsertUserFromClaims(
+  claims: OidcClaims,
+  jitEnabled: boolean,
+) {
+  // 1. Match by stable OIDC identity
+  const bySubject = await userQueries.findByOidcSubject(claims.issuer, claims.subject);
+  if (bySubject) return bySubject;
+
+  // 2. Match by email — link existing local account
+  const byEmail = await userQueries.findByEmail(claims.email);
+  if (byEmail) {
+    await userQueries.linkOidcIdentity(byEmail.id, claims.issuer, claims.subject);
+    return byEmail;
+  }
+
+  // 3. JIT-create
+  if (!jitEnabled) return null;
+
+  const existingCount = await userQueries.count();
+  const newUser = await userQueries.createOidc({
+    email: claims.email,
+    name: claims.name,
+    issuer: claims.issuer,
+    subject: claims.subject,
+  });
+
+  // First user (this one makes the count 1) becomes admin.
+  if (existingCount === 0) {
+    await userQueries.setAdmin(newUser.id, true);
+    newUser.is_admin = true;
+  }
+
+  return newUser;
+}
+
+export default router;

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -69,6 +69,14 @@ router.put('/password', async (req: AuthRequest, res: Response) => {
       return;
     }
 
+    // OIDC-only users never had a password and can't change one here.
+    if (!user.password_hash) {
+      res.status(400).json({
+        error: 'This account signs in via SSO. Password changes happen in your identity provider.',
+      });
+      return;
+    }
+
     const isValidPassword = await bcrypt.compare(current_password, user.password_hash);
     if (!isValidPassword) {
       res.status(401).json({ error: 'Current password is incorrect' });

--- a/backend/src/services/oidc.ts
+++ b/backend/src/services/oidc.ts
@@ -1,0 +1,237 @@
+// OIDC client cache + flow state store.
+//
+// The openid-client Client is expensive to construct (requires hitting the
+// provider's .well-known endpoint and parsing the JWKS). We cache one Client
+// and invalidate it whenever the admin saves the auth config.
+//
+// Flow state (state, code_verifier, nonce) lives in memory keyed by the state
+// value. This is safe with a single backend replica — see SSO_DESIGN.md.
+
+import { Client, Issuer, TokenSet, generators } from 'openid-client';
+import { authConfigQueries, AuthConfig } from '../models/auth-config';
+
+// ---------------------------------------------------------------------------
+// Feature flag
+// ---------------------------------------------------------------------------
+
+export function isSsoEnabled(): boolean {
+  return process.env.ENABLE_SSO === 'true';
+}
+
+// ---------------------------------------------------------------------------
+// Redirect URI derivation
+// ---------------------------------------------------------------------------
+
+export function getRedirectUri(): string {
+  const override = process.env.OIDC_REDIRECT_URI_OVERRIDE;
+  if (override) return override;
+  const base = process.env.PUBLIC_URL;
+  if (!base) {
+    throw new Error(
+      'PUBLIC_URL env var is required when SSO is enabled (or set OIDC_REDIRECT_URI_OVERRIDE)',
+    );
+  }
+  return `${base.replace(/\/+$/, '')}/api/auth/oidc/callback`;
+}
+
+export function getFrontendCompleteUrl(): string {
+  const base = process.env.PUBLIC_URL;
+  if (!base) {
+    throw new Error('PUBLIC_URL env var is required when SSO is enabled');
+  }
+  return `${base.replace(/\/+$/, '')}/auth/sso-complete`;
+}
+
+// ---------------------------------------------------------------------------
+// Client cache
+// ---------------------------------------------------------------------------
+
+let cachedClient: Client | null = null;
+let cachedClientKey: string | null = null;
+
+function configCacheKey(cfg: AuthConfig): string {
+  // Cache key includes everything that would change the issued Client.
+  // Redirect URI is environment-derived but we still include it so env changes
+  // also invalidate.
+  return JSON.stringify({
+    issuer: cfg.oidc_issuer_url,
+    clientId: cfg.oidc_client_id,
+    clientSecret: cfg.oidc_client_secret, // rotating the secret should rebuild the client
+    redirect: getRedirectUri(),
+  });
+}
+
+export function invalidateOidcClient(): void {
+  cachedClient = null;
+  cachedClientKey = null;
+}
+
+export async function getOidcClient(): Promise<Client> {
+  const cfg = await authConfigQueries.get();
+
+  if (!cfg.oidc_enabled) {
+    throw new Error('OIDC is not enabled');
+  }
+  if (!cfg.oidc_issuer_url || !cfg.oidc_client_id) {
+    throw new Error('OIDC issuer URL and client ID are required');
+  }
+
+  const key = configCacheKey(cfg);
+  if (cachedClient && cachedClientKey === key) {
+    return cachedClient;
+  }
+
+  const issuer = await Issuer.discover(cfg.oidc_issuer_url);
+  cachedClient = new issuer.Client({
+    client_id: cfg.oidc_client_id,
+    // openid-client expects undefined (not null) for public clients. We don't
+    // support public clients for now; a secret is required.
+    client_secret: cfg.oidc_client_secret ?? undefined,
+    redirect_uris: [getRedirectUri()],
+    response_types: ['code'],
+  });
+  cachedClientKey = key;
+  return cachedClient;
+}
+
+// ---------------------------------------------------------------------------
+// Flow state store
+// ---------------------------------------------------------------------------
+
+interface FlowState {
+  codeVerifier: string;
+  nonce: string;
+  expiresAt: number;
+}
+
+const FLOW_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const flowStates = new Map<string, FlowState>();
+
+// Periodic cleanup of expired entries. Single process, so this is fine.
+const flowStateSweeper = setInterval(() => {
+  const now = Date.now();
+  for (const [key, value] of flowStates.entries()) {
+    if (value.expiresAt < now) flowStates.delete(key);
+  }
+}, 60 * 1000);
+// Don't keep the event loop alive just for the sweeper.
+flowStateSweeper.unref?.();
+
+export function storeFlowState(state: string, codeVerifier: string, nonce: string): void {
+  flowStates.set(state, {
+    codeVerifier,
+    nonce,
+    expiresAt: Date.now() + FLOW_STATE_TTL_MS,
+  });
+}
+
+export function consumeFlowState(state: string): FlowState | null {
+  const entry = flowStates.get(state);
+  if (!entry) return null;
+  flowStates.delete(state); // single-use
+  if (entry.expiresAt < Date.now()) return null;
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Flow helpers — thin wrappers over openid-client so route code stays small.
+// ---------------------------------------------------------------------------
+
+export interface StartedFlow {
+  authorizationUrl: string;
+  state: string;
+}
+
+export async function startFlow(): Promise<StartedFlow> {
+  const cfg = await authConfigQueries.get();
+  const client = await getOidcClient();
+
+  const codeVerifier = generators.codeVerifier();
+  const codeChallenge = generators.codeChallenge(codeVerifier);
+  const state = generators.state();
+  const nonce = generators.nonce();
+
+  storeFlowState(state, codeVerifier, nonce);
+
+  const authorizationUrl = client.authorizationUrl({
+    scope: cfg.oidc_scopes,
+    state,
+    nonce,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+
+  return { authorizationUrl, state };
+}
+
+export interface OidcClaims {
+  issuer: string;
+  subject: string;
+  email: string;
+  emailVerified: boolean;
+  name: string | null;
+}
+
+export async function completeFlow(
+  params: URLSearchParams,
+  state: string,
+): Promise<OidcClaims> {
+  const client = await getOidcClient();
+
+  const stored = consumeFlowState(state);
+  if (!stored) {
+    throw new Error('Invalid or expired OIDC state. Please retry the login.');
+  }
+
+  const tokenSet: TokenSet = await client.callback(
+    getRedirectUri(),
+    Object.fromEntries(params) as Record<string, string>,
+    {
+      state,
+      nonce: stored.nonce,
+      code_verifier: stored.codeVerifier,
+    },
+  );
+
+  const claims = tokenSet.claims();
+
+  // userinfo gives us email/name if not in the ID token (Authentik, for
+  // example, puts them there only if the right scopes are requested).
+  let email = typeof claims.email === 'string' ? claims.email : undefined;
+  let emailVerified = claims.email_verified === true;
+  let name =
+    typeof claims.name === 'string'
+      ? claims.name
+      : typeof claims.preferred_username === 'string'
+      ? claims.preferred_username
+      : null;
+
+  if (!email || typeof claims.email_verified !== 'boolean') {
+    if (tokenSet.access_token) {
+      const info = await client.userinfo(tokenSet.access_token);
+      if (!email && typeof info.email === 'string') email = info.email;
+      if (typeof info.email_verified === 'boolean') emailVerified = info.email_verified;
+      if (!name) {
+        if (typeof info.name === 'string') name = info.name;
+        else if (typeof info.preferred_username === 'string') name = info.preferred_username;
+      }
+    }
+  }
+
+  if (!email) {
+    throw new Error('Provider did not return an email claim — cannot log in.');
+  }
+  if (!emailVerified) {
+    throw new Error(
+      'Provider did not assert email_verified. Refusing to auto-link or create an account.',
+    );
+  }
+
+  const issuer = typeof claims.iss === 'string' ? claims.iss : '';
+  const subject = typeof claims.sub === 'string' ? claims.sub : '';
+  if (!issuer || !subject) {
+    throw new Error('Provider did not return a usable iss/sub pair.');
+  }
+
+  return { issuer, subject, email, emailVerified, name };
+}

--- a/backend/src/services/oidc.ts
+++ b/backend/src/services/oidc.ts
@@ -176,6 +176,7 @@ export async function completeFlow(
   params: URLSearchParams,
   state: string,
 ): Promise<OidcClaims> {
+  const cfg = await authConfigQueries.get();
   const client = await getOidcClient();
 
   const stored = consumeFlowState(state);
@@ -221,9 +222,13 @@ export async function completeFlow(
   if (!email) {
     throw new Error('Provider did not return an email claim — cannot log in.');
   }
-  if (!emailVerified) {
+  // Toggle lets admins accept claims from IdPs that don't emit email_verified
+  // (Authentik's default scope mapping, Keycloak without explicit mapper,
+  // etc.). Default in auth_config is true, so the strict behavior is still
+  // the out-of-the-box behavior.
+  if (cfg.oidc_require_email_verified && !emailVerified) {
     throw new Error(
-      'Provider did not assert email_verified. Refusing to auto-link or create an account.',
+      'Provider did not assert email_verified. Admin can disable this check in Settings → Authentication.',
     );
   }
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -186,6 +186,7 @@ CREATE TABLE IF NOT EXISTS auth_config (
   oidc_client_secret TEXT,
   oidc_scopes TEXT NOT NULL DEFAULT 'openid profile email',
   oidc_jit_enabled BOOLEAN NOT NULL DEFAULT true,
+  oidc_require_email_verified BOOLEAN NOT NULL DEFAULT true,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 INSERT INTO auth_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING;

--- a/database/init.sql
+++ b/database/init.sql
@@ -152,6 +152,44 @@ BEGIN
   END IF;
 END $$;
 
+-- Migration: SSO / OIDC support (v1.2.0)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'auth_provider') THEN
+    ALTER TABLE users ADD COLUMN auth_provider VARCHAR(20) NOT NULL DEFAULT 'local';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'oidc_subject') THEN
+    ALTER TABLE users ADD COLUMN oidc_subject TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'oidc_issuer') THEN
+    ALTER TABLE users ADD COLUMN oidc_issuer TEXT;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'users' AND column_name = 'password_hash' AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_oidc_sub_idx
+  ON users(oidc_issuer, oidc_subject)
+  WHERE oidc_subject IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS auth_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  policy VARCHAR(20) NOT NULL DEFAULT 'local',
+  oidc_enabled BOOLEAN NOT NULL DEFAULT false,
+  oidc_provider_name TEXT,
+  oidc_issuer_url TEXT,
+  oidc_client_id TEXT,
+  oidc_client_secret TEXT,
+  oidc_scopes TEXT NOT NULL DEFAULT 'openid profile email',
+  oidc_jit_enabled BOOLEAN NOT NULL DEFAULT true,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO auth_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
 -- Index for faster price history queries
 CREATE INDEX IF NOT EXISTS idx_price_history_product_date
 ON price_history(product_id, recorded_at);

--- a/docs/SSO_DESIGN.md
+++ b/docs/SSO_DESIGN.md
@@ -1,0 +1,242 @@
+# SSO / OIDC — Design Document
+
+Target release: **v1.2.0**. Feature branch: `feature/sso`.
+
+## Goals
+
+- Let PriceStalker act as an OIDC Relying Party against any compliant provider
+  (Authentik, Keycloak, Google, Okta, Auth0, etc.) using the standard
+  **Authorization Code + PKCE** flow.
+- Coexist with the existing local email/password system — admin picks a policy.
+- Safe, incremental rollout: ship off-by-default, flip on once verified in prod.
+
+## Non-goals (v1.2.0)
+
+- Single Logout (SLO) against the IdP — local logout only for now.
+- SAML. Only OIDC.
+- Multiple simultaneous OIDC providers — one provider at a time.
+- Group → role mapping from provider claims — all OIDC users start as regular
+  users; admin promotes manually (admin-of-first-sight rule below handles the
+  initial admin).
+- SCIM user provisioning — JIT only.
+
+## Decisions (answered by project owner)
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | First-admin on fresh install | **First person to log in (any method) auto-becomes admin.** Row count check in the users table at login time. |
+| 2 | Traefik Authentik middleware | **Remove it.** The app takes over OIDC directly so the fork is usable by anyone, not just users with Authentik in front. |
+| 3 | User invitation model | **JIT only.** Admin grants access in the IdP; user shows up via OIDC; PriceStalker auto-creates them. No pre-provisioning. |
+| 4 | Logout behavior | **Local session logout only** for v1.2.0. SLO can come later. |
+
+## User-visible scope
+
+### Admin policy options
+
+Configured in **Settings → Authentication** (admin only):
+
+- **Local only** — current behavior. OIDC UI hidden on login page. Default for upgrades, so nothing changes for existing users until the admin opts in.
+- **OIDC only** — login page only shows "Sign in with {provider name}". Local password form hidden. Local users can't log in (but still exist in the DB for admin-recovery purposes — see "break-glass" below).
+- **Both** — login page shows local form **and** SSO button. User chooses.
+
+### JIT provisioning
+
+When an OIDC user arrives for the first time:
+
+1. Exchange code → get ID token + userinfo.
+2. Verify `email_verified` claim is `true` (hard-block if the provider doesn't set this — we rely on it for safe auto-link).
+3. Look up existing user by `oidc_subject` (stable ID). If found → log them in.
+4. Else look up by email. If found → link: set `oidc_subject` on that record, log them in. This covers the "admin already had a local account" case.
+5. Else create a new user with `auth_provider='oidc'`, `password_hash=NULL`, email + name from claims.
+6. If this is the **very first** user in the DB → also set `is_admin=true`.
+
+Admin can toggle JIT off if they want to pre-provision users manually in a future version; for v1.2.0 JIT defaults on when OIDC is enabled.
+
+### Break-glass local access
+
+Even in `OIDC only` policy mode, local users with `is_admin=true` must still be able to log in via email/password. Without this, a misconfigured IdP locks out the owner forever. Implementation: policy check treats `(is_admin && password_hash IS NOT NULL)` as always eligible for local login. Documented in admin UI as "admin fallback".
+
+## Technical architecture
+
+### Flow (Authorization Code + PKCE)
+
+```
+Browser                 PriceStalker API           Authentik / IdP
+   │                          │                          │
+   │ click "Sign in with SSO" │                          │
+   │────────────────────────▶│                          │
+   │                          │ discovery + gen           │
+   │                          │ code_verifier/state/nonce │
+   │                          │ store in short-lived      │
+   │                          │ server-side session       │
+   │ 302 redirect to IdP      │                          │
+   │◀─────────────────────────│                          │
+   │────────────────────────────────────────────────────▶│
+   │                          │              authenticate │
+   │◀────────────────────────────────────────────────────│
+   │ 302 back to /api/auth/oidc/callback?code=&state=     │
+   │─────────────────────────▶│                          │
+   │                          │ verify state              │
+   │                          │ exchange code+verifier    │
+   │                          │────────────────────────▶│
+   │                          │       id_token+userinfo  │
+   │                          │◀────────────────────────│
+   │                          │ verify ID token (JWKS)    │
+   │                          │ verify nonce              │
+   │                          │ lookup / JIT-create user  │
+   │                          │ issue our own JWT         │
+   │ 302 to /auth/sso-complete#token=<jwt>                │
+   │◀─────────────────────────│                          │
+   │ JS reads hash, stores in localStorage, clears hash,  │
+   │ redirects to /                                       │
+```
+
+Why the hash fragment, not query string: hash is never sent to the server,
+keeping the short-lived JWT out of access logs.
+
+### Backend
+
+**Library**: [`openid-client`](https://github.com/panva/node-openid-client) v5.x.
+Mature, spec-correct, handles discovery, PKCE, JWKS caching, ID token
+validation. Pin v5.x for CommonJS compatibility (v6+ is ESM-only).
+
+**New routes** (all under `/api/auth/oidc`):
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET`  | `/config/public` | none | Returns `{ enabled, policy, providerName }` — used by the login page to decide what to render |
+| `GET`  | `/start` | none | Initiates flow: generates PKCE + state + nonce, stores server-side, 302 to IdP |
+| `GET`  | `/callback` | none | IdP redirects here with `code` + `state`. Verifies, exchanges, issues JWT, 302 to frontend with `#token=` |
+
+**Admin routes** under `/api/admin/auth` (existing admin middleware):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/` | Read current config (client_secret redacted) |
+| `PUT`  | `/` | Update config |
+| `POST` | `/test-discovery` | Hit the issuer's `.well-known/openid-configuration` and return success/error — lets admin verify the issuer URL before saving |
+
+**Short-lived flow state storage**: we need to persist the `code_verifier`, `state`, and `nonce` between the initial redirect and the callback. Options:
+- Server-side Map with expiry — simple, lost on restart (acceptable, worst case user re-clicks).
+- Redis / DB — overkill for this size.
+
+Going with in-process Map keyed by `state`, entries expire after 10 minutes. Single backend replica (current reality) means this just works. If multi-replica becomes a concern we migrate to Redis.
+
+### Data model changes
+
+New columns on `users` (idempotent migration in `backend/src/index.ts`):
+
+```sql
+ALTER TABLE users ADD COLUMN auth_provider VARCHAR(20) DEFAULT 'local' NOT NULL;
+ALTER TABLE users ADD COLUMN oidc_subject TEXT;
+ALTER TABLE users ADD COLUMN oidc_issuer TEXT;
+CREATE UNIQUE INDEX users_oidc_sub_idx ON users(oidc_issuer, oidc_subject) WHERE oidc_subject IS NOT NULL;
+
+ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL;  -- OIDC users have no password
+```
+
+New table `auth_config` (single row, admin-only):
+
+```sql
+CREATE TABLE IF NOT EXISTS auth_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),  -- singleton row
+  policy VARCHAR(20) NOT NULL DEFAULT 'local',  -- 'local' | 'oidc' | 'both'
+  oidc_enabled BOOLEAN NOT NULL DEFAULT false,
+  oidc_provider_name TEXT,                 -- display label, e.g. "Authentik"
+  oidc_issuer_url TEXT,
+  oidc_client_id TEXT,
+  oidc_client_secret TEXT,                 -- stored plain, never returned via API
+  oidc_scopes TEXT NOT NULL DEFAULT 'openid profile email',
+  oidc_jit_enabled BOOLEAN NOT NULL DEFAULT true,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO auth_config (id) VALUES (1) ON CONFLICT DO NOTHING;
+```
+
+Secret handling: `oidc_client_secret` is read-write server-side only. API GET returns a boolean `has_secret` instead of the value. API PUT accepts a new secret or `null` to keep the existing one. Admin UI shows `••••••` with a "Change secret" action.
+
+### Frontend
+
+**New route**: `/auth/sso-complete` — reads `#token=` from URL hash, stores in `localStorage`, clears hash, navigates to `/`. Unprotected (pre-auth page).
+
+**Login page** (`AuthForm.tsx`) fetches `/api/auth/oidc/config/public` on mount:
+
+- `policy === 'local'` → current form as-is
+- `policy === 'oidc'` → only the "Sign in with {providerName}" button. Small "admin sign-in" link at the bottom that reveals the local form (break-glass).
+- `policy === 'both'` → both, with a visual divider
+
+**Settings → Authentication** (admin-only panel):
+
+- Policy select
+- OIDC enabled toggle
+- Provider name input
+- Issuer URL input + "Test discovery" button
+- Client ID
+- Client secret (write-only field; placeholder shows `••••••` if one is already saved)
+- Scopes (advanced section, collapsed)
+- JIT provisioning toggle
+- Save button
+
+### Security requirements
+
+- **PKCE** (S256) — mandatory, not optional.
+- **State** parameter — 32 bytes, cryptographically random, bound to the flow entry.
+- **Nonce** — 32 bytes, included in ID token claims, verified on callback.
+- **ID token signature** — verified against the provider's JWKS (openid-client handles this).
+- **`email_verified` claim required** — reject callbacks where the provider doesn't assert email verification.
+- **HTTPS-only** — the redirect URI must be `https://...`. Handled by Traefik, no code change needed.
+- **Open redirect protection** — `redirect_uri` is fixed in IdP config, not user-supplied.
+- **Feature flag** — `ENABLE_SSO=false` env var gates all OIDC routes entirely. Ships off by default in v1.2.0.
+
+### Config surface
+
+| Env var | Purpose | Default |
+|---------|---------|---------|
+| `ENABLE_SSO` | Master kill switch for all OIDC routes | `false` |
+| `OIDC_REDIRECT_URI_OVERRIDE` | Override the auto-derived redirect URI (useful for testing behind reverse proxies) | auto: `{PUBLIC_URL}/api/auth/oidc/callback` |
+| `PUBLIC_URL` | Base URL of the app — used to build the redirect URI | `http://localhost` |
+
+Everything else (issuer URL, client ID, client secret, scopes, policy, JIT toggle) is in the DB so admins can change it without redeploying.
+
+## Migration path
+
+### For Mike's deployment
+
+1. Deploy v1.2.0 with `ENABLE_SSO=false` — zero behavior change, local login still works.
+2. Set `ENABLE_SSO=true`, redeploy. SSO routes come alive but policy defaults to `local`, so the login page is unchanged.
+3. In Authentik, create an **OIDC Provider** + **Application** for PriceStalker. Redirect URI: `https://priceghost.ikessler.ch/api/auth/oidc/callback`.
+4. In PriceStalker Settings → Authentication: paste issuer URL, client ID, client secret. Hit "Test discovery". Enable OIDC. Keep policy `both` for safety.
+5. Log out, verify "Sign in with Authentik" button appears, click it, complete flow. Verify identity linking (should link to your existing admin account by email).
+6. Once confident, flip policy to `oidc` (with break-glass admin still available on local).
+7. Remove the Traefik Authentik middleware label from the frontend service. Users now hit PriceStalker's login page directly; OIDC click goes to Authentik.
+
+### For other deployers
+
+Same sequence, just with their own IdP. The feature flag and the `local` default policy mean nothing breaks on upgrade — deliberate action is required to turn SSO on.
+
+## Rollout phases
+
+| Phase | Scope | Commits | PR review gate |
+|-------|-------|---------|----------------|
+| 0 | This doc | 1 | ⬅ we are here |
+| 1 | Backend: deps, DB migrations, auth_config model, admin config endpoints, test-discovery endpoint | 2-3 | Type-check passes, admin config persists |
+| 2 | Backend: `/start` + `/callback` routes, JIT provisioning, identity linking, feature flag | 3-4 | Can complete flow against a test Authentik app |
+| 3 | Frontend: `sso-complete` route, login page `oidc/config/public` fetch, conditional SSO button | 2 | Login page renders correctly per policy |
+| 4 | Frontend: Settings → Authentication admin panel | 2 | Admin can configure end-to-end |
+| 5 | End-to-end test against prod Authentik with policy `both`, preview image deployed as parallel stack on swarm | 0-1 | Manual verification |
+| 6 | Merge to main, cut v1.2.0, ship | — | — |
+
+## Open questions / risks
+
+- **Clock skew on ID token validation** — openid-client allows some tolerance; default 60s should be fine, document if not.
+- **Email collision at JIT time** — two users in the IdP with the same email claim. We're email-linking, so second user would try to link to first's row. Mitigation: unique constraint on `email` already exists in the schema, second creation throws, we surface "email already in use with a different identity" error.
+- **Admin locks themselves out** — if an admin enables `oidc only` policy with a misconfigured IdP AND has no local admin with a password set, they're locked out. Break-glass (local admin with password can always log in) mitigates this. Admin UI should warn when enabling `oidc only` mode if no local admin has a password set.
+- **openid-client ESM vs CommonJS** — noted above; pinning v5.x.
+- **Single-process flow state** — noted above; in-process Map works for one replica. If we ever scale horizontally, migrate to Redis/DB.
+
+## Rejected alternatives
+
+- **Trusted header SSO** (e.g. rely on Traefik/Authentik's `X-Forwarded-User`). Simpler but non-portable — only works for deployers who have Authentik / similar in front. Rejected because the goal is "anyone can deploy this".
+- **SAML**. More enterprise than self-hosters typically want, much more protocol surface. OIDC covers 95% of modern IdPs. Not doing it.
+- **Multiple simultaneous providers**. YAGNI for v1.2.0. Schema leaves room (`oidc_issuer` per user) but admin UI only supports one.
+- **Group → role mapping from provider claims**. Future work. For now, first-user-wins admin handles the initial case and admins promote further users manually.

--- a/docs/SSO_DESIGN.md
+++ b/docs/SSO_DESIGN.md
@@ -234,6 +234,37 @@ Same sequence, just with their own IdP. The feature flag and the `local` default
 - **openid-client ESM vs CommonJS** — noted above; pinning v5.x.
 - **Single-process flow state** — noted above; in-process Map works for one replica. If we ever scale horizontally, migrate to Redis/DB.
 
+## Future work (post-v1.2.0)
+
+Items deliberately out of scope for the initial release, roughly in priority
+order:
+
+- **Single Logout (SLO)** — when the admin logs out of the IdP, PriceStalker
+  should invalidate their JWT too. Today the two sessions are decoupled: an
+  IdP logout doesn't reach into PriceStalker's localStorage. Implementation
+  path: back-channel logout endpoint at `/api/auth/oidc/backchannel-logout`,
+  session-ID tracking in JWTs, a server-side session store (probably a new
+  `user_sessions` table — the in-memory flow-state Map won't cut it for this),
+  and Authentik/other IdP configuration. Target: **v1.3.0**.
+- **Silent auth (prompt=none)** — in `both` policy mode, attempt a background
+  OIDC auth on page load to discover if the user already has an IdP session.
+  If yes, auto-sign-in; if no, show the regular login page. Complementary to
+  SLO — together they make the SSO feel truly seamless.
+- **Shorter JWT lifetime for OIDC users** — 7 days is fine for local users;
+  OIDC users could plausibly have shorter JWTs (e.g. 8h) to tighten the gap
+  until SLO lands. Simple to implement, worth doing if v1.3.0 slips.
+- **Group → role mapping from provider claims** — map an IdP group (e.g.
+  `pricestalker-admins`) to the `is_admin` flag so admin privileges survive
+  JIT without manual promotion. Requires a new admin UI for the mapping rules.
+- **Multiple simultaneous providers** — schema already leaves room (per-user
+  `oidc_issuer`). Admin UI only supports one for v1.2.0.
+- **Email change handling** — if an OIDC user's email changes in the IdP,
+  currently we don't update PriceStalker's record. Needs a "refresh from
+  provider on sign-in" pass that updates (name, email) from the latest claims.
+- **PKCE-only / public client support** — we require a client secret today.
+  Public-client flows (no secret) would let purely frontend or mobile
+  deployments work.
+
 ## Rejected alternatives
 
 - **Trusted header SSO** (e.g. rely on Traefik/Authentik's `X-Forwarded-User`). Simpler but non-portable — only works for deployers who have Authentik / similar in front. Rejected because the goal is "anyone can deploy this".

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pricestalker-frontend",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pricestalker-frontend",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "dependencies": {
         "axios": "^1.6.0",
         "react": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pricestalker-frontend",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pricestalker-v1.1.3';
+const CACHE_NAME = 'pricestalker-v1.2.0';
 const STATIC_ASSETS = [
   '/',
   '/icon.svg',

--- a/frontend/public/version.json
+++ b/frontend/public/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.1.3",
+  "version": "1.2.0",
   "releaseDate": "2026-04-21"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from './context/AuthContext';
 import { ToastProvider } from './context/ToastContext';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import SsoComplete from './pages/SsoComplete';
 import Dashboard from './pages/Dashboard';
 import ProductDetail from './pages/ProductDetail';
 import Settings from './pages/Settings';
@@ -120,6 +121,7 @@ function AppRoutes() {
           </ProtectedRoute>
         }
       />
+      <Route path="/auth/sso-complete" element={<SsoComplete />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -439,4 +439,44 @@ export const adminApi = {
     api.put<SystemSettings>('/admin/settings', data),
 };
 
+// Admin auth config — used by the Settings → Authentication panel
+export interface AuthConfigAdminView {
+  policy: AuthPolicy;
+  oidc_enabled: boolean;
+  oidc_provider_name: string | null;
+  oidc_issuer_url: string | null;
+  oidc_client_id: string | null;
+  has_client_secret: boolean;
+  oidc_scopes: string;
+  oidc_jit_enabled: boolean;
+  updated_at: string;
+}
+
+export interface AuthConfigUpdate {
+  policy?: AuthPolicy;
+  oidc_enabled?: boolean;
+  oidc_provider_name?: string | null;
+  oidc_issuer_url?: string | null;
+  oidc_client_id?: string | null;
+  oidc_client_secret?: string | null; // undefined = unchanged, "" = clear
+  oidc_scopes?: string;
+  oidc_jit_enabled?: boolean;
+}
+
+export interface DiscoveryTestResult {
+  ok: boolean;
+  error?: string;
+  issuer?: string;
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+  jwks_uri?: string;
+}
+
+export const adminAuthApi = {
+  get: () => api.get<AuthConfigAdminView>('/admin/auth'),
+  update: (data: AuthConfigUpdate) => api.put<AuthConfigAdminView>('/admin/auth', data),
+  testDiscovery: (issuer_url: string) =>
+    api.post<DiscoveryTestResult>('/admin/auth/test-discovery', { issuer_url }),
+};
+
 export default api;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -43,6 +43,21 @@ export const authApi = {
     api.get<{ registration_enabled: boolean }>('/auth/registration-status'),
 };
 
+// OIDC public config — used by the login page to decide what to render.
+// Returns 404 when SSO is disabled at the server level; the caller treats
+// that as 'no SSO available' and renders the local form only.
+export type AuthPolicy = 'local' | 'oidc' | 'both';
+
+export interface OidcPublicConfig {
+  policy: AuthPolicy;
+  oidc_enabled: boolean;
+  oidc_provider_name: string | null;
+}
+
+export const oidcApi = {
+  getPublicConfig: () => api.get<OidcPublicConfig>('/auth/oidc/config/public'),
+};
+
 // Products API
 export type StockStatus = 'in_stock' | 'out_of_stock' | 'unknown';
 export type AIStatus = 'verified' | 'corrected' | null;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -449,6 +449,7 @@ export interface AuthConfigAdminView {
   has_client_secret: boolean;
   oidc_scopes: string;
   oidc_jit_enabled: boolean;
+  oidc_require_email_verified: boolean;
   updated_at: string;
 }
 
@@ -461,6 +462,7 @@ export interface AuthConfigUpdate {
   oidc_client_secret?: string | null; // undefined = unchanged, "" = clear
   oidc_scopes?: string;
   oidc_jit_enabled?: boolean;
+  oidc_require_email_verified?: boolean;
 }
 
 export interface DiscoveryTestResult {

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react';
 import { Link } from 'react-router-dom';
-import { authApi } from '../api/client';
+import { authApi, oidcApi, OidcPublicConfig } from '../api/client';
 
 interface AuthFormProps {
   mode: 'login' | 'register';
@@ -14,6 +14,11 @@ export default function AuthForm({ mode, onSubmit }: AuthFormProps) {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [registrationEnabled, setRegistrationEnabled] = useState<boolean | null>(null);
+  const [oidcConfig, setOidcConfig] = useState<OidcPublicConfig | null>(null);
+  // In 'oidc' policy mode the local form is hidden behind a break-glass
+  // link so accidental admin-password leaks aren't staring everyone in the
+  // face. Click reveals the form (admins only expected to use it).
+  const [showLocalForm, setShowLocalForm] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     const saved = localStorage.getItem('theme');
     return (saved as 'light' | 'dark') || 'light';
@@ -25,11 +30,23 @@ export default function AuthForm({ mode, onSubmit }: AuthFormProps) {
   }, [theme]);
 
   useEffect(() => {
-    // Check if registration is enabled
     authApi.getRegistrationStatus()
       .then(res => setRegistrationEnabled(res.data.registration_enabled))
-      .catch(() => setRegistrationEnabled(true)); // Default to true on error
+      .catch(() => setRegistrationEnabled(true));
+
+    // Fetch OIDC public config. 404 means SSO is disabled on this server —
+    // fall back to 'local' so the UI renders exactly like before SSO existed.
+    oidcApi.getPublicConfig()
+      .then(res => setOidcConfig(res.data))
+      .catch(() => setOidcConfig({ policy: 'local', oidc_enabled: false, oidc_provider_name: null }));
   }, []);
+
+  // Derived UI flags
+  const showOidcButton = !!oidcConfig?.oidc_enabled && oidcConfig.policy !== 'local' && mode === 'login';
+  const oidcOnly = oidcConfig?.oidc_enabled === true && oidcConfig.policy === 'oidc';
+  const hideLocalFormByDefault = oidcOnly && mode === 'login';
+  const localFormVisible = !hideLocalFormByDefault || showLocalForm;
+  const providerLabel = oidcConfig?.oidc_provider_name || 'SSO';
 
   const toggleTheme = () => {
     setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
@@ -158,6 +175,54 @@ export default function AuthForm({ mode, onSubmit }: AuthFormProps) {
 
         {error && <div className="alert alert-error">{error}</div>}
 
+        {showOidcButton && (
+          <>
+            <a
+              href="/api/auth/oidc/start"
+              className="btn btn-primary"
+              style={{ width: '100%', marginBottom: '1rem', textAlign: 'center', textDecoration: 'none' }}
+            >
+              Sign in with {providerLabel}
+            </a>
+            {!hideLocalFormByDefault && (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.75rem',
+                  margin: '1rem 0',
+                  color: 'var(--muted)',
+                  fontSize: '0.875rem',
+                }}
+              >
+                <div style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+                or
+                <div style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+              </div>
+            )}
+          </>
+        )}
+
+        {hideLocalFormByDefault && !showLocalForm && (
+          <div className="auth-form-footer" style={{ marginTop: '1rem' }}>
+            <button
+              type="button"
+              onClick={() => setShowLocalForm(true)}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--muted)',
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+                textDecoration: 'underline',
+              }}
+            >
+              Admin sign-in with password
+            </button>
+          </div>
+        )}
+
+        {localFormVisible && (
         <form onSubmit={handleSubmit}>
           <div className="form-group">
             <label htmlFor="email">Email</label>
@@ -215,8 +280,9 @@ export default function AuthForm({ mode, onSubmit }: AuthFormProps) {
             )}
           </button>
         </form>
+        )}
 
-        {mode === 'login' && registrationEnabled && (
+        {mode === 'login' && registrationEnabled && oidcConfig?.policy !== 'oidc' && (
           <div className="auth-form-footer">
             Don't have an account? <Link to="/register">Sign up</Link>
           </div>

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -48,6 +48,20 @@ export default function AuthForm({ mode, onSubmit }: AuthFormProps) {
   const localFormVisible = !hideLocalFormByDefault || showLocalForm;
   const providerLabel = oidcConfig?.oidc_provider_name || 'SSO';
 
+  // In OIDC-only policy mode the login page is just a 'Sign in' button.
+  // Skip the click and bounce straight to the IdP. Escape hatches:
+  //   - /login?local=1  forces the form to render (break-glass admin sign-in)
+  //   - /login?local=1  is also what the 'Back to login' link on an SSO
+  //     error page uses, so an admin who just lost SSO access can still
+  //     reach the local form without being redirected into the broken flow.
+  useEffect(() => {
+    if (!oidcConfig || mode !== 'login') return;
+    if (!oidcConfig.oidc_enabled || oidcConfig.policy !== 'oidc') return;
+    const search = new URLSearchParams(window.location.search);
+    if (search.get('local') === '1') return;
+    window.location.href = '/api/auth/oidc/start';
+  }, [oidcConfig, mode]);
+
   const toggleTheme = () => {
     setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
   };

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -61,7 +61,10 @@ export default function Layout({ children }: LayoutProps) {
 
   const handleLogout = () => {
     logout();
-    navigate('/login');
+    // ?local=1 prevents the auto-redirect-to-IdP in oidc-only policy mode;
+    // we just logged out, getting bounced straight back in would be surprising.
+    // Harmless in local / both modes (the query param is ignored).
+    navigate('/login?local=1');
   };
 
   return (

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,7 +5,7 @@ import {
   useEffect,
   ReactNode,
 } from 'react';
-import { authApi } from '../api/client';
+import { authApi, profileApi } from '../api/client';
 
 interface User {
   id: number;
@@ -18,6 +18,10 @@ interface AuthContextType {
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string) => Promise<void>;
+  // Called by the /auth/sso-complete page once the OIDC callback has
+  // returned us a JWT via URL hash fragment. We stash the token and then
+  // hit /profile to learn which user it belongs to.
+  completeOidcLogin: (token: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -61,6 +65,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(userData);
   };
 
+  const completeOidcLogin = async (token: string) => {
+    // Token must be in localStorage before the profile fetch so the axios
+    // interceptor attaches it.
+    localStorage.setItem('token', token);
+    const { data: profile } = await profileApi.get();
+    const userData: User = {
+      id: profile.id,
+      email: profile.email,
+      name: profile.name,
+    };
+    localStorage.setItem('user', JSON.stringify(userData));
+    setUser(userData);
+  };
+
   const logout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('user');
@@ -68,7 +86,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, register, logout }}>
+    <AuthContext.Provider
+      value={{ user, isLoading, login, register, completeOidcLogin, logout }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import Layout from '../components/Layout';
 import PasswordInput from '../components/PasswordInput';
 import {
@@ -22,8 +22,21 @@ interface VersionInfo {
   releaseDate: string;
 }
 
+const VALID_SECTIONS: SettingsSection[] = ['profile', 'notifications', 'ai', 'auth', 'admin'];
+
 export default function Settings() {
-  const [activeSection, setActiveSection] = useState<SettingsSection>('profile');
+  const location = useLocation();
+  // Deep-link support — e.g. /settings?section=auth jumps straight to the
+  // Authentication panel. Used by the SsoComplete error page to land the
+  // admin on the exact toggle they need to flip.
+  const initialSection = (() => {
+    const fromQuery = new URLSearchParams(location.search).get('section');
+    if (fromQuery && VALID_SECTIONS.includes(fromQuery as SettingsSection)) {
+      return fromQuery as SettingsSection;
+    }
+    return 'profile';
+  })();
+  const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2243,13 +2243,52 @@ export default function Settings() {
               <div className="settings-section">
                 <div className="settings-section-header">
                   <span className="settings-section-icon">🔐</span>
-                  <h2 className="settings-section-title">Authentication</h2>
+                  <h2 className="settings-section-title">
+                    Authentication
+                    <span
+                      style={{
+                        marginLeft: '0.75rem',
+                        padding: '0.15rem 0.5rem',
+                        borderRadius: '999px',
+                        background: 'rgba(251, 146, 60, 0.15)',
+                        color: '#ea580c',
+                        fontSize: '0.65rem',
+                        fontWeight: 700,
+                        letterSpacing: '0.05em',
+                        verticalAlign: 'middle',
+                      }}
+                    >
+                      BETA
+                    </span>
+                  </h2>
                 </div>
                 <p className="settings-section-description">
                   Configure how users sign in. Local email/password is always available;
                   OIDC can be enabled for single sign-on against Authentik, Keycloak, Google,
                   or any other compliant provider.
                 </p>
+                <div
+                  className="alert"
+                  style={{
+                    background: 'rgba(251, 146, 60, 0.1)',
+                    color: '#9a3412',
+                    marginBottom: '1.5rem',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  <strong>Beta.</strong> OIDC integration is new in v1.2.0. The flow works
+                  end-to-end but hasn't been battle-tested across every provider yet.
+                  Known limitation: logging out of your IdP does not automatically log you
+                  out of PriceStalker (Single Logout arrives in v1.3.0). Report issues at{' '}
+                  <a
+                    href="https://github.com/mikeknight85/PriceStalker/issues"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    github.com/mikeknight85/PriceStalker/issues
+                  </a>
+                  .
+                </div>
 
                 <div className="settings-form-group">
                   <label>Sign-in policy</label>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,13 +6,16 @@ import {
   settingsApi,
   profileApi,
   adminApi,
+  adminAuthApi,
   NotificationSettings,
   AISettings,
   UserProfile,
   SystemSettings,
+  AuthConfigAdminView,
+  AuthPolicy,
 } from '../api/client';
 
-type SettingsSection = 'profile' | 'notifications' | 'ai' | 'admin';
+type SettingsSection = 'profile' | 'notifications' | 'ai' | 'auth' | 'admin';
 
 interface VersionInfo {
   version: string;
@@ -93,6 +96,22 @@ export default function Settings() {
   const [newUserPassword, setNewUserPassword] = useState('');
   const [newUserRole, setNewUserRole] = useState<'user' | 'admin'>('user');
   const [isCreatingUser, setIsCreatingUser] = useState(false);
+
+  // Auth config (Settings → Authentication, admin only)
+  const [authConfig, setAuthConfig] = useState<AuthConfigAdminView | null>(null);
+  const [authPolicy, setAuthPolicy] = useState<AuthPolicy>('local');
+  const [oidcEnabled, setOidcEnabled] = useState(false);
+  const [oidcProviderName, setOidcProviderName] = useState('');
+  const [oidcIssuerUrl, setOidcIssuerUrl] = useState('');
+  const [oidcClientId, setOidcClientId] = useState('');
+  // Empty = unchanged. User types a new value to rotate; clear explicitly to remove.
+  const [oidcClientSecret, setOidcClientSecret] = useState('');
+  const [oidcClientSecretClear, setOidcClientSecretClear] = useState(false);
+  const [oidcScopes, setOidcScopes] = useState('openid profile email');
+  const [oidcJitEnabled, setOidcJitEnabled] = useState(true);
+  const [isSavingAuth, setIsSavingAuth] = useState(false);
+  const [isTestingDiscovery, setIsTestingDiscovery] = useState(false);
+  const [discoveryResult, setDiscoveryResult] = useState<string | null>(null);
 
   useEffect(() => {
     fetchInitialData();
@@ -179,6 +198,81 @@ export default function Settings() {
       fetchAdminData();
     }
   }, [activeSection, profile]);
+
+  useEffect(() => {
+    if (activeSection === 'auth' && profile?.is_admin && !authConfig) {
+      adminAuthApi.get()
+        .then((res) => {
+          setAuthConfig(res.data);
+          setAuthPolicy(res.data.policy);
+          setOidcEnabled(res.data.oidc_enabled);
+          setOidcProviderName(res.data.oidc_provider_name || '');
+          setOidcIssuerUrl(res.data.oidc_issuer_url || '');
+          setOidcClientId(res.data.oidc_client_id || '');
+          setOidcScopes(res.data.oidc_scopes);
+          setOidcJitEnabled(res.data.oidc_jit_enabled);
+          setOidcClientSecret('');
+          setOidcClientSecretClear(false);
+          setDiscoveryResult(null);
+        })
+        .catch(() => setError('Failed to load auth config'));
+    }
+  }, [activeSection, profile, authConfig]);
+
+  const handleTestDiscovery = async () => {
+    clearMessages();
+    if (!oidcIssuerUrl) {
+      setError('Enter an issuer URL first');
+      return;
+    }
+    setIsTestingDiscovery(true);
+    setDiscoveryResult(null);
+    try {
+      const { data } = await adminAuthApi.testDiscovery(oidcIssuerUrl);
+      if (data.ok) {
+        setDiscoveryResult(`OK — issuer: ${data.issuer}`);
+      } else {
+        setError(data.error || 'Discovery failed');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Discovery failed';
+      setError(message);
+    } finally {
+      setIsTestingDiscovery(false);
+    }
+  };
+
+  const handleSaveAuth = async () => {
+    clearMessages();
+    setIsSavingAuth(true);
+    try {
+      const payload = {
+        policy: authPolicy,
+        oidc_enabled: oidcEnabled,
+        oidc_provider_name: oidcProviderName || null,
+        oidc_issuer_url: oidcIssuerUrl || null,
+        oidc_client_id: oidcClientId || null,
+        oidc_client_secret: oidcClientSecretClear
+          ? null
+          : oidcClientSecret
+          ? oidcClientSecret
+          : undefined,
+        oidc_scopes: oidcScopes,
+        oidc_jit_enabled: oidcJitEnabled,
+      };
+      const { data } = await adminAuthApi.update(payload);
+      setAuthConfig(data);
+      setOidcClientSecret('');
+      setOidcClientSecretClear(false);
+      setSuccess('Authentication settings saved');
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const axiosError = err as any;
+      setError(axiosError.response?.data?.error || 'Failed to save auth settings');
+    } finally {
+      setIsSavingAuth(false);
+    }
+  };
 
   const clearMessages = () => {
     setError('');
@@ -1088,6 +1182,18 @@ export default function Settings() {
               </svg>
               AI Extraction
             </button>
+            {profile?.is_admin && (
+              <button
+                className={`settings-nav-item ${activeSection === 'auth' ? 'active' : ''}`}
+                onClick={() => { setActiveSection('auth'); clearMessages(); }}
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="11" width="18" height="11" rx="2" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+                Authentication
+              </button>
+            )}
             {profile?.is_admin && (
               <button
                 className={`settings-nav-item ${activeSection === 'admin' ? 'active' : ''}`}
@@ -2113,6 +2219,171 @@ export default function Settings() {
                   </div>
                 </div>
               )}
+            </>
+          )}
+
+          {activeSection === 'auth' && profile?.is_admin && (
+            <>
+              <div className="settings-section">
+                <div className="settings-section-header">
+                  <span className="settings-section-icon">🔐</span>
+                  <h2 className="settings-section-title">Authentication</h2>
+                </div>
+                <p className="settings-section-description">
+                  Configure how users sign in. Local email/password is always available;
+                  OIDC can be enabled for single sign-on against Authentik, Keycloak, Google,
+                  or any other compliant provider.
+                </p>
+
+                <div className="settings-form-group">
+                  <label>Sign-in policy</label>
+                  <select
+                    value={authPolicy}
+                    onChange={(e) => setAuthPolicy(e.target.value as AuthPolicy)}
+                    style={{ width: '100%', padding: '0.625rem 0.75rem', border: '1px solid var(--border)', borderRadius: '0.375rem', background: 'var(--background)', color: 'var(--text)', fontSize: '0.875rem' }}
+                  >
+                    <option value="local">Local only (email + password)</option>
+                    <option value="both">Both (local and SSO)</option>
+                    <option value="oidc">SSO only (admins keep password break-glass)</option>
+                  </select>
+                  <p className="hint">
+                    {authPolicy === 'oidc' && 'Admins with a local password can still sign in via the break-glass link on the login page. Regular users must use SSO.'}
+                    {authPolicy === 'both' && 'Login page shows both the SSO button and the local form.'}
+                    {authPolicy === 'local' && 'SSO is hidden from the login page. OIDC settings below are saved but not used until you flip this to Both or SSO only.'}
+                  </p>
+                </div>
+
+                <div className="settings-toggle">
+                  <div className="settings-toggle-label">
+                    <span className="settings-toggle-title">OIDC enabled</span>
+                    <span className="settings-toggle-description">
+                      When off, all OIDC endpoints are inactive even if the server has ENABLE_SSO=true.
+                    </span>
+                  </div>
+                  <label className="switch">
+                    <input type="checkbox" checked={oidcEnabled} onChange={(e) => setOidcEnabled(e.target.checked)} />
+                    <span className="slider" />
+                  </label>
+                </div>
+
+                <div className="settings-toggle">
+                  <div className="settings-toggle-label">
+                    <span className="settings-toggle-title">JIT provisioning</span>
+                    <span className="settings-toggle-description">
+                      Auto-create a PriceStalker account the first time someone signs in via OIDC. Email verification is required either way.
+                    </span>
+                  </div>
+                  <label className="switch">
+                    <input type="checkbox" checked={oidcJitEnabled} onChange={(e) => setOidcJitEnabled(e.target.checked)} />
+                    <span className="slider" />
+                  </label>
+                </div>
+
+                <div className="settings-form-group">
+                  <label>Provider display name</label>
+                  <input
+                    type="text"
+                    value={oidcProviderName}
+                    onChange={(e) => setOidcProviderName(e.target.value)}
+                    placeholder="Authentik"
+                  />
+                  <p className="hint">Shown on the login page as "Sign in with {oidcProviderName || 'SSO'}".</p>
+                </div>
+
+                <div className="settings-form-group">
+                  <label>Issuer URL</label>
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <input
+                      type="url"
+                      style={{ flex: 1 }}
+                      value={oidcIssuerUrl}
+                      onChange={(e) => setOidcIssuerUrl(e.target.value)}
+                      placeholder="https://auth.example.com/application/o/pricestalker/"
+                    />
+                    <button
+                      className="btn btn-secondary"
+                      onClick={handleTestDiscovery}
+                      disabled={isTestingDiscovery || !oidcIssuerUrl}
+                      style={{ whiteSpace: 'nowrap' }}
+                    >
+                      {isTestingDiscovery ? 'Testing...' : 'Test discovery'}
+                    </button>
+                  </div>
+                  <p className="hint">
+                    Base URL of the OIDC provider. We append <code>/.well-known/openid-configuration</code> automatically.
+                    {discoveryResult && <span style={{ color: 'var(--success, #10b981)', marginLeft: 8 }}>{discoveryResult}</span>}
+                  </p>
+                </div>
+
+                <div className="settings-form-group">
+                  <label>Client ID</label>
+                  <input
+                    type="text"
+                    value={oidcClientId}
+                    onChange={(e) => setOidcClientId(e.target.value)}
+                    placeholder="pricestalker"
+                  />
+                </div>
+
+                <div className="settings-form-group">
+                  <label>Client secret {authConfig?.has_client_secret && '(set)'}</label>
+                  {oidcClientSecretClear ? (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                      <em style={{ color: 'var(--muted)' }}>Will be cleared on save.</em>
+                      <button className="btn btn-secondary" onClick={() => setOidcClientSecretClear(false)}>
+                        Undo
+                      </button>
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                      <div style={{ flex: 1 }}>
+                        <PasswordInput
+                          value={oidcClientSecret}
+                          onChange={(e) => setOidcClientSecret(e.target.value)}
+                          placeholder={authConfig?.has_client_secret ? '••••••• (leave empty to keep existing)' : ''}
+                        />
+                      </div>
+                      {authConfig?.has_client_secret && (
+                        <button
+                          className="btn btn-secondary"
+                          onClick={() => { setOidcClientSecret(''); setOidcClientSecretClear(true); }}
+                          style={{ whiteSpace: 'nowrap' }}
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
+                  )}
+                  <p className="hint">Never returned by the API. Leave empty to keep the existing value.</p>
+                </div>
+
+                <div className="settings-form-group">
+                  <label>Scopes</label>
+                  <input
+                    type="text"
+                    value={oidcScopes}
+                    onChange={(e) => setOidcScopes(e.target.value)}
+                    placeholder="openid profile email"
+                  />
+                  <p className="hint">Space-separated. <code>openid</code> is required. <code>email</code> is required for JIT / email-linking.</p>
+                </div>
+
+                <div className="settings-form-actions">
+                  <button
+                    className="btn btn-primary"
+                    onClick={handleSaveAuth}
+                    disabled={isSavingAuth}
+                  >
+                    {isSavingAuth ? 'Saving...' : 'Save Authentication Settings'}
+                  </button>
+                </div>
+
+                {authPolicy === 'oidc' && (
+                  <div className="alert" style={{ marginTop: '1rem', background: 'var(--warning-bg, #fef3c7)', color: 'var(--warning-text, #92400e)' }}>
+                    <strong>Heads up:</strong> you're about to require SSO for all non-admin users. Make sure at least one admin has a local password set (break-glass) before saving, or you may lock yourself out if the IdP is misconfigured.
+                  </div>
+                )}
+              </div>
             </>
           )}
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -109,6 +109,7 @@ export default function Settings() {
   const [oidcClientSecretClear, setOidcClientSecretClear] = useState(false);
   const [oidcScopes, setOidcScopes] = useState('openid profile email');
   const [oidcJitEnabled, setOidcJitEnabled] = useState(true);
+  const [oidcRequireEmailVerified, setOidcRequireEmailVerified] = useState(true);
   const [isSavingAuth, setIsSavingAuth] = useState(false);
   const [isTestingDiscovery, setIsTestingDiscovery] = useState(false);
   const [discoveryResult, setDiscoveryResult] = useState<string | null>(null);
@@ -211,6 +212,7 @@ export default function Settings() {
           setOidcClientId(res.data.oidc_client_id || '');
           setOidcScopes(res.data.oidc_scopes);
           setOidcJitEnabled(res.data.oidc_jit_enabled);
+          setOidcRequireEmailVerified(res.data.oidc_require_email_verified);
           setOidcClientSecret('');
           setOidcClientSecretClear(false);
           setDiscoveryResult(null);
@@ -259,6 +261,7 @@ export default function Settings() {
           : undefined,
         oidc_scopes: oidcScopes,
         oidc_jit_enabled: oidcJitEnabled,
+        oidc_require_email_verified: oidcRequireEmailVerified,
       };
       const { data } = await adminAuthApi.update(payload);
       setAuthConfig(data);
@@ -2270,11 +2273,25 @@ export default function Settings() {
                   <div className="settings-toggle-label">
                     <span className="settings-toggle-title">JIT provisioning</span>
                     <span className="settings-toggle-description">
-                      Auto-create a PriceStalker account the first time someone signs in via OIDC. Email verification is required either way.
+                      Auto-create a PriceStalker account the first time someone signs in via OIDC.
                     </span>
                   </div>
                   <label className="switch">
                     <input type="checkbox" checked={oidcJitEnabled} onChange={(e) => setOidcJitEnabled(e.target.checked)} />
+                    <span className="slider" />
+                  </label>
+                </div>
+
+                <div className="settings-toggle">
+                  <div className="settings-toggle-label">
+                    <span className="settings-toggle-title">Require verified email from provider</span>
+                    <span className="settings-toggle-description">
+                      Only allow sign-in when the IdP asserts <code>email_verified=true</code> in the ID token or userinfo.
+                      Safe for public IdPs (Google, Microsoft). Disable for self-hosted IdPs that don't emit this claim by default (Authentik, Keycloak).
+                    </span>
+                  </div>
+                  <label className="switch">
+                    <input type="checkbox" checked={oidcRequireEmailVerified} onChange={(e) => setOidcRequireEmailVerified(e.target.checked)} />
                     <span className="slider" />
                   </label>
                 </div>

--- a/frontend/src/pages/SsoComplete.tsx
+++ b/frontend/src/pages/SsoComplete.tsx
@@ -85,7 +85,7 @@ export default function SsoComplete() {
                 </Link>
               )}
               <Link
-                to="/login"
+                to="/login?local=1"
                 className={needsEmailVerifiedFix ? 'btn btn-secondary' : 'btn btn-primary'}
               >
                 Back to login

--- a/frontend/src/pages/SsoComplete.tsx
+++ b/frontend/src/pages/SsoComplete.tsx
@@ -1,0 +1,89 @@
+// Landing page the OIDC callback redirects the browser to after successfully
+// exchanging the authorization code. The backend puts the JWT in the URL
+// hash (#token=...) because hash fragments never hit the server — keeping
+// the short-lived token out of access logs.
+//
+// On load: parse the hash, hand the token off to AuthContext, navigate to /
+// on success or show the error message on failure.
+
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export default function SsoComplete() {
+  const navigate = useNavigate();
+  const { completeOidcLogin } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const hash = window.location.hash.replace(/^#/, '');
+    const params = new URLSearchParams(hash);
+    const err = params.get('error');
+    const token = params.get('token');
+
+    // Clear the hash immediately so the token isn't visible in the URL bar
+    // any longer than necessary, and so a refresh doesn't re-use it.
+    history.replaceState(null, '', window.location.pathname);
+
+    if (err) {
+      setError(err);
+      return;
+    }
+
+    if (!token) {
+      setError('No token received from identity provider. Please retry.');
+      return;
+    }
+
+    completeOidcLogin(token)
+      .then(() => navigate('/', { replace: true }))
+      .catch((e) => {
+        const message = e instanceof Error ? e.message : 'Sign-in failed';
+        setError(message);
+      });
+  }, [completeOidcLogin, navigate]);
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '1rem',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 400,
+          background: 'var(--surface)',
+          borderRadius: '1rem',
+          boxShadow: 'var(--shadow-lg)',
+          padding: '2rem',
+          textAlign: 'center',
+        }}
+      >
+        <img
+          src="/icon.svg"
+          alt="PriceStalker"
+          style={{ width: 64, height: 64, marginBottom: '0.5rem' }}
+        />
+        {error ? (
+          <>
+            <h1 style={{ marginBottom: '0.5rem' }}>Sign-in failed</h1>
+            <p style={{ color: 'var(--danger)', marginBottom: '1.5rem' }}>{error}</p>
+            <Link to="/login" className="btn btn-primary">
+              Back to login
+            </Link>
+          </>
+        ) : (
+          <>
+            <h1 style={{ marginBottom: '0.5rem' }}>Signing you in…</h1>
+            <p style={{ color: 'var(--muted)' }}>Verifying your identity.</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SsoComplete.tsx
+++ b/frontend/src/pages/SsoComplete.tsx
@@ -43,6 +43,11 @@ export default function SsoComplete() {
       });
   }, [completeOidcLogin, navigate]);
 
+  // Specific-error detection lets us surface a one-click deep link to the
+  // exact admin toggle rather than making the admin hunt for it.
+  const needsEmailVerifiedFix =
+    !!error && error.toLowerCase().includes('email_verified');
+
   return (
     <div
       style={{
@@ -73,9 +78,19 @@ export default function SsoComplete() {
           <>
             <h1 style={{ marginBottom: '0.5rem' }}>Sign-in failed</h1>
             <p style={{ color: 'var(--danger)', marginBottom: '1.5rem' }}>{error}</p>
-            <Link to="/login" className="btn btn-primary">
-              Back to login
-            </Link>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              {needsEmailVerifiedFix && (
+                <Link to="/settings?section=auth" className="btn btn-primary">
+                  Open Authentication settings
+                </Link>
+              )}
+              <Link
+                to="/login"
+                className={needsEmailVerifiedFix ? 'btn btn-secondary' : 'btn btn-primary'}
+              >
+                Back to login
+              </Link>
+            </div>
           </>
         ) : (
           <>


### PR DESCRIPTION
Tracking PR for the SSO feature. Stays **draft** until all phases land and preview-deployed end-to-end.

## Design
Full spec lives at [`docs/SSO_DESIGN.md`](../blob/feature/sso/docs/SSO_DESIGN.md) — review this first; everything in subsequent commits conforms to it.

## Decisions encoded in the design
1. First person to log in (any method) auto-becomes admin
2. Traefik Authentik middleware removed; app takes over OIDC directly
3. JIT provisioning only (no pre-provisioning UI)
4. Local session logout only for v1.2.0 (SLO deferred)

## Phases
- [x] **Phase 0** — Design doc (this commit)
- [ ] **Phase 1** — Backend: deps, DB migrations, `auth_config` model, admin config endpoints, test-discovery endpoint
- [ ] **Phase 2** — Backend: `/auth/oidc/start` + `/auth/oidc/callback`, JIT provisioning, feature flag
- [ ] **Phase 3** — Frontend: `sso-complete` route, login page conditional rendering
- [ ] **Phase 4** — Frontend: Settings → Authentication admin panel
- [ ] **Phase 5** — End-to-end test against real Authentik, preview image deployed as parallel stack
- [ ] **Phase 6** — Mark ready-for-review, merge, cut v1.2.0

## Rollout safety
- Ships with `ENABLE_SSO=false` default feature flag → merging to main changes nothing until opt-in
- Policy defaults to `local` → even with `ENABLE_SSO=true`, login page unchanged until admin configures a provider
- Local admin with password always retains break-glass access even in `oidc only` mode