### PR TITLE
Add daily update check + in-app banner when a newer release is available

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,13 @@
 # ---------------------------------------------------------------------------
 # FRONTEND_PORT=8080            # change if port 80 is in use
 # POSTGRES_USER=postgres
+
+# ---------------------------------------------------------------------------
+# Update check (default: enabled)
+# ---------------------------------------------------------------------------
+# Once a day the backend queries GitHub for the latest PriceStalker release
+# and, if a newer version is available, shows a dismissible banner to logged-
+# in users. The check is server-side only — your users' browsers never call
+# GitHub. Set the variable below to 'true' to disable the check entirely
+# (recommended for air-gapped deployments).
+# DISABLE_UPDATE_CHECK=true

--- a/README.md
+++ b/README.md
@@ -351,6 +351,25 @@ PriceStalker/
 
 ---
 
+## Update check & privacy
+
+Once a day, the backend queries `api.github.com` for the latest PriceStalker
+release tag. If a newer version is available, logged-in users see a
+dismissible banner with a link to the release notes. The check runs
+server-side only — your users' browsers never contact GitHub.
+
+**What's sent.** A single HTTPS GET to
+`https://api.github.com/repos/mikeknight85/PriceStalker/releases/latest`
+with a `User-Agent: PriceStalker/<version>` header. No data about your
+deployment, users, or products is transmitted. PriceStalker does not run
+any telemetry or analytics — there's no separate phone-home.
+
+**Disable it.** Set `DISABLE_UPDATE_CHECK=true` in `.env` (or as a service
+env var) and the daily check never runs. Useful for air-gapped or
+strict-egress deployments.
+
+---
+
 ## Rate limiting & retailer etiquette
 
 Don't get banned:

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,7 +11,9 @@ import profileRoutes from './routes/profile';
 import adminRoutes from './routes/admin';
 import adminAuthRoutes from './routes/admin-auth';
 import notificationRoutes from './routes/notifications';
+import versionRoutes from './routes/version';
 import { startScheduler } from './services/scheduler';
+import { startUpdateCheckScheduler } from './services/updateCheck';
 import pool from './config/database';
 
 // Run database migrations
@@ -353,6 +355,7 @@ app.use('/api/profile', profileRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/admin/auth', adminAuthRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/version', versionRoutes);
 
 // Error handling middleware
 app.use(
@@ -379,6 +382,7 @@ async function startServer() {
       // Start the background price checker
       if (process.env.NODE_ENV !== 'test') {
         startScheduler();
+        startUpdateCheckScheduler();
       }
     });
   } catch (error) {

--- a/backend/src/routes/version.ts
+++ b/backend/src/routes/version.ts
@@ -1,0 +1,28 @@
+import { Router, Response } from 'express';
+import { AuthRequest, authMiddleware } from '../middleware/auth';
+import { checkForUpdate, getCurrentVersion } from '../services/updateCheck';
+
+const router = Router();
+
+// Authenticated — only logged-in users see what's running and whether an
+// update is available.
+router.get('/check', authMiddleware, async (_req: AuthRequest, res: Response) => {
+  try {
+    const result = await checkForUpdate();
+    res.json(result);
+  } catch (error) {
+    console.error('[Version] check failed:', error);
+    res.status(500).json({
+      current: getCurrentVersion(),
+      latest: null,
+      isOutdated: false,
+      releaseUrl: null,
+      publishedAt: null,
+      checkedAt: new Date().toISOString(),
+      disabled: false,
+      error: 'check failed',
+    });
+  }
+});
+
+export default router;

--- a/backend/src/services/updateCheck.ts
+++ b/backend/src/services/updateCheck.ts
@@ -1,0 +1,129 @@
+import axios from 'axios';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Daily check against GitHub releases for new versions of this fork.
+// Opt-out via DISABLE_UPDATE_CHECK=true. No telemetry — the only outbound
+// request is to api.github.com, and it's only made by the backend (never
+// from the user's browser).
+
+export interface UpdateCheckResult {
+  current: string;
+  latest: string | null;
+  isOutdated: boolean;
+  releaseUrl: string | null;
+  publishedAt: string | null;
+  checkedAt: string;
+  disabled: boolean;
+  error: string | null;
+}
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const RELEASE_API = 'https://api.github.com/repos/mikeknight85/PriceStalker/releases/latest';
+
+let cached: UpdateCheckResult | null = null;
+let lastCheck = 0;
+
+function loadVersion(): string {
+  try {
+    // dist/services/updateCheck.js → ../../package.json
+    const pkgPath = join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const CURRENT_VERSION = loadVersion();
+
+function compareVersions(a: string, b: string): number {
+  const parts = (v: string) => v.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const [a1, a2, a3] = parts(a);
+  const [b1, b2, b3] = parts(b);
+  return (a1 - b1) || (a2 - b2) || (a3 - b3);
+}
+
+async function fetchLatestRelease(): Promise<UpdateCheckResult> {
+  const result: UpdateCheckResult = {
+    current: CURRENT_VERSION,
+    latest: null,
+    isOutdated: false,
+    releaseUrl: null,
+    publishedAt: null,
+    checkedAt: new Date().toISOString(),
+    disabled: false,
+    error: null,
+  };
+
+  try {
+    const response = await axios.get<{
+      tag_name?: string;
+      html_url?: string;
+      published_at?: string;
+    }>(RELEASE_API, {
+      timeout: 10000,
+      headers: { 'User-Agent': `PriceStalker/${CURRENT_VERSION}` },
+    });
+    const tag = response.data?.tag_name;
+    if (!tag) {
+      result.error = 'no tag_name in release response';
+      return result;
+    }
+    result.latest = tag.replace(/^v/, '');
+    result.isOutdated = compareVersions(result.latest, CURRENT_VERSION) > 0;
+    result.releaseUrl = response.data?.html_url ?? null;
+    result.publishedAt = response.data?.published_at ?? null;
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : 'check failed';
+  }
+
+  return result;
+}
+
+export async function checkForUpdate(force = false): Promise<UpdateCheckResult> {
+  if (process.env.DISABLE_UPDATE_CHECK === 'true') {
+    return {
+      current: CURRENT_VERSION,
+      latest: null,
+      isOutdated: false,
+      releaseUrl: null,
+      publishedAt: null,
+      checkedAt: new Date().toISOString(),
+      disabled: true,
+      error: null,
+    };
+  }
+
+  const now = Date.now();
+  if (!force && cached && now - lastCheck < CHECK_INTERVAL_MS) {
+    return cached;
+  }
+
+  cached = await fetchLatestRelease();
+  lastCheck = now;
+  return cached;
+}
+
+export function startUpdateCheckScheduler(): void {
+  if (process.env.DISABLE_UPDATE_CHECK === 'true') {
+    console.log('[UpdateCheck] disabled via DISABLE_UPDATE_CHECK env var');
+    return;
+  }
+
+  // First check 30 s after boot so we don't block startup.
+  setTimeout(() => {
+    checkForUpdate(true).catch(() => {});
+  }, 30_000);
+
+  // Daily refresh thereafter.
+  setInterval(() => {
+    checkForUpdate(true).catch(() => {});
+  }, CHECK_INTERVAL_MS);
+
+  console.log(`[UpdateCheck] scheduled (current version: ${CURRENT_VERSION})`);
+}
+
+export function getCurrentVersion(): string {
+  return CURRENT_VERSION;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -496,4 +496,19 @@ export const adminAuthApi = {
     api.post<DiscoveryTestResult>('/admin/auth/test-discovery', { issuer_url }),
 };
 
+export interface UpdateCheckResult {
+  current: string;
+  latest: string | null;
+  isOutdated: boolean;
+  releaseUrl: string | null;
+  publishedAt: string | null;
+  checkedAt: string;
+  disabled: boolean;
+  error: string | null;
+}
+
+export const versionApi = {
+  check: () => api.get<UpdateCheckResult>('/version/check'),
+};
+
 export default api;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState, useEffect, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import { versionApi, UpdateCheckResult } from '../api/client';
 import NotificationBell from './NotificationBell';
 import ParticleBackground from './ParticleBackground';
 
@@ -21,6 +22,32 @@ export default function Layout({ children }: LayoutProps) {
   });
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const [updateInfo, setUpdateInfo] = useState<UpdateCheckResult | null>(null);
+  const [updateDismissed, setUpdateDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    versionApi
+      .check()
+      .then((res) => {
+        setUpdateInfo(res.data);
+        const dismissedFor = localStorage.getItem('pricestalker_update_dismissed_for');
+        if (res.data.latest && dismissedFor === res.data.latest) {
+          setUpdateDismissed(true);
+        }
+      })
+      .catch(() => {});
+  }, [user]);
+
+  const dismissUpdate = () => {
+    if (updateInfo?.latest) {
+      localStorage.setItem('pricestalker_update_dismissed_for', updateInfo.latest);
+    }
+    setUpdateDismissed(true);
+  };
+
+  const showUpdateBanner =
+    !!user && !updateDismissed && !!updateInfo?.isOutdated && !!updateInfo.latest;
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
@@ -377,6 +404,55 @@ export default function Layout({ children }: LayoutProps) {
           </div>
         </div>
       </nav>
+
+      {showUpdateBanner && updateInfo && (
+        <div
+          style={{
+            background: 'linear-gradient(90deg, rgba(99,102,241,0.12), rgba(99,102,241,0.04))',
+            borderBottom: '1px solid var(--border)',
+            padding: '0.6rem 1rem',
+            fontSize: '0.875rem',
+            color: 'var(--text)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <span>🎉</span>
+          <span>
+            PriceStalker <strong>v{updateInfo.latest}</strong> is available
+            {updateInfo.current && ` (you're on v${updateInfo.current})`}.
+          </span>
+          {updateInfo.releaseUrl && (
+            <a
+              href={updateInfo.releaseUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'var(--primary)', textDecoration: 'underline' }}
+            >
+              Release notes →
+            </a>
+          )}
+          <button
+            onClick={dismissUpdate}
+            aria-label="Dismiss update notification"
+            style={{
+              background: 'transparent',
+              border: '1px solid var(--border)',
+              borderRadius: '0.375rem',
+              padding: '0.15rem 0.5rem',
+              fontSize: '0.75rem',
+              color: 'var(--text-muted)',
+              cursor: 'pointer',
+              marginLeft: '0.5rem',
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       <main className="main-content">
         <div className="main-content-inner">{children}</div>


### PR DESCRIPTION
The backend queries GitHub releases once a day. When a newer version is available, logged-in users see a dismissible banner with a link to the release notes. Per-version dismissal via localStorage so a new release re-surfaces it.

No telemetry — the only outbound request is a single HTTPS GET to `api.github.com/repos/.../releases/latest` from the backend (never from the user's browser). `DISABLE_UPDATE_CHECK=true` opts out entirely.

Branch name has `-and-telemetry` because the original scope included a Plausible event; we decided to skip telemetry. Code on the branch reflects the no-telemetry decision.

## Test plan

- [ ] Run a stale-version backend (e.g. set package.json version to 0.0.1 and run dev). Banner appears within ~30 s of login with a link to the latest GitHub release. Dismiss persists across reload.
- [ ] Run a current-version backend. No banner.
- [ ] `DISABLE_UPDATE_CHECK=true` → no GitHub call (verify via network or backend logs), no banner ever.
- [ ] `GET /api/version/check` returns the expected JSON shape.
- [ ] First call within 24h is cached (second call returns the same `checkedAt` timestamp).