### PR TITLE
Add currency override + show extraction source on product detail (#6)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -281,6 +281,14 @@ async function runMigrations() {
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'notify_any_change') THEN
           ALTER TABLE products ADD COLUMN notify_any_change BOOLEAN DEFAULT false;
         END IF;
+        -- Per-product currency override (issue #6)
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'currency_override') THEN
+          ALTER TABLE products ADD COLUMN currency_override VARCHAR(3);
+        END IF;
+        -- Stored "how was this price extracted" context for UI display (issue #6)
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'extraction_context') THEN
+          ALTER TABLE products ADD COLUMN extraction_context TEXT;
+        END IF;
       END $$;
     `);
 

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -444,6 +444,8 @@ export interface Product {
   ai_verification_disabled: boolean;
   ai_extraction_disabled: boolean;
   checking_paused: boolean;
+  currency_override: string | null;
+  extraction_context: string | null;
   created_at: Date;
 }
 
@@ -472,7 +474,7 @@ export interface ProductWithSparkline extends ProductWithLatestPrice {
 export const productQueries = {
   findByUserId: async (userId: number): Promise<ProductWithLatestPrice[]> => {
     const result = await pool.query(
-      `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status
+      `SELECT p.*, ph.price as current_price, COALESCE(p.currency_override, ph.currency) as currency, ph.ai_status
        FROM products p
        LEFT JOIN LATERAL (
          SELECT price, currency, ai_status FROM price_history
@@ -490,7 +492,7 @@ export const productQueries = {
   findByUserIdWithSparkline: async (userId: number): Promise<ProductWithSparkline[]> => {
     // Get all products with current price
     const productsResult = await pool.query(
-      `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status
+      `SELECT p.*, ph.price as current_price, COALESCE(p.currency_override, ph.currency) as currency, ph.ai_status
        FROM products p
        LEFT JOIN LATERAL (
          SELECT price, currency, ai_status FROM price_history
@@ -564,7 +566,7 @@ export const productQueries = {
 
   findById: async (id: number, userId: number): Promise<ProductWithLatestPrice | null> => {
     const result = await pool.query(
-      `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status
+      `SELECT p.*, ph.price as current_price, COALESCE(p.currency_override, ph.currency) as currency, ph.ai_status
        FROM products p
        LEFT JOIN LATERAL (
          SELECT price, currency, ai_status FROM price_history
@@ -611,6 +613,7 @@ export const productQueries = {
       notify_any_change?: boolean;
       ai_verification_disabled?: boolean;
       ai_extraction_disabled?: boolean;
+      currency_override?: string | null;
     }
   ): Promise<Product | null> => {
     const fields: string[] = [];
@@ -648,6 +651,14 @@ export const productQueries = {
     if (updates.ai_extraction_disabled !== undefined) {
       fields.push(`ai_extraction_disabled = $${paramIndex++}`);
       values.push(updates.ai_extraction_disabled);
+    }
+    if (updates.currency_override !== undefined) {
+      // Normalise to uppercase 3-letter code or null
+      const normalised = updates.currency_override
+        ? updates.currency_override.toUpperCase().slice(0, 3)
+        : null;
+      fields.push(`currency_override = $${paramIndex++}`);
+      values.push(normalised);
     }
 
     if (fields.length === 0) return null;
@@ -699,10 +710,10 @@ export const productQueries = {
     return result.rows;
   },
 
-  updateExtractionMethod: async (id: number, method: string): Promise<void> => {
+  updateExtractionMethod: async (id: number, method: string, context?: string | null): Promise<void> => {
     await pool.query(
-      'UPDATE products SET preferred_extraction_method = $1, needs_price_review = false WHERE id = $2',
-      [method, id]
+      'UPDATE products SET preferred_extraction_method = $1, extraction_context = $2, needs_price_review = false WHERE id = $3',
+      [method, context ?? null, id]
     );
   },
 

--- a/backend/src/routes/products.ts
+++ b/backend/src/routes/products.ts
@@ -24,7 +24,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
 router.post('/', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.userId!;
-    const { url, refresh_interval, selectedPrice, selectedMethod, notify_back_in_stock } = req.body;
+    const { url, refresh_interval, selectedPrice, selectedMethod, selectedContext, notify_back_in_stock } = req.body;
 
     if (!url) {
       res.status(400).json({ error: 'URL is required' });
@@ -62,19 +62,26 @@ router.post('/', async (req: AuthRequest, res: Response) => {
         finalNotifyBackInStock
       );
 
-      // Store the preferred extraction method and the user-selected price
-      await productQueries.updateExtractionMethod(product.id, selectedMethod);
+      // Store the preferred extraction method and the user-selected price.
+      // selectedContext (e.g. ".price-tag → \"$9.99\"") surfaces in the UI so
+      // users can see exactly where the price came from.
+      await productQueries.updateExtractionMethod(
+        product.id,
+        selectedMethod,
+        typeof selectedContext === 'string' ? selectedContext : null
+      );
 
       // Store the anchor price - used on refresh to select the correct variant
       await productQueries.updateAnchorPrice(product.id, selectedPrice);
       console.log(`[Products] Saved anchor price ${selectedPrice} for product ${product.id} (method: ${selectedMethod})`);
 
       // Record the user-selected price with the currency the scraper detected
-      // (avoids defaulting EUR/GBP/etc. products to USD).
+      // (avoids defaulting EUR/GBP/etc. products to USD). If the user already
+      // set a per-product currency override, that wins.
       await priceHistoryQueries.create(
         product.id,
         selectedPrice,
-        scrapedData.price?.currency || 'USD',
+        product.currency_override || scrapedData.price?.currency || 'USD',
         null
       );
 
@@ -153,9 +160,17 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       finalNotifyBackInStock
     );
 
-    // Store the extraction method that worked
+    // Store the extraction method that worked, plus the winning candidate's
+    // context if we have one (for the "how was this extracted" UI hint).
     if (scrapedData.selectedMethod) {
-      await productQueries.updateExtractionMethod(product.id, scrapedData.selectedMethod);
+      const winning = scrapedData.priceCandidates.find(
+        (c) => c.method === scrapedData.selectedMethod && c.price === scrapedData.price?.price
+      );
+      await productQueries.updateExtractionMethod(
+        product.id,
+        scrapedData.selectedMethod,
+        winning?.context ?? null
+      );
     }
 
     // Record initial price if available
@@ -233,7 +248,7 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
       return;
     }
 
-    const { name, refresh_interval, price_drop_threshold, target_price, notify_back_in_stock, notify_any_change, ai_verification_disabled, ai_extraction_disabled } = req.body;
+    const { name, refresh_interval, price_drop_threshold, target_price, notify_back_in_stock, notify_any_change, ai_verification_disabled, ai_extraction_disabled, currency_override } = req.body;
 
     const product = await productQueries.update(productId, userId, {
       name,
@@ -244,6 +259,7 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
       notify_any_change,
       ai_verification_disabled,
       ai_extraction_disabled,
+      currency_override,
     });
 
     if (!product) {

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -105,6 +105,10 @@ async function checkPrices(): Promise<void> {
           // Get the latest recorded price to compare
           const latestPrice = await priceHistoryQueries.getLatest(product.id);
 
+          // Honour per-product currency override (issue #6) — the notification
+          // and history rows should both show what the user said the currency is.
+          const effectiveCurrency = product.currency_override || scrapedData.price.currency;
+
           // Only record if price has changed or it's the first entry
           if (!latestPrice || latestPrice.price !== scrapedData.price.price) {
             // Per-product "any change" alert. Fires on every price movement
@@ -129,7 +133,7 @@ async function checkPrices(): Promise<void> {
                     type: 'price_change',
                     oldPrice: oldPrice!,
                     newPrice,
-                    currency: scrapedData.price.currency,
+                    currency: effectiveCurrency,
                   };
                   const result = await sendNotifications(userSettings, payload);
                   console.log(`Price change notification sent for product ${product.id}: ${oldPrice} -> ${newPrice}`);
@@ -142,7 +146,7 @@ async function checkPrices(): Promise<void> {
                       notification_type: 'price_change' as NotificationType,
                       old_price: oldPrice!,
                       new_price: newPrice,
-                      currency: scrapedData.price.currency,
+                      currency: effectiveCurrency,
                       price_change_percent: Math.round(priceChangePercent * 100) / 100,
                       channels_notified: result.channelsNotified,
                       product_name: product.name || 'Unknown Product',
@@ -171,7 +175,7 @@ async function checkPrices(): Promise<void> {
                       type: 'price_drop',
                       oldPrice: oldPrice,
                       newPrice: newPrice,
-                      currency: scrapedData.price.currency,
+                      currency: effectiveCurrency,
                       threshold: product.price_drop_threshold,
                     };
                     const result = await sendNotifications(userSettings, payload);
@@ -186,7 +190,7 @@ async function checkPrices(): Promise<void> {
                         notification_type: 'price_drop' as NotificationType,
                         old_price: oldPrice,
                         new_price: newPrice,
-                        currency: scrapedData.price.currency,
+                        currency: effectiveCurrency,
                         price_change_percent: Math.round(priceChangePercent * 100) / 100,
                         channels_notified: result.channelsNotified,
                         product_name: product.name || 'Unknown Product',
@@ -216,7 +220,7 @@ async function checkPrices(): Promise<void> {
                       productUrl: product.url,
                       type: 'target_price',
                       newPrice: newPrice,
-                      currency: scrapedData.price.currency,
+                      currency: effectiveCurrency,
                       targetPrice: targetPrice,
                     };
                     const result = await sendNotifications(userSettings, payload);
@@ -230,7 +234,7 @@ async function checkPrices(): Promise<void> {
                         notification_type: 'price_target' as NotificationType,
                         old_price: oldPrice || undefined,
                         new_price: newPrice,
-                        currency: scrapedData.price.currency,
+                        currency: effectiveCurrency,
                         target_price: targetPrice,
                         channels_notified: result.channelsNotified,
                         product_name: product.name || 'Unknown Product',
@@ -247,11 +251,11 @@ async function checkPrices(): Promise<void> {
             await priceHistoryQueries.create(
               product.id,
               scrapedData.price.price,
-              scrapedData.price.currency,
+              effectiveCurrency,
               scrapedData.aiStatus
             );
             console.log(
-              `Recorded new price for product ${product.id}: ${scrapedData.price.currency} ${scrapedData.price.price}${scrapedData.aiStatus ? ` (AI: ${scrapedData.aiStatus})` : ''}`
+              `Recorded new price for product ${product.id}: ${effectiveCurrency} ${scrapedData.price.price}${scrapedData.aiStatus ? ` (AI: ${scrapedData.aiStatus})` : ''}`
             );
           } else {
             console.log(`Price unchanged for product ${product.id}`);

--- a/backend/src/services/scraper.ts
+++ b/backend/src/services/scraper.ts
@@ -215,7 +215,7 @@ function extractGenericCssCandidates($: CheerioAPI): PriceCandidate[] {
             }
           }
           parsed = { price, currency };
-          context = `data-price-amount attribute`;
+          context = `${selector}[data-price-amount]`;
         }
       }
 
@@ -223,7 +223,10 @@ function extractGenericCssCandidates($: CheerioAPI): PriceCandidate[] {
         const priceStr = content || dataPrice || text;
         parsed = parsePrice(priceStr);
         if (parsed) {
-          context = text.trim().slice(0, 50);
+          // Surface the CSS selector alongside the matched text so the
+          // product-detail "how was this extracted" hint is actionable.
+          const sample = text.trim().slice(0, 40);
+          context = sample ? `${selector} → "${sample}"` : selector;
         }
       }
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -131,6 +131,23 @@ BEGIN
   END IF;
 END $$;
 
+-- Migration: Per-product currency override + extraction context (issue #6)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'products' AND column_name = 'currency_override'
+  ) THEN
+    ALTER TABLE products ADD COLUMN currency_override VARCHAR(3);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'products' AND column_name = 'extraction_context'
+  ) THEN
+    ALTER TABLE products ADD COLUMN extraction_context TEXT;
+  END IF;
+END $$;
+
 -- Price history table
 CREATE TABLE IF NOT EXISTS price_history (
   id SERIAL PRIMARY KEY,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,6 +84,9 @@ export interface Product {
   ai_verification_disabled: boolean;
   ai_extraction_disabled: boolean;
   checking_paused: boolean;
+  currency_override: string | null;
+  extraction_context: string | null;
+  preferred_extraction_method: string | null;
   created_at: string;
   current_price: number | null;
   currency: string | null;
@@ -141,13 +144,15 @@ export const productsApi = {
     refreshInterval?: number,
     selectedPrice?: number,
     selectedMethod?: string,
-    notifyBackInStock?: boolean
+    notifyBackInStock?: boolean,
+    selectedContext?: string
   ) =>
     api.post<CreateProductResponse>('/products', {
       url,
       refresh_interval: refreshInterval,
       selectedPrice,
       selectedMethod,
+      selectedContext,
       notify_back_in_stock: notifyBackInStock,
     }),
 
@@ -160,6 +165,7 @@ export const productsApi = {
     notify_any_change?: boolean;
     ai_verification_disabled?: boolean;
     ai_extraction_disabled?: boolean;
+    currency_override?: string | null;
   }) => api.put<Product>(`/products/${id}`, data),
 
   delete: (id: number) => api.delete(`/products/${id}`),

--- a/frontend/src/components/PriceSelectionModal.tsx
+++ b/frontend/src/components/PriceSelectionModal.tsx
@@ -12,7 +12,7 @@ export interface PriceCandidate {
 interface PriceSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (price: number, method: string, notifyBackInStock: boolean) => void;
+  onSelect: (price: number, method: string, notifyBackInStock: boolean, context: string | undefined) => void;
   productName: string | null;
   imageUrl: string | null;
   candidates: PriceCandidate[];
@@ -62,7 +62,7 @@ export default function PriceSelectionModal({
     const selected = candidates[selectedIndex];
     setIsSubmitting(true);
     try {
-      await onSelect(selected.price, selected.method, notifyBackInStock);
+      await onSelect(selected.price, selected.method, notifyBackInStock, selected.context);
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -101,7 +101,8 @@ export default function Dashboard() {
   const handlePriceSelected = async (
     selectedPrice: number,
     selectedMethod: string,
-    notifyBackInStock: boolean
+    notifyBackInStock: boolean,
+    selectedContext: string | undefined
   ) => {
     if (!priceReviewData) return;
 
@@ -110,7 +111,8 @@ export default function Dashboard() {
       pendingRefreshInterval,
       selectedPrice,
       selectedMethod,
-      notifyBackInStock
+      notifyBackInStock,
+      selectedContext
     );
 
     // When selecting a price, the API should always return a Product

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -32,8 +32,11 @@ export default function ProductDetail() {
   const [targetPrice, setTargetPrice] = useState<string>('');
   const [notifyBackInStock, setNotifyBackInStock] = useState(false);
   const [notifyAnyChange, setNotifyAnyChange] = useState(false);
+  const [currencyOverride, setCurrencyOverride] = useState<string>('');
   const [aiVerificationDisabled, setAiVerificationDisabled] = useState(false);
   const [aiExtractionDisabled, setAiExtractionDisabled] = useState(false);
+
+  const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'CHF', 'CAD', 'AUD', 'JPY', 'INR', 'BRL', 'PLN', 'SEK', 'NOK', 'DKK', 'KRW', 'RUB', 'CNY'];
 
   const REFRESH_INTERVALS = [
     { value: 300, label: '5 minutes' },
@@ -72,6 +75,7 @@ export default function ProductDetail() {
         }
         setNotifyBackInStock(productRes.data.notify_back_in_stock || false);
         setNotifyAnyChange(productRes.data.notify_any_change || false);
+        setCurrencyOverride(productRes.data.currency_override || '');
         setAiVerificationDisabled(productRes.data.ai_verification_disabled || false);
         setAiExtractionDisabled(productRes.data.ai_extraction_disabled || false);
         setIsLoading(false);
@@ -154,6 +158,7 @@ export default function ProductDetail() {
     try {
       const threshold = priceDropThreshold ? parseFloat(priceDropThreshold) : null;
       const target = targetPrice ? parseFloat(targetPrice) : null;
+      const normalisedCurrencyOverride = currencyOverride ? currencyOverride : null;
       await productsApi.update(productId, {
         price_drop_threshold: threshold,
         target_price: target,
@@ -161,6 +166,7 @@ export default function ProductDetail() {
         notify_any_change: notifyAnyChange,
         ai_verification_disabled: aiVerificationDisabled,
         ai_extraction_disabled: aiExtractionDisabled,
+        currency_override: normalisedCurrencyOverride,
       });
       setProduct({
         ...product,
@@ -170,6 +176,8 @@ export default function ProductDetail() {
         notify_any_change: notifyAnyChange,
         ai_verification_disabled: aiVerificationDisabled,
         ai_extraction_disabled: aiExtractionDisabled,
+        currency_override: normalisedCurrencyOverride,
+        currency: normalisedCurrencyOverride || product.currency,
       });
       showToast('Notification settings saved');
     } catch {
@@ -482,6 +490,35 @@ export default function ProductDetail() {
               </span>
             )}
 
+            {product.preferred_extraction_method && (
+              <div
+                style={{
+                  fontSize: '0.75rem',
+                  color: 'var(--text-muted)',
+                  marginTop: '0.5rem',
+                }}
+                title="How PriceStalker extracted this price"
+              >
+                <span>ⓘ Detected via: </span>
+                <strong>
+                  {product.preferred_extraction_method === 'json-ld'
+                    ? 'JSON-LD'
+                    : product.preferred_extraction_method === 'site-specific'
+                      ? 'Site-specific scraper'
+                      : product.preferred_extraction_method === 'generic-css'
+                        ? 'Generic CSS'
+                        : product.preferred_extraction_method === 'ai'
+                          ? 'AI extraction'
+                          : product.preferred_extraction_method}
+                </strong>
+                {product.extraction_context && (
+                  <span style={{ fontFamily: 'monospace', marginLeft: '0.25rem' }}>
+                    ({product.extraction_context})
+                  </span>
+                )}
+              </div>
+            )}
+
             <div className="product-detail-meta">
               <div className="product-detail-meta-item">
                 <span className="product-detail-meta-label">Last Checked</span>
@@ -788,6 +825,25 @@ export default function ProductDetail() {
                     </span>
                   </div>
                 </label>
+              </div>
+            </div>
+
+            <div className="notification-form-row">
+              <div className="notification-form-group">
+                <label>Currency</label>
+                <select
+                  value={currencyOverride}
+                  onChange={(e) => setCurrencyOverride(e.target.value)}
+                >
+                  <option value="">Auto-detect</option>
+                  {SUPPORTED_CURRENCIES.map((code) => (
+                    <option key={code} value={code}>{code}</option>
+                  ))}
+                </select>
+                <span className="hint">
+                  Force the displayed and stored currency for this product. Useful when the scraper
+                  defaults to USD on a non-USD store.
+                </span>
               </div>
             </div>
 


### PR DESCRIPTION
Closes #6.

- Per-product currency override (`currency_override` column). When set, it wins over the scraper's detected currency — applied at price-history write time, in notification payloads, and via `COALESCE` in product SELECT queries so it reflects in the UI immediately. New dropdown of supported currencies on the product detail page with an "Auto-detect" default.
- Surface the extraction source: new `extraction_context` column stores the winning candidate's context. Product detail page renders a small "Detected via: Generic CSS (`.price-tag` → \"\$9.99\")" hint under the price. `extractGenericCssCandidates` now includes the matched CSS selector in its context string.
- The modal-confirm flow threads the selected candidate's context to the backend so the hint is populated on initial add. The voting auto-create path persists the winning context the same way.
- Idempotent DB migration adds both columns.

## Test plan

- [ ] Add a product where the scraper picks the wrong currency. Open Notification Settings on the product detail page, set Currency to the correct code, save — the displayed currency updates immediately.
- [ ] Confirm subsequent scrape rows in `price_history` use the override.
- [ ] Confirm the "Detected via: ..." hint shows the method + (for generic CSS) the selector that won.
- [ ] Regression: products without an override keep showing the scraped currency.