### PR TITLE
Fix: manual refresh now also backfills missing image_url

### DIFF
--- a/backend/src/routes/prices.ts
+++ b/backend/src/routes/prices.ts
@@ -84,6 +84,13 @@ router.post('/:productId/refresh', async (req: AuthRequest, res: Response) => {
       await stockStatusHistoryQueries.recordChange(productId, scrapedData.stockStatus);
     }
 
+    // Self-heal missing product images (parity with the scheduler — see
+    // scheduler.ts; image_url is only written at create-time, so a manual
+    // refresh should also rescue products that missed the picture on add).
+    if (!product.image_url && scrapedData.imageUrl) {
+      await productQueries.updateImageUrl(productId, scrapedData.imageUrl);
+    }
+
     // Record new price if available
     let newPrice = null;
     if (scrapedData.price) {


### PR DESCRIPTION
Parity with the scheduler's image self-heal added in v1.2.9. The manual 'Refresh Price now' button hits a separate code path that wasn't updated. Three-line fix.

## Test plan

- [ ] Clear a product's image_url in the DB, hit 'Refresh Price now' in the UI, confirm the image populates immediately.