### PR TITLE
Fix Shopify restock detection and OOS price display (#2)

### DIFF
--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -583,16 +583,17 @@ export const productQueries = {
     name: string | null,
     imageUrl: string | null,
     refreshInterval: number = 3600,
-    stockStatus: StockStatus = 'unknown'
+    stockStatus: StockStatus = 'unknown',
+    notifyBackInStock: boolean = false
   ): Promise<Product> => {
     // Set initial next_check_at to a random time within the refresh interval
     // This spreads out new products so they don't all check at once
     const randomDelaySeconds = Math.floor(Math.random() * refreshInterval);
     const result = await pool.query(
-      `INSERT INTO products (user_id, url, name, image_url, refresh_interval, stock_status, next_check_at)
-       VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP + ($7 || ' seconds')::interval)
+      `INSERT INTO products (user_id, url, name, image_url, refresh_interval, stock_status, notify_back_in_stock, next_check_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP + ($8 || ' seconds')::interval)
        RETURNING *`,
-      [userId, url, name, imageUrl, refreshInterval, stockStatus, randomDelaySeconds]
+      [userId, url, name, imageUrl, refreshInterval, stockStatus, notifyBackInStock, randomDelaySeconds]
     );
     return result.rows[0];
   },

--- a/backend/src/routes/products.ts
+++ b/backend/src/routes/products.ts
@@ -24,7 +24,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
 router.post('/', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.userId!;
-    const { url, refresh_interval, selectedPrice, selectedMethod } = req.body;
+    const { url, refresh_interval, selectedPrice, selectedMethod, notify_back_in_stock } = req.body;
 
     if (!url) {
       res.status(400).json({ error: 'URL is required' });
@@ -44,6 +44,13 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       // User has selected a price from candidates - use it directly
       const scrapedData = await scrapeProduct(url, userId);
 
+      // Default the restock-alert toggle to ON when the user is adding an OOS
+      // product — they've almost certainly opted in to back-in-stock alerts by
+      // taking the trouble to track something unbuyable today.
+      const finalNotifyBackInStock = typeof notify_back_in_stock === 'boolean'
+        ? notify_back_in_stock
+        : scrapedData.stockStatus === 'out_of_stock';
+
       // Create product with the user-selected price
       const product = await productQueries.create(
         userId,
@@ -51,7 +58,8 @@ router.post('/', async (req: AuthRequest, res: Response) => {
         scrapedData.name?.substring(0, 255) ?? null,
         scrapedData.imageUrl,
         refresh_interval || 3600,
-        scrapedData.stockStatus
+        scrapedData.stockStatus,
+        finalNotifyBackInStock
       );
 
       // Store the preferred extraction method and the user-selected price
@@ -61,11 +69,12 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       await productQueries.updateAnchorPrice(product.id, selectedPrice);
       console.log(`[Products] Saved anchor price ${selectedPrice} for product ${product.id} (method: ${selectedMethod})`);
 
-      // Record the user-selected price
+      // Record the user-selected price with the currency the scraper detected
+      // (avoids defaulting EUR/GBP/etc. products to USD).
       await priceHistoryQueries.create(
         product.id,
         selectedPrice,
-        'USD', // TODO: Get currency from selection
+        scrapedData.price?.currency || 'USD',
         null
       );
 
@@ -129,6 +138,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       }
     }
 
+    const finalNotifyBackInStock = typeof notify_back_in_stock === 'boolean'
+      ? notify_back_in_stock
+      : scrapedData.stockStatus === 'out_of_stock';
+
     // Create product with stock status
     const product = await productQueries.create(
       userId,
@@ -136,7 +149,8 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       scrapedData.name?.substring(0, 255) ?? null,
       scrapedData.imageUrl,
       refresh_interval || 3600,
-      scrapedData.stockStatus
+      scrapedData.stockStatus,
+      finalNotifyBackInStock
     );
 
     // Store the extraction method that worked

--- a/backend/src/services/scraper.ts
+++ b/backend/src/services/scraper.ts
@@ -1190,14 +1190,27 @@ export async function scrapeProduct(url: string, userId?: number): Promise<Scrap
     }
 
     // Try JSON-LD structured data
+    let jsonLdDataCached: ReturnType<typeof extractJsonLd> = null;
     if (!result.price || !result.name || result.stockStatus === 'unknown') {
-      const jsonLdData = extractJsonLd($);
-      if (jsonLdData) {
-        if (!result.name && jsonLdData.name) result.name = jsonLdData.name;
-        if (!result.price && jsonLdData.price) result.price = jsonLdData.price;
-        if (!result.imageUrl && jsonLdData.image) result.imageUrl = jsonLdData.image;
-        if (result.stockStatus === 'unknown' && jsonLdData.stockStatus) {
-          result.stockStatus = jsonLdData.stockStatus;
+      jsonLdDataCached = extractJsonLd($);
+      if (jsonLdDataCached) {
+        if (!result.name && jsonLdDataCached.name) result.name = jsonLdDataCached.name;
+        if (!result.price && jsonLdDataCached.price) result.price = jsonLdDataCached.price;
+        if (!result.imageUrl && jsonLdDataCached.image) result.imageUrl = jsonLdDataCached.image;
+        if (result.stockStatus === 'unknown' && jsonLdDataCached.stockStatus) {
+          result.stockStatus = jsonLdDataCached.stockStatus;
+        }
+      }
+    }
+
+    // Shopify-aware extraction overrides earlier signals when present.
+    if (isShopifyPage($)) {
+      const shopify = await extractShopifyData(url);
+      if (shopify) {
+        result.stockStatus = shopify.available ? 'in_stock' : 'out_of_stock';
+        if (!result.price && shopify.price && shopify.price > 0) {
+          const currency = jsonLdDataCached?.price?.currency;
+          if (currency) result.price = { price: shopify.price, currency };
         }
       }
     }
@@ -1442,7 +1455,9 @@ export async function scrapeProductWithVoting(
     // 1. JSON-LD extraction (highest reliability)
     const jsonLdCandidates = extractJsonLdCandidates($);
     allCandidates.push(...jsonLdCandidates);
-    console.log(`[Voting] JSON-LD found ${jsonLdCandidates.length} candidates`);
+    const jsonLdData = extractJsonLd($);
+    if (jsonLdData?.stockStatus) result.stockStatus = jsonLdData.stockStatus;
+    console.log(`[Voting] JSON-LD found ${jsonLdCandidates.length} candidates, stock=${jsonLdData?.stockStatus ?? 'n/a'}`);
 
     // 2. Site-specific extraction
     const siteResult = extractSiteSpecificCandidates($, url);
@@ -1457,6 +1472,29 @@ export async function scrapeProductWithVoting(
     allCandidates.push(...genericCandidates);
     console.log(`[Voting] Generic CSS found ${genericCandidates.length} candidates`);
 
+    // 4. Shopify-aware extraction. /products/<handle>.js is the most reliable
+    // signal for Shopify storefronts because it bypasses theme/localization
+    // differences. Overrides earlier signals when present.
+    if (isShopifyPage($)) {
+      const shopify = await extractShopifyData(url);
+      if (shopify) {
+        result.stockStatus = shopify.available ? 'in_stock' : 'out_of_stock';
+        if (shopify.price && shopify.price > 0) {
+          const currency = jsonLdData?.price?.currency || jsonLdCandidates[0]?.currency;
+          if (currency) {
+            allCandidates.push({
+              price: shopify.price,
+              currency,
+              method: 'site-specific',
+              context: 'Shopify /products/<handle>.js',
+              confidence: 0.95,
+            });
+          }
+        }
+        console.log(`[Voting] Shopify .js: available=${shopify.available}, price=${shopify.price ?? 'n/a'}`);
+      }
+    }
+
     // If no candidates found in static HTML, try browser rendering
     if (allCandidates.length === 0 && !usedBrowser) {
       console.log(`[Voting] No candidates in static HTML, trying browser...`);
@@ -1466,7 +1504,12 @@ export async function scrapeProductWithVoting(
         $ = load(html);
 
         // Re-run all extraction methods
-        allCandidates.push(...extractJsonLdCandidates($));
+        const browserJsonLdCandidates = extractJsonLdCandidates($);
+        allCandidates.push(...browserJsonLdCandidates);
+        const browserJsonLdData = extractJsonLd($);
+        if (result.stockStatus === 'unknown' && browserJsonLdData?.stockStatus) {
+          result.stockStatus = browserJsonLdData.stockStatus;
+        }
         const browserSiteResult = extractSiteSpecificCandidates($, url);
         allCandidates.push(...browserSiteResult.candidates);
         if (!result.name && browserSiteResult.name) result.name = browserSiteResult.name;
@@ -1475,6 +1518,24 @@ export async function scrapeProductWithVoting(
           result.stockStatus = browserSiteResult.stockStatus;
         }
         allCandidates.push(...extractGenericCssCandidates($));
+        if (isShopifyPage($)) {
+          const shopify = await extractShopifyData(url);
+          if (shopify) {
+            result.stockStatus = shopify.available ? 'in_stock' : 'out_of_stock';
+            if (shopify.price && shopify.price > 0) {
+              const currency = browserJsonLdData?.price?.currency || browserJsonLdCandidates[0]?.currency;
+              if (currency) {
+                allCandidates.push({
+                  price: shopify.price,
+                  currency,
+                  method: 'site-specific',
+                  context: 'Shopify /products/<handle>.js',
+                  confidence: 0.95,
+                });
+              }
+            }
+          }
+        }
         console.log(`[Voting] Browser found ${allCandidates.length} total candidates`);
       } catch (browserError) {
         console.error(`[Voting] Browser fallback failed:`, browserError);
@@ -1836,6 +1897,46 @@ function extractJsonLd(
   return null;
 }
 
+// Shopify-aware extraction. Shopify storefronts expose /products/<handle>.js
+// returning canonical product JSON with per-variant `available` and price in
+// minor units. This bypasses theme HTML variation entirely.
+function isShopifyPage($: CheerioAPI): boolean {
+  const html = $.html();
+  return html.includes('cdn.shopify.com') || html.includes('Shopify.theme');
+}
+
+async function extractShopifyData(
+  url: string
+): Promise<{ available: boolean; price?: number } | null> {
+  try {
+    const parsed = new URL(url);
+    if (!/\/products\/[^/]+/.test(parsed.pathname)) return null;
+    const cleanPath = parsed.pathname.replace(/\/$/, '');
+    const jsUrl = `${parsed.origin}${cleanPath}.js`;
+
+    const response = await axios.get<{
+      available?: boolean;
+      price?: number;
+    }>(jsUrl, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+        Accept: 'application/json',
+      },
+      timeout: 10000,
+    });
+
+    const data = response.data;
+    if (typeof data?.available !== 'boolean') return null;
+    return {
+      available: data.available,
+      price: typeof data.price === 'number' ? data.price / 100 : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function findProduct(data: JsonLdProduct | JsonLdProduct[]): JsonLdProduct | null {
   if (!data) return null;
 
@@ -2028,6 +2129,17 @@ function extractGenericStockStatus($: CheerioAPI): StockStatus {
     'ships today',
     'ships immediately',
     'ready to ship',
+    // Localized "in stock" / "add to cart" — common on European Shopify themes
+    'in winkelwagen',
+    'aan winkelwagen toevoegen',
+    'op voorraad',
+    'in den warenkorb',
+    'auf lager',
+    'ajouter au panier',
+    'en stock',
+    'añadir al carrito',
+    'aggiungi al carrello',
+    'adicionar ao carrinho',
   ];
 
   // First, check if the page has strong in-stock indicators
@@ -2099,9 +2211,13 @@ function extractGenericStockStatus($: CheerioAPI): StockStatus {
     return 'in_stock';
   }
 
-  // Check for explicit out-of-stock elements - be specific
-  const hasOutOfStockBadge = $('[class*="out-of-stock" i]').length > 0 ||
-                              $('[class*="sold-out" i]').length > 0 ||
+  // Check for explicit out-of-stock elements - be specific.
+  // Exclude `badge`-classed spans: Shopify Dawn-family themes render both
+  // sale-badge and sold-out-badge in the DOM and toggle visibility via CSS
+  // rules (not inline style), so the bare class selector misfires on
+  // in-stock products. Real OOS indicators are buttons/forms, not badges.
+  const hasOutOfStockBadge = $('[class*="out-of-stock" i]').not('[class*="badge" i]').length > 0 ||
+                              $('[class*="sold-out" i]').not('[class*="badge" i]').length > 0 ||
                               $('[data-testid*="out-of-stock" i]').length > 0;
 
   if (hasOutOfStockBadge) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -135,12 +135,19 @@ export const productsApi = {
 
   getById: (id: number) => api.get<ProductWithStats>(`/products/${id}`),
 
-  create: (url: string, refreshInterval?: number, selectedPrice?: number, selectedMethod?: string) =>
+  create: (
+    url: string,
+    refreshInterval?: number,
+    selectedPrice?: number,
+    selectedMethod?: string,
+    notifyBackInStock?: boolean
+  ) =>
     api.post<CreateProductResponse>('/products', {
       url,
       refresh_interval: refreshInterval,
       selectedPrice,
       selectedMethod,
+      notify_back_in_stock: notifyBackInStock,
     }),
 
   update: (id: number, data: {

--- a/frontend/src/components/PriceSelectionModal.tsx
+++ b/frontend/src/components/PriceSelectionModal.tsx
@@ -12,12 +12,13 @@ export interface PriceCandidate {
 interface PriceSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (price: number, method: string) => void;
+  onSelect: (price: number, method: string, notifyBackInStock: boolean) => void;
   productName: string | null;
   imageUrl: string | null;
   candidates: PriceCandidate[];
   suggestedPrice: { price: number; currency: string } | null;
   url: string;
+  stockStatus?: string;
 }
 
 const METHOD_LABELS: Record<string, string> = {
@@ -43,6 +44,7 @@ export default function PriceSelectionModal({
   candidates,
   suggestedPrice,
   url,
+  stockStatus,
 }: PriceSelectionModalProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(
     suggestedPrice
@@ -50,6 +52,8 @@ export default function PriceSelectionModal({
       : 0
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isOutOfStock = stockStatus === 'out_of_stock';
+  const [notifyBackInStock, setNotifyBackInStock] = useState(isOutOfStock);
 
   if (!isOpen) return null;
 
@@ -58,7 +62,7 @@ export default function PriceSelectionModal({
     const selected = candidates[selectedIndex];
     setIsSubmitting(true);
     try {
-      await onSelect(selected.price, selected.method);
+      await onSelect(selected.price, selected.method, notifyBackInStock);
     } finally {
       setIsSubmitting(false);
     }
@@ -284,6 +288,35 @@ export default function PriceSelectionModal({
         </div>
 
         <div className="price-modal-body">
+          {isOutOfStock && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '0.75rem',
+                padding: '0.75rem 1rem',
+                marginBottom: '1rem',
+                borderRadius: '0.5rem',
+                background: 'rgba(245, 158, 11, 0.1)',
+                border: '1px solid rgba(245, 158, 11, 0.3)',
+              }}
+            >
+              <span style={{ fontSize: '1.25rem', lineHeight: 1 }}>⚠</span>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 500, color: 'var(--text)', marginBottom: '0.5rem' }}>
+                  Currently out of stock
+                </div>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.875rem', color: 'var(--text)', cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={notifyBackInStock}
+                    onChange={(e) => setNotifyBackInStock(e.target.checked)}
+                  />
+                  Notify me when this comes back in stock
+                </label>
+              </div>
+            </div>
+          )}
           <div className="price-candidates-list">
             {sortedCandidates.map((candidate, index) => {
               const originalIndex = candidates.indexOf(candidate);

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -550,11 +550,12 @@ export default function ProductCard({ product, onDelete, onRefresh, isSelected, 
       </div>
 
       <div className="product-price-section">
-        {isOutOfStock ? (
+        {isOutOfStock && (
           <span className="product-stock-badge out-of-stock">
             Out of Stock
           </span>
-        ) : (
+        )}
+        {product.current_price !== null && product.current_price !== undefined && (
           <>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem' }}>
               <span className="product-current-price">
@@ -562,17 +563,17 @@ export default function ProductCard({ product, onDelete, onRefresh, isSelected, 
               </span>
               <AIStatusBadge status={product.ai_status} size="small" />
             </div>
-            {product.price_change_7d !== null && product.price_change_7d !== undefined && (
+            {!isOutOfStock && product.price_change_7d !== null && product.price_change_7d !== undefined && (
               <span className={`product-price-change ${priceChangeClass}`}>
                 {formatPriceChange(product.price_change_7d)} (7d)
               </span>
             )}
-            {isHistoricalLow && (
+            {!isOutOfStock && isHistoricalLow && (
               <span className="product-stock-badge historical-low">
                 Lowest Price
               </span>
             )}
-            {isNearHistoricalLow && (
+            {!isOutOfStock && isNearHistoricalLow && (
               <span className="product-stock-badge near-low">
                 Near Low
               </span>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -98,14 +98,19 @@ export default function Dashboard() {
     setProducts((prev) => [response.data as Product, ...prev]);
   };
 
-  const handlePriceSelected = async (selectedPrice: number, selectedMethod: string) => {
+  const handlePriceSelected = async (
+    selectedPrice: number,
+    selectedMethod: string,
+    notifyBackInStock: boolean
+  ) => {
     if (!priceReviewData) return;
 
     const response = await productsApi.create(
       priceReviewData.url,
       pendingRefreshInterval,
       selectedPrice,
-      selectedMethod
+      selectedMethod,
+      notifyBackInStock
     );
 
     // When selecting a price, the API should always return a Product
@@ -795,6 +800,7 @@ export default function Dashboard() {
         candidates={priceReviewData?.priceCandidates || []}
         suggestedPrice={priceReviewData?.suggestedPrice || null}
         url={priceReviewData?.url || ''}
+        stockStatus={priceReviewData?.stockStatus}
       />
 
       {error && <div className="alert alert-error">{error}</div>}

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -451,14 +451,21 @@ export default function ProductDetail() {
               </div>
             ) : null}
 
-            <div className="product-detail-price" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <div className="product-detail-price" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
               <span>
-                {product.stock_status === 'out_of_stock'
-                  ? 'Price unavailable'
-                  : formatPrice(product.current_price, product.currency)}
+                {product.current_price !== null && product.current_price !== undefined
+                  ? formatPrice(product.current_price, product.currency)
+                  : 'Price unavailable'}
               </span>
-              {product.stock_status !== 'out_of_stock' && (
+              {product.current_price !== null && product.current_price !== undefined && (
                 <AIStatusBadge status={product.ai_status} />
+              )}
+              {product.stock_status === 'out_of_stock' &&
+                product.current_price !== null &&
+                product.current_price !== undefined && (
+                  <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                    last known price
+                  </span>
               )}
             </div>
 


### PR DESCRIPTION
Closes #2.

- Add Shopify-aware extraction via `/products/<handle>.js` for reliable per-variant availability across themes and locales.
- Wire JSON-LD `offers.availability` into the voting scraper (was silently dropped).
- Stop matching theme badge spans as out-of-stock markers (caused false OOS on Shopify Dawn-family themes that dual-render both badges).
- Show last-known price alongside the OOS badge instead of hiding it.
- Accept `notify_back_in_stock` on `POST /products` and default it on when adding an out-of-stock product. Use scraped currency on the initial price-history row instead of hardcoded USD.

## Test plan

- [ ] Add an in-stock Shopify product — detects as in-stock with correct price.
- [ ] Add an out-of-stock Shopify product — OOS badge shows, last-known price visible, restock-alert checkbox pre-checked.
- [ ] Verify a back-in-stock transition fires the configured notification.
- [ ] Regression: non-Shopify products still resolve correctly.