### PR TITLE
Fix: wire JSON-LD image into voting path + overwrite bogus image_url

### DIFF
--- a/backend/src/routes/prices.ts
+++ b/backend/src/routes/prices.ts
@@ -84,10 +84,10 @@ router.post('/:productId/refresh', async (req: AuthRequest, res: Response) => {
       await stockStatusHistoryQueries.recordChange(productId, scrapedData.stockStatus);
     }
 
-    // Self-heal missing product images (parity with the scheduler — see
-    // scheduler.ts; image_url is only written at create-time, so a manual
-    // refresh should also rescue products that missed the picture on add).
-    if (!product.image_url && scrapedData.imageUrl) {
+    // Self-heal product images on every manual refresh — parity with the
+    // scheduler. Updates whenever the scrape returned a different non-null
+    // URL, so previously-stored bogus URLs get replaced (not just nulls).
+    if (scrapedData.imageUrl && scrapedData.imageUrl !== product.image_url) {
       await productQueries.updateImageUrl(productId, scrapedData.imageUrl);
     }
 

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -49,13 +49,15 @@ async function checkPrices(): Promise<void> {
 
         console.log(`[Scheduler] Product ${product.id} - scraped price: ${scrapedData.price?.price}, candidates: ${scrapedData.priceCandidates.map(c => `${c.price}(${c.method})`).join(', ')}`);
 
-        // Self-heal missing product images. image_url is only written at
-        // create-time, so if the first scrape missed the picture (Puppeteer
-        // timing on a JS-heavy SPA, lazy-load, transient error), it stays
-        // NULL forever. Back-fill on the next successful scrape.
-        if (!product.image_url && scrapedData.imageUrl) {
+        // Self-heal product images. image_url used to only be written at
+        // create-time; we now also update whenever a scrape returns a
+        // different non-null URL. Covers (a) first-scrape misses, (b)
+        // recovery from previously-stored bogus URLs (e.g. when an earlier
+        // scrape picked up a recommendation card's image), and (c)
+        // legitimate retailer image swaps.
+        if (scrapedData.imageUrl && scrapedData.imageUrl !== product.image_url) {
           await productQueries.updateImageUrl(product.id, scrapedData.imageUrl);
-          console.log(`[Scheduler] Backfilled image for product ${product.id}: ${scrapedData.imageUrl}`);
+          console.log(`[Scheduler] Updated image for product ${product.id}: ${scrapedData.imageUrl}`);
         }
 
         // Check for back-in-stock notification

--- a/backend/src/services/scraper.ts
+++ b/backend/src/services/scraper.ts
@@ -1479,7 +1479,12 @@ export async function scrapeProductWithVoting(
     allCandidates.push(...jsonLdCandidates);
     const jsonLdData = extractJsonLd($);
     if (jsonLdData?.stockStatus) result.stockStatus = jsonLdData.stockStatus;
-    console.log(`[Voting] JSON-LD found ${jsonLdCandidates.length} candidates, stock=${jsonLdData?.stockStatus ?? 'n/a'}`);
+    // Prefer JSON-LD's Product.image because it's type-aware — findProduct()
+    // walks the page's JSON-LD blocks looking specifically for the Product
+    // type, so it won't accidentally pick up a recommendation card's image
+    // the way the generic img-tag scan does.
+    if (jsonLdData?.image) result.imageUrl = jsonLdData.image;
+    console.log(`[Voting] JSON-LD found ${jsonLdCandidates.length} candidates, stock=${jsonLdData?.stockStatus ?? 'n/a'}, image=${jsonLdData?.image ? 'yes' : 'no'}`);
 
     // 2. Site-specific extraction
     const siteResult = extractSiteSpecificCandidates($, url);
@@ -1531,6 +1536,9 @@ export async function scrapeProductWithVoting(
         const browserJsonLdData = extractJsonLd($);
         if (result.stockStatus === 'unknown' && browserJsonLdData?.stockStatus) {
           result.stockStatus = browserJsonLdData.stockStatus;
+        }
+        if (!result.imageUrl && browserJsonLdData?.image) {
+          result.imageUrl = browserJsonLdData.image;
         }
         const browserSiteResult = extractSiteSpecificCandidates($, url);
         allCandidates.push(...browserSiteResult.candidates);


### PR DESCRIPTION
Bogus image URLs persist permanently on digitec/SPA products because (1) the voting scraper ignores JSON-LD's Product.image field and falls back to a generic img scan that picks recommendation cards, and (2) the self-heal only triggers when image_url IS NULL. Together: wrong picture in, wrong picture forever.

Wire JSON-LD image into the voting path (mirrors the stock-status fix from v1.2.6) and loosen the backfill to overwrite when the scrape produces a different non-null URL.

## Test plan

- [ ] After deploy, hit 'Refresh Price now' on a product currently showing a wrong/missing image. Verify the URL changes and the new image renders.
- [ ] Verify the new URL points at the actual product (UUID matches what's on the retailer site).