### PR TITLE
Fix: self-heal missing product images + better lazy-load handling

### DIFF
--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -717,6 +717,10 @@ export const productQueries = {
     );
   },
 
+  updateImageUrl: async (id: number, imageUrl: string): Promise<void> => {
+    await pool.query('UPDATE products SET image_url = $1 WHERE id = $2', [imageUrl, id]);
+  },
+
   getPreferredExtractionMethod: async (id: number): Promise<string | null> => {
     const result = await pool.query(
       'SELECT preferred_extraction_method FROM products WHERE id = $1',

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -49,6 +49,15 @@ async function checkPrices(): Promise<void> {
 
         console.log(`[Scheduler] Product ${product.id} - scraped price: ${scrapedData.price?.price}, candidates: ${scrapedData.priceCandidates.map(c => `${c.price}(${c.method})`).join(', ')}`);
 
+        // Self-heal missing product images. image_url is only written at
+        // create-time, so if the first scrape missed the picture (Puppeteer
+        // timing on a JS-heavy SPA, lazy-load, transient error), it stays
+        // NULL forever. Back-fill on the next successful scrape.
+        if (!product.image_url && scrapedData.imageUrl) {
+          await productQueries.updateImageUrl(product.id, scrapedData.imageUrl);
+          console.log(`[Scheduler] Backfilled image for product ${product.id}: ${scrapedData.imageUrl}`);
+        }
+
         // Check for back-in-stock notification
         const wasOutOfStock = product.stock_status === 'out_of_stock';
         const nowInStock = scrapedData.stockStatus === 'in_stock';

--- a/backend/src/services/scraper.ts
+++ b/backend/src/services/scraper.ts
@@ -2069,14 +2069,30 @@ function extractGenericName($: CheerioAPI): string | null {
 }
 
 function extractGenericImage($: CheerioAPI, baseUrl: string): string | null {
+  // Pull the first URL out of a srcset value (`url1 1x, url2 2x` or
+  // `url1 480w, url2 800w` — both forms are common).
+  const firstFromSrcset = (srcset: string | undefined): string | undefined => {
+    if (!srcset) return undefined;
+    const first = srcset.split(',')[0]?.trim().split(/\s+/)[0];
+    return first || undefined;
+  };
+
   for (const selector of genericImageSelectors) {
     const element = $(selector).first();
     if (element.length) {
+      // Try the common patterns plus several lazy-load conventions.
+      // Order matters — explicit lazy attrs first, then fall back to plain
+      // `src` (which on some SPAs is a 1×1 placeholder before hydration).
       const src =
-        element.attr('src') ||
         element.attr('content') ||
         element.attr('data-zoom-image') ||
-        element.attr('data-src');
+        element.attr('data-src') ||
+        element.attr('data-original') ||
+        element.attr('data-lazy') ||
+        element.attr('data-lazy-src') ||
+        firstFromSrcset(element.attr('data-srcset')) ||
+        firstFromSrcset(element.attr('srcset')) ||
+        element.attr('src');
       if (src) {
         try {
           return new URL(src, baseUrl).href;


### PR DESCRIPTION
image_url was only written at create-time, so a first-scrape miss became permanent. JS-heavy SPAs (digitec.ch React app via Puppeteer) hit this when render timing varies.

- Scheduler now backfills image_url whenever the current value is null and the scrape produced one. Existing broken products self-heal on the next scheduled check.
- extractGenericImage adds data-original, data-lazy, data-lazy-src, data-srcset, srcset to the lookup. Picks the first URL out of srcset values.

## Test plan

- [ ] Manually clear image_url for a product, wait for the next scheduler tick, confirm it gets backfilled.
- [ ] Regression: products that already had an image are not changed.