### PR TITLE
Add per-product "notify on any price change" alert (#5)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -58,6 +58,7 @@ async function runMigrations() {
         price_drop_threshold DECIMAL(10,2),
         target_price DECIMAL(10,2),
         notify_back_in_stock BOOLEAN DEFAULT false,
+        notify_any_change BOOLEAN DEFAULT false,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         UNIQUE(user_id, url)
       );
@@ -275,6 +276,10 @@ async function runMigrations() {
         -- Per-product checking pause flag
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'checking_paused') THEN
           ALTER TABLE products ADD COLUMN checking_paused BOOLEAN DEFAULT false;
+        END IF;
+        -- Notify on any price change (issue #5)
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'notify_any_change') THEN
+          ALTER TABLE products ADD COLUMN notify_any_change BOOLEAN DEFAULT false;
         END IF;
       END $$;
     `);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -440,6 +440,7 @@ export interface Product {
   price_drop_threshold: number | null;
   target_price: number | null;
   notify_back_in_stock: boolean;
+  notify_any_change: boolean;
   ai_verification_disabled: boolean;
   ai_extraction_disabled: boolean;
   checking_paused: boolean;
@@ -607,6 +608,7 @@ export const productQueries = {
       price_drop_threshold?: number | null;
       target_price?: number | null;
       notify_back_in_stock?: boolean;
+      notify_any_change?: boolean;
       ai_verification_disabled?: boolean;
       ai_extraction_disabled?: boolean;
     }
@@ -634,6 +636,10 @@ export const productQueries = {
     if (updates.notify_back_in_stock !== undefined) {
       fields.push(`notify_back_in_stock = $${paramIndex++}`);
       values.push(updates.notify_back_in_stock);
+    }
+    if (updates.notify_any_change !== undefined) {
+      fields.push(`notify_any_change = $${paramIndex++}`);
+      values.push(updates.notify_any_change);
     }
     if (updates.ai_verification_disabled !== undefined) {
       fields.push(`ai_verification_disabled = $${paramIndex++}`);
@@ -971,7 +977,7 @@ export const stockStatusHistoryQueries = {
 };
 
 // Notification History types and queries
-export type NotificationType = 'price_drop' | 'price_target' | 'stock_change';
+export type NotificationType = 'price_drop' | 'price_target' | 'stock_change' | 'price_change';
 
 export interface NotificationHistory {
   id: number;

--- a/backend/src/routes/products.ts
+++ b/backend/src/routes/products.ts
@@ -233,7 +233,7 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
       return;
     }
 
-    const { name, refresh_interval, price_drop_threshold, target_price, notify_back_in_stock, ai_verification_disabled, ai_extraction_disabled } = req.body;
+    const { name, refresh_interval, price_drop_threshold, target_price, notify_back_in_stock, notify_any_change, ai_verification_disabled, ai_extraction_disabled } = req.body;
 
     const product = await productQueries.update(productId, userId, {
       name,
@@ -241,6 +241,7 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
       price_drop_threshold,
       target_price,
       notify_back_in_stock,
+      notify_any_change,
       ai_verification_disabled,
       ai_extraction_disabled,
     });

--- a/backend/src/services/notifications.ts
+++ b/backend/src/services/notifications.ts
@@ -15,7 +15,7 @@ function getCurrencySymbol(currency?: string): string {
 export interface NotificationPayload {
   productName: string;
   productUrl: string;
-  type: 'price_drop' | 'back_in_stock' | 'target_price';
+  type: 'price_drop' | 'back_in_stock' | 'target_price' | 'price_change';
   oldPrice?: number;
   newPrice?: number;
   currency?: string;
@@ -47,6 +47,19 @@ function formatMessage(payload: NotificationPayload): string {
     return `🎯 Target Price Reached!\n\n` +
       `📦 ${payload.productName}\n\n` +
       `💰 Price is now ${newPriceStr} (your target: ${targetPriceStr})\n\n` +
+      `🔗 ${payload.productUrl}`;
+  }
+
+  if (payload.type === 'price_change') {
+    const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
+    const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
+    const delta = payload.oldPrice && payload.newPrice ? payload.newPrice - payload.oldPrice : 0;
+    const arrow = delta < 0 ? '↓' : '↑';
+    const deltaStr = `${currencySymbol}${Math.abs(delta).toFixed(2)}`;
+
+    return `📊 Price Changed\n\n` +
+      `📦 ${payload.productName}\n\n` +
+      `${arrow} ${oldPriceStr} → ${newPriceStr} (${arrow}${deltaStr})\n\n` +
       `🔗 ${payload.productUrl}`;
   }
 
@@ -123,6 +136,22 @@ export async function sendDiscordNotification(
         url: payload.productUrl,
         timestamp: new Date().toISOString(),
       };
+    } else if (payload.type === 'price_change') {
+      const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
+      const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
+      const wentDown = payload.oldPrice && payload.newPrice && payload.newPrice < payload.oldPrice;
+
+      embed = {
+        title: wentDown ? '📊 Price Decreased' : '📊 Price Increased',
+        description: payload.productName,
+        color: wentDown ? 0x10b981 : 0xef4444, // Green if down, red if up
+        fields: [
+          { name: 'Old Price', value: oldPriceStr, inline: true },
+          { name: 'New Price', value: newPriceStr, inline: true },
+        ],
+        url: payload.productUrl,
+        timestamp: new Date().toISOString(),
+      };
     } else {
       const priceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'Check link';
 
@@ -172,6 +201,12 @@ export async function sendPushoverNotification(
       const targetPriceStr = payload.targetPrice ? `${currencySymbol}${payload.targetPrice.toFixed(2)}` : 'N/A';
       title = '🎯 Target Price Reached!';
       message = `${payload.productName}\n\nPrice is now ${newPriceStr} (your target: ${targetPriceStr})`;
+    } else if (payload.type === 'price_change') {
+      const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
+      const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
+      const wentDown = payload.oldPrice && payload.newPrice && payload.newPrice < payload.oldPrice;
+      title = wentDown ? '📊 Price Decreased' : '📊 Price Increased';
+      message = `${payload.productName}\n\nPrice changed from ${oldPriceStr} to ${newPriceStr}`;
     } else {
       const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
       title = '🎉 Back in Stock!';
@@ -221,6 +256,13 @@ export async function sendNtfyNotification(
       title = 'Target Price Reached!';
       message = `${payload.productName}\n\nPrice is now ${newPriceStr} (your target: ${targetPriceStr})`;
       tags = ['dart', 'white_check_mark'];
+    } else if (payload.type === 'price_change') {
+      const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
+      const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
+      const wentDown = payload.oldPrice && payload.newPrice && payload.newPrice < payload.oldPrice;
+      title = wentDown ? 'Price Decreased' : 'Price Increased';
+      message = `${payload.productName}\n\nPrice changed from ${oldPriceStr} to ${newPriceStr}`;
+      tags = wentDown ? ['chart_with_downwards_trend'] : ['chart_with_upwards_trend'];
     } else {
       const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
       title = 'Back in Stock!';
@@ -279,6 +321,13 @@ export async function sendGotifyNotification(
       title = 'Target Price Reached!';
       message = `${payload.productName}\n\nPrice is now ${newPriceStr} (your target: ${targetPriceStr})\n\n${payload.productUrl}`;
       priority = 8; // Higher priority
+    } else if (payload.type === 'price_change') {
+      const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
+      const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
+      const wentDown = payload.oldPrice && payload.newPrice && payload.newPrice < payload.oldPrice;
+      title = wentDown ? 'Price Decreased' : 'Price Increased';
+      message = `${payload.productName}\n\nPrice changed from ${oldPriceStr} to ${newPriceStr}\n\n${payload.productUrl}`;
+      priority = 5; // Normal priority — informational
     } else {
       const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
       title = 'Back in Stock!';

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -107,8 +107,56 @@ async function checkPrices(): Promise<void> {
 
           // Only record if price has changed or it's the first entry
           if (!latestPrice || latestPrice.price !== scrapedData.price.price) {
+            // Per-product "any change" alert. Fires on every price movement
+            // (up or down) above a 0.01 noise floor. When this is on, the
+            // price_drop_threshold check below is skipped to avoid sending
+            // two notifications for the same change.
+            const oldPrice = latestPrice ? parseFloat(String(latestPrice.price)) : null;
+            const newPrice = scrapedData.price.price;
+            const anyChangeFired =
+              latestPrice &&
+              product.notify_any_change &&
+              oldPrice !== null &&
+              Math.abs(newPrice - oldPrice) >= 0.01;
+
+            if (anyChangeFired) {
+              try {
+                const userSettings = await userQueries.getNotificationSettings(product.user_id);
+                if (userSettings) {
+                  const payload: NotificationPayload = {
+                    productName: product.name || 'Unknown Product',
+                    productUrl: product.url,
+                    type: 'price_change',
+                    oldPrice: oldPrice!,
+                    newPrice,
+                    currency: scrapedData.price.currency,
+                  };
+                  const result = await sendNotifications(userSettings, payload);
+                  console.log(`Price change notification sent for product ${product.id}: ${oldPrice} -> ${newPrice}`);
+
+                  if (result.channelsNotified.length > 0) {
+                    const priceChangePercent = ((newPrice - oldPrice!) / oldPrice!) * 100;
+                    await notificationHistoryQueries.create({
+                      user_id: product.user_id,
+                      product_id: product.id,
+                      notification_type: 'price_change' as NotificationType,
+                      old_price: oldPrice!,
+                      new_price: newPrice,
+                      currency: scrapedData.price.currency,
+                      price_change_percent: Math.round(priceChangePercent * 100) / 100,
+                      channels_notified: result.channelsNotified,
+                      product_name: product.name || 'Unknown Product',
+                      product_url: product.url,
+                    });
+                  }
+                }
+              } catch (notifyError) {
+                console.error(`Failed to send price change notification for product ${product.id}:`, notifyError);
+              }
+            }
+
             // Check for price drop notification before recording
-            if (latestPrice && product.price_drop_threshold) {
+            if (!anyChangeFired && latestPrice && product.price_drop_threshold) {
               const oldPrice = parseFloat(String(latestPrice.price));
               const newPrice = scrapedData.price.price;
               const priceDrop = oldPrice - newPrice;

--- a/database/init.sql
+++ b/database/init.sql
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS products (
   price_drop_threshold DECIMAL(10,2),
   target_price DECIMAL(10,2),
   notify_back_in_stock BOOLEAN DEFAULT false,
+  notify_any_change BOOLEAN DEFAULT false,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(user_id, url)
 );
@@ -116,6 +117,17 @@ BEGIN
     WHERE table_name = 'products' AND column_name = 'target_price'
   ) THEN
     ALTER TABLE products ADD COLUMN target_price DECIMAL(10,2);
+  END IF;
+END $$;
+
+-- Migration: Add notify_any_change column for "alert on any price change"
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'products' AND column_name = 'notify_any_change'
+  ) THEN
+    ALTER TABLE products ADD COLUMN notify_any_change BOOLEAN DEFAULT false;
   END IF;
 END $$;
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -80,6 +80,7 @@ export interface Product {
   price_drop_threshold: number | null;
   target_price: number | null;
   notify_back_in_stock: boolean;
+  notify_any_change: boolean;
   ai_verification_disabled: boolean;
   ai_extraction_disabled: boolean;
   checking_paused: boolean;
@@ -156,6 +157,7 @@ export const productsApi = {
     price_drop_threshold?: number | null;
     target_price?: number | null;
     notify_back_in_stock?: boolean;
+    notify_any_change?: boolean;
     ai_verification_disabled?: boolean;
     ai_extraction_disabled?: boolean;
   }) => api.put<Product>(`/products/${id}`, data),

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -31,6 +31,7 @@ export default function ProductDetail() {
   const [priceDropThreshold, setPriceDropThreshold] = useState<string>('');
   const [targetPrice, setTargetPrice] = useState<string>('');
   const [notifyBackInStock, setNotifyBackInStock] = useState(false);
+  const [notifyAnyChange, setNotifyAnyChange] = useState(false);
   const [aiVerificationDisabled, setAiVerificationDisabled] = useState(false);
   const [aiExtractionDisabled, setAiExtractionDisabled] = useState(false);
 
@@ -70,6 +71,7 @@ export default function ProductDetail() {
           setTargetPrice(productRes.data.target_price.toString());
         }
         setNotifyBackInStock(productRes.data.notify_back_in_stock || false);
+        setNotifyAnyChange(productRes.data.notify_any_change || false);
         setAiVerificationDisabled(productRes.data.ai_verification_disabled || false);
         setAiExtractionDisabled(productRes.data.ai_extraction_disabled || false);
         setIsLoading(false);
@@ -156,6 +158,7 @@ export default function ProductDetail() {
         price_drop_threshold: threshold,
         target_price: target,
         notify_back_in_stock: notifyBackInStock,
+        notify_any_change: notifyAnyChange,
         ai_verification_disabled: aiVerificationDisabled,
         ai_extraction_disabled: aiExtractionDisabled,
       });
@@ -164,6 +167,7 @@ export default function ProductDetail() {
         price_drop_threshold: threshold,
         target_price: target,
         notify_back_in_stock: notifyBackInStock,
+        notify_any_change: notifyAnyChange,
         ai_verification_disabled: aiVerificationDisabled,
         ai_extraction_disabled: aiExtractionDisabled,
       });
@@ -765,6 +769,23 @@ export default function ProductDetail() {
                   <div className="notification-checkbox-label">
                     <span>Enable back-in-stock notifications</span>
                     <span>Get notified when this item becomes available</span>
+                  </div>
+                </label>
+              </div>
+
+              <div className="notification-form-group">
+                <label>Any Price Change</label>
+                <label className="notification-checkbox-group">
+                  <input
+                    type="checkbox"
+                    checked={notifyAnyChange}
+                    onChange={(e) => setNotifyAnyChange(e.target.checked)}
+                  />
+                  <div className="notification-checkbox-label">
+                    <span>Notify on every price change</span>
+                    <span>
+                      Fires on any movement (up or down). Overrides the price-drop threshold above when enabled.
+                    </span>
                   </div>
                 </label>
               </div>


### PR DESCRIPTION
Closes #5.

- New `notify_any_change` boolean on `products`. When enabled, the scheduler fires a `price_change` notification on every price movement ≥ 0.01 in either direction.
- Overrides the per-product price-drop threshold while enabled (so users don't get double-notified). Target-price alerts still fire independently.
- Notifications support: Telegram, Discord (green/red embed by direction), Pushover, ntfy (up/down trend tags), Gotify (normal-priority informational).
- Per-product toggle added next to the existing back-in-stock toggle in the product detail page.
- Idempotent DB migration adds the column.

## Test plan

- [ ] Enable the toggle on a tracked product; on the next scrape where the price changes, confirm a notification is delivered on each configured channel.
- [ ] Confirm a `price_change` row appears in `notification_history`.
- [ ] Confirm threshold-based price-drop notifications do NOT fire when "any change" is on (same change should produce one notification, not two).
- [ ] Regression: products without the toggle still use the existing threshold + target-price behaviour.