### PR TITLE
CI: add :beta channel for pre-release testing

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,7 +78,8 @@ jobs:
             type=sha,prefix=
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=beta,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Backend image
         uses: docker/build-push-action@v7
@@ -127,7 +128,8 @@ jobs:
             type=sha,prefix=
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=beta,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Frontend image
         uses: docker/build-push-action@v7

--- a/README.md
+++ b/README.md
@@ -177,17 +177,22 @@ automatically on first boot.
 
 See [.env.example](.env.example) for all available overrides.
 
-### Pinning to a specific version
+### Image channels
 
-`ghcr.io/mikeknight85/pricestalker-backend:latest` tracks main. Pin to a
-specific release for stability:
+Three rolling tags are published, in order of stability:
+
+| Tag | When it updates | Use for |
+|-----|-----------------|---------|
+| `:latest` | Every tagged release (`vX.Y.Z`) | Production. Sticks until the next release. |
+| `:1.2` | Same as `:latest`, but only within the 1.2.x line | Production with auto-patch but no minor bumps. |
+| `:beta` | Every merge to `main` | Pre-release / staging instances. May break. |
+
+Pin to an immutable version for absolute stability:
 
 ```yaml
-image: ghcr.io/mikeknight85/pricestalker-backend:1.1.2
-image: ghcr.io/mikeknight85/pricestalker-frontend:1.1.2
+image: ghcr.io/mikeknight85/pricestalker-backend:1.2.11
+image: ghcr.io/mikeknight85/pricestalker-frontend:1.2.11
 ```
-
-Major.minor tags (e.g. `:1.1`) also auto-move to the latest patch in that line.
 
 ---
 


### PR DESCRIPTION
Adds a `:beta` tag that tracks every merge to main, and restricts `:latest` to tagged releases only.

Concretely: test/demo stacks pin to `:beta` and auto-roll on every PR merge; prod stacks pin to `:latest` (or a major.minor like `:1.2`) and only roll when a new `vX.Y.Z` tag is cut.

No app code changes; CI + docs only. No version bump.