### PR TITLE
Add configurable generic webhook notification provider (#4)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -142,6 +142,24 @@ async function runMigrations() {
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'gotify_enabled') THEN
           ALTER TABLE users ADD COLUMN gotify_enabled BOOLEAN DEFAULT true;
         END IF;
+        -- Generic configurable webhook (issue #4) — URL/method/headers/body
+        -- template let users route notifications to anything (Apprise, Home
+        -- Assistant, Zapier, custom services, etc.).
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'webhook_url') THEN
+          ALTER TABLE users ADD COLUMN webhook_url TEXT;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'webhook_method') THEN
+          ALTER TABLE users ADD COLUMN webhook_method VARCHAR(10) DEFAULT 'POST';
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'webhook_headers') THEN
+          ALTER TABLE users ADD COLUMN webhook_headers TEXT;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'webhook_body_template') THEN
+          ALTER TABLE users ADD COLUMN webhook_body_template TEXT;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'webhook_enabled') THEN
+          ALTER TABLE users ADD COLUMN webhook_enabled BOOLEAN DEFAULT true;
+        END IF;
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'ai_verification_enabled') THEN
           ALTER TABLE users ADD COLUMN ai_verification_enabled BOOLEAN DEFAULT false;
         END IF;

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -43,6 +43,11 @@ export interface NotificationSettings {
   gotify_url: string | null;
   gotify_app_token: string | null;
   gotify_enabled: boolean;
+  webhook_url: string | null;
+  webhook_method: string | null;
+  webhook_headers: string | null;
+  webhook_body_template: string | null;
+  webhook_enabled: boolean;
 }
 
 export interface AISettings {
@@ -140,7 +145,9 @@ export const userQueries = {
               discord_webhook_url, COALESCE(discord_enabled, true) as discord_enabled,
               pushover_user_key, pushover_app_token, COALESCE(pushover_enabled, true) as pushover_enabled,
               ntfy_topic, ntfy_server_url, ntfy_username, ntfy_password, COALESCE(ntfy_enabled, true) as ntfy_enabled,
-              gotify_url, gotify_app_token, COALESCE(gotify_enabled, true) as gotify_enabled
+              gotify_url, gotify_app_token, COALESCE(gotify_enabled, true) as gotify_enabled,
+              webhook_url, COALESCE(webhook_method, 'POST') as webhook_method,
+              webhook_headers, webhook_body_template, COALESCE(webhook_enabled, true) as webhook_enabled
        FROM users WHERE id = $1`,
       [id]
     );
@@ -219,6 +226,26 @@ export const userQueries = {
       fields.push(`gotify_enabled = $${paramIndex++}`);
       values.push(settings.gotify_enabled);
     }
+    if (settings.webhook_url !== undefined) {
+      fields.push(`webhook_url = $${paramIndex++}`);
+      values.push(settings.webhook_url);
+    }
+    if (settings.webhook_method !== undefined) {
+      fields.push(`webhook_method = $${paramIndex++}`);
+      values.push(settings.webhook_method);
+    }
+    if (settings.webhook_headers !== undefined) {
+      fields.push(`webhook_headers = $${paramIndex++}`);
+      values.push(settings.webhook_headers);
+    }
+    if (settings.webhook_body_template !== undefined) {
+      fields.push(`webhook_body_template = $${paramIndex++}`);
+      values.push(settings.webhook_body_template);
+    }
+    if (settings.webhook_enabled !== undefined) {
+      fields.push(`webhook_enabled = $${paramIndex++}`);
+      values.push(settings.webhook_enabled);
+    }
 
     if (fields.length === 0) return null;
 
@@ -229,7 +256,9 @@ export const userQueries = {
                  discord_webhook_url, COALESCE(discord_enabled, true) as discord_enabled,
                  pushover_user_key, pushover_app_token, COALESCE(pushover_enabled, true) as pushover_enabled,
                  ntfy_topic, ntfy_server_url, ntfy_username, ntfy_password, COALESCE(ntfy_enabled, true) as ntfy_enabled,
-                 gotify_url, gotify_app_token, COALESCE(gotify_enabled, true) as gotify_enabled`,
+                 gotify_url, gotify_app_token, COALESCE(gotify_enabled, true) as gotify_enabled,
+                 webhook_url, COALESCE(webhook_method, 'POST') as webhook_method,
+                 webhook_headers, webhook_body_template, COALESCE(webhook_enabled, true) as webhook_enabled`,
       values
     );
     return result.rows[0] || null;

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -35,6 +35,11 @@ router.get('/notifications', async (req: AuthRequest, res: Response) => {
       gotify_url: settings.gotify_url || null,
       gotify_app_token: settings.gotify_app_token || null,
       gotify_enabled: settings.gotify_enabled ?? true,
+      webhook_url: settings.webhook_url || null,
+      webhook_method: settings.webhook_method || 'POST',
+      webhook_headers: settings.webhook_headers || null,
+      webhook_body_template: settings.webhook_body_template || null,
+      webhook_enabled: settings.webhook_enabled ?? true,
     });
   } catch (error) {
     console.error('Error fetching notification settings:', error);
@@ -63,7 +68,38 @@ router.put('/notifications', async (req: AuthRequest, res: Response) => {
       gotify_url,
       gotify_app_token,
       gotify_enabled,
+      webhook_url,
+      webhook_method,
+      webhook_headers,
+      webhook_body_template,
+      webhook_enabled,
     } = req.body;
+
+    // Validate webhook_headers is a parseable JSON object when provided.
+    if (
+      typeof webhook_headers === 'string' &&
+      webhook_headers.trim().length > 0
+    ) {
+      try {
+        const parsed = JSON.parse(webhook_headers);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          res.status(400).json({ error: 'webhook_headers must be a JSON object' });
+          return;
+        }
+      } catch {
+        res.status(400).json({ error: 'webhook_headers is not valid JSON' });
+        return;
+      }
+    }
+
+    // Validate method is one of the supported verbs.
+    if (typeof webhook_method === 'string' && webhook_method.length > 0) {
+      const allowed = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+      if (!allowed.includes(webhook_method.toUpperCase())) {
+        res.status(400).json({ error: `webhook_method must be one of ${allowed.join(', ')}` });
+        return;
+      }
+    }
 
     const settings = await userQueries.updateNotificationSettings(userId, {
       telegram_bot_token,
@@ -82,6 +118,11 @@ router.put('/notifications', async (req: AuthRequest, res: Response) => {
       gotify_url,
       gotify_app_token,
       gotify_enabled,
+      webhook_url,
+      webhook_method: webhook_method ? webhook_method.toUpperCase() : undefined,
+      webhook_headers,
+      webhook_body_template,
+      webhook_enabled,
     });
 
     if (!settings) {
@@ -106,6 +147,11 @@ router.put('/notifications', async (req: AuthRequest, res: Response) => {
       gotify_url: settings.gotify_url || null,
       gotify_app_token: settings.gotify_app_token || null,
       gotify_enabled: settings.gotify_enabled ?? true,
+      webhook_url: settings.webhook_url || null,
+      webhook_method: settings.webhook_method || 'POST',
+      webhook_headers: settings.webhook_headers || null,
+      webhook_body_template: settings.webhook_body_template || null,
+      webhook_enabled: settings.webhook_enabled ?? true,
       message: 'Notification settings updated successfully',
     });
   } catch (error) {
@@ -628,6 +674,45 @@ router.post('/ai/test-openrouter', async (req: AuthRequest, res: Response) => {
         success: false,
       });
     }
+  }
+});
+
+// Test generic webhook — fires the saved template against a stub payload
+router.post('/notifications/test/webhook', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId!;
+    const settings = await userQueries.getNotificationSettings(userId);
+
+    if (!settings?.webhook_url) {
+      res.status(400).json({ error: 'Webhook not configured' });
+      return;
+    }
+
+    const { sendWebhookNotification } = await import('../services/notifications');
+    const success = await sendWebhookNotification(
+      settings.webhook_url,
+      settings.webhook_method || 'POST',
+      settings.webhook_headers,
+      settings.webhook_body_template,
+      {
+        productName: 'Test Product',
+        productUrl: 'https://example.com/product',
+        type: 'price_drop',
+        oldPrice: 29.99,
+        newPrice: 19.99,
+        currency: 'USD',
+        threshold: 10,
+      }
+    );
+
+    if (success) {
+      res.json({ message: 'Test webhook fired successfully' });
+    } else {
+      res.status(502).json({ error: 'Webhook target returned a non-2xx status or was unreachable' });
+    }
+  } catch (error) {
+    console.error('Error testing webhook:', error);
+    res.status(500).json({ error: 'Failed to fire test webhook' });
   }
 });
 

--- a/backend/src/services/notifications.ts
+++ b/backend/src/services/notifications.ts
@@ -381,6 +381,92 @@ export async function testGotifyConnection(
   }
 }
 
+// Render a webhook body template by substituting {placeholder} tokens.
+// Available tokens: {title} {type} {url} {currency} {price} {new_price}
+// {old_price} {threshold} {target_price} {timestamp}. Missing values
+// resolve to empty strings rather than literal "undefined" so a JSON
+// template stays parseable.
+export function renderWebhookTemplate(
+  template: string,
+  payload: NotificationPayload,
+  timestampIso: string
+): string {
+  const v = {
+    title: payload.productName ?? '',
+    type: payload.type ?? '',
+    url: payload.productUrl ?? '',
+    currency: payload.currency ?? '',
+    price: payload.newPrice !== undefined ? String(payload.newPrice) : '',
+    new_price: payload.newPrice !== undefined ? String(payload.newPrice) : '',
+    old_price: payload.oldPrice !== undefined ? String(payload.oldPrice) : '',
+    threshold: payload.threshold !== undefined ? String(payload.threshold) : '',
+    target_price: payload.targetPrice !== undefined ? String(payload.targetPrice) : '',
+    timestamp: timestampIso,
+  };
+  return template.replace(/\{(\w+)\}/g, (_, key) =>
+    key in v ? (v as Record<string, string>)[key] : ''
+  );
+}
+
+export const DEFAULT_WEBHOOK_BODY_TEMPLATE =
+  '{"title":"{title}","type":"{type}","url":"{url}","price":"{price}","old_price":"{old_price}","currency":"{currency}","timestamp":"{timestamp}"}';
+
+export async function sendWebhookNotification(
+  webhookUrl: string,
+  method: string,
+  headersJson: string | null,
+  bodyTemplate: string | null,
+  payload: NotificationPayload
+): Promise<boolean> {
+  try {
+    const verb = (method || 'POST').toUpperCase();
+    const template = bodyTemplate && bodyTemplate.trim().length > 0
+      ? bodyTemplate
+      : DEFAULT_WEBHOOK_BODY_TEMPLATE;
+    const body = renderWebhookTemplate(template, payload, new Date().toISOString());
+
+    let parsedHeaders: Record<string, string> = {};
+    if (headersJson && headersJson.trim().length > 0) {
+      try {
+        const obj = JSON.parse(headersJson);
+        if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+          for (const [k, val] of Object.entries(obj)) {
+            if (typeof val === 'string') parsedHeaders[k] = val;
+          }
+        }
+      } catch {
+        console.error('[Webhook] Invalid headers JSON, sending without custom headers');
+        parsedHeaders = {};
+      }
+    }
+
+    // Default Content-Type only if the caller didn't set one — body templates
+    // are JSON by default but users might POST form-encoded or anything else.
+    const hasContentType = Object.keys(parsedHeaders).some((k) => k.toLowerCase() === 'content-type');
+    if (!hasContentType && verb !== 'GET') {
+      parsedHeaders['Content-Type'] = 'application/json';
+    }
+
+    const config = {
+      method: verb,
+      url: webhookUrl,
+      headers: parsedHeaders,
+      timeout: 15000,
+      // GET requests don't carry a body — most webhook receivers expect a
+      // pure URL trigger. Body templates only apply to non-GET verbs.
+      ...(verb === 'GET' ? {} : { data: body }),
+      validateStatus: (s: number) => s >= 200 && s < 300,
+    };
+
+    await axios(config);
+    console.log(`Webhook notification sent (${verb} ${webhookUrl})`);
+    return true;
+  } catch (error) {
+    console.error('Failed to send webhook notification:', error);
+    return false;
+  }
+}
+
 export interface NotificationResult {
   channelsNotified: string[];
   channelsFailed: string[];
@@ -404,6 +490,11 @@ export async function sendNotifications(
     gotify_url: string | null;
     gotify_app_token: string | null;
     gotify_enabled?: boolean;
+    webhook_url?: string | null;
+    webhook_method?: string | null;
+    webhook_headers?: string | null;
+    webhook_body_template?: string | null;
+    webhook_enabled?: boolean;
   },
   payload: NotificationPayload
 ): Promise<NotificationResult> {
@@ -448,6 +539,19 @@ export async function sendNotifications(
     channelPromises.push({
       channel: 'gotify',
       promise: sendGotifyNotification(settings.gotify_url, settings.gotify_app_token, payload),
+    });
+  }
+
+  if (settings.webhook_url && settings.webhook_enabled !== false) {
+    channelPromises.push({
+      channel: 'webhook',
+      promise: sendWebhookNotification(
+        settings.webhook_url,
+        settings.webhook_method || 'POST',
+        settings.webhook_headers ?? null,
+        settings.webhook_body_template ?? null,
+        payload
+      ),
     });
   }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -231,6 +231,11 @@ export interface NotificationSettings {
   gotify_url: string | null;
   gotify_app_token: string | null;
   gotify_enabled: boolean;
+  webhook_url: string | null;
+  webhook_method: string;
+  webhook_headers: string | null;
+  webhook_body_template: string | null;
+  webhook_enabled: boolean;
 }
 
 export const settingsApi = {
@@ -254,6 +259,11 @@ export const settingsApi = {
     gotify_url?: string | null;
     gotify_app_token?: string | null;
     gotify_enabled?: boolean;
+    webhook_url?: string | null;
+    webhook_method?: string;
+    webhook_headers?: string | null;
+    webhook_body_template?: string | null;
+    webhook_enabled?: boolean;
   }) => api.put<NotificationSettings & { message: string }>('/settings/notifications', data),
 
   testTelegram: () =>
@@ -276,6 +286,9 @@ export const settingsApi = {
 
   testGotify: () =>
     api.post<{ message: string }>('/settings/notifications/test/gotify'),
+
+  testWebhook: () =>
+    api.post<{ message: string }>('/settings/notifications/test/webhook'),
 
   // AI Settings
   getAI: () =>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -70,8 +70,13 @@ export default function Settings() {
   const [gotifyAppToken, setGotifyAppToken] = useState('');
   const [gotifyEnabled, setGotifyEnabled] = useState(true);
   const [isTestingGotify, setIsTestingGotify] = useState(false);
+  const [webhookUrl, setWebhookUrl] = useState('');
+  const [webhookMethod, setWebhookMethod] = useState('POST');
+  const [webhookHeaders, setWebhookHeaders] = useState('');
+  const [webhookBodyTemplate, setWebhookBodyTemplate] = useState('');
+  const [webhookEnabled, setWebhookEnabled] = useState(true);
   const [isSavingNotifications, setIsSavingNotifications] = useState(false);
-  const [isTesting, setIsTesting] = useState<'telegram' | 'discord' | 'pushover' | 'ntfy' | 'gotify' | null>(null);
+  const [isTesting, setIsTesting] = useState<'telegram' | 'discord' | 'pushover' | 'ntfy' | 'gotify' | 'webhook' | null>(null);
 
   // AI state
   const [aiSettings, setAISettings] = useState<AISettings | null>(null);
@@ -164,6 +169,11 @@ export default function Settings() {
       setGotifyUrl(notificationsRes.data.gotify_url || '');
       setGotifyAppToken(notificationsRes.data.gotify_app_token || '');
       setGotifyEnabled(notificationsRes.data.gotify_enabled ?? true);
+      setWebhookUrl(notificationsRes.data.webhook_url || '');
+      setWebhookMethod(notificationsRes.data.webhook_method || 'POST');
+      setWebhookHeaders(notificationsRes.data.webhook_headers || '');
+      setWebhookBodyTemplate(notificationsRes.data.webhook_body_template || '');
+      setWebhookEnabled(notificationsRes.data.webhook_enabled ?? true);
       // Populate AI fields with actual values
       setAISettings(aiRes.data);
       setAIEnabled(aiRes.data.ai_enabled);
@@ -567,6 +577,54 @@ export default function Settings() {
     } catch {
       setGotifyEnabled(!enabled);
       setError('Failed to update Gotify status');
+    }
+  };
+
+  // Webhook handlers
+  const handleSaveWebhook = async () => {
+    clearMessages();
+    setIsSavingNotifications(true);
+    try {
+      const response = await settingsApi.updateNotifications({
+        webhook_url: webhookUrl || null,
+        webhook_method: webhookMethod,
+        webhook_headers: webhookHeaders.trim() || null,
+        webhook_body_template: webhookBodyTemplate.trim() || null,
+      });
+      setNotificationSettings(response.data);
+      setSuccess('Webhook settings saved successfully');
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const axiosError = err as any;
+      setError(axiosError?.response?.data?.error || 'Failed to save webhook settings');
+    } finally {
+      setIsSavingNotifications(false);
+    }
+  };
+
+  const handleTestWebhook = async () => {
+    clearMessages();
+    setIsTesting('webhook');
+    try {
+      await settingsApi.testWebhook();
+      setSuccess('Webhook fired successfully — check the receiving service');
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const axiosError = err as any;
+      setError(axiosError?.response?.data?.error || 'Webhook test failed');
+    } finally {
+      setIsTesting(null);
+    }
+  };
+
+  const handleToggleWebhook = async (enabled: boolean) => {
+    setWebhookEnabled(enabled);
+    try {
+      const response = await settingsApi.updateNotifications({ webhook_enabled: enabled });
+      setNotificationSettings(response.data);
+    } catch {
+      setWebhookEnabled(!enabled);
+      setError('Failed to update webhook status');
     }
   };
 
@@ -1729,6 +1787,119 @@ export default function Settings() {
                       disabled={isTesting === 'gotify'}
                     >
                       {isTesting === 'gotify' ? 'Sending...' : 'Send Test'}
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div className="settings-section">
+                <div className="settings-section-header">
+                  <span className="settings-section-icon">🪝</span>
+                  <h2 className="settings-section-title">Custom Webhook</h2>
+                  <span className={`settings-section-status ${notificationSettings?.webhook_url ? 'configured' : 'not-configured'}`}>
+                    {notificationSettings?.webhook_url ? 'Configured' : 'Not Configured'}
+                  </span>
+                </div>
+                <p className="settings-section-description">
+                  Route notifications to any HTTP endpoint — Apprise, Home Assistant, n8n, Zapier,
+                  a custom backend, anything that speaks HTTP. Configure the URL, method, optional
+                  headers (JSON), and a body template with placeholders. Available placeholders:
+                  {' '}<code>{'{title}'}</code>, <code>{'{type}'}</code>, <code>{'{url}'}</code>,
+                  {' '}<code>{'{currency}'}</code>, <code>{'{price}'}</code>,
+                  {' '}<code>{'{new_price}'}</code>, <code>{'{old_price}'}</code>,
+                  {' '}<code>{'{threshold}'}</code>, <code>{'{target_price}'}</code>,
+                  {' '}<code>{'{timestamp}'}</code>.
+                </p>
+
+                <div className="settings-toggle">
+                  <div className="settings-toggle-label">
+                    <span className="settings-toggle-title">Enable Webhook Notifications</span>
+                    <span className="settings-toggle-description">
+                      Toggle to enable or disable the custom webhook
+                    </span>
+                  </div>
+                  <button
+                    className={`toggle-switch ${webhookEnabled ? 'active' : ''}`}
+                    onClick={() => handleToggleWebhook(!webhookEnabled)}
+                    aria-label="Toggle Webhook"
+                    type="button"
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="webhook-url">Webhook URL</label>
+                  <input
+                    id="webhook-url"
+                    type="url"
+                    value={webhookUrl}
+                    onChange={(e) => setWebhookUrl(e.target.value)}
+                    placeholder="https://example.com/webhook"
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="webhook-method">HTTP Method</label>
+                  <select
+                    id="webhook-method"
+                    value={webhookMethod}
+                    onChange={(e) => setWebhookMethod(e.target.value)}
+                  >
+                    <option value="POST">POST</option>
+                    <option value="PUT">PUT</option>
+                    <option value="PATCH">PATCH</option>
+                    <option value="GET">GET</option>
+                    <option value="DELETE">DELETE</option>
+                  </select>
+                  <p className="hint">GET requests don't include a body — useful for trigger URLs.</p>
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="webhook-headers">Headers (JSON object)</label>
+                  <textarea
+                    id="webhook-headers"
+                    value={webhookHeaders}
+                    onChange={(e) => setWebhookHeaders(e.target.value)}
+                    placeholder={'{\n  "Authorization": "Bearer xxx",\n  "X-Source": "PriceStalker"\n}'}
+                    rows={4}
+                    style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                  />
+                  <p className="hint">
+                    Optional. JSON object of header name → string value. Content-Type defaults to
+                    {' '}<code>application/json</code> for non-GET if not set.
+                  </p>
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="webhook-body">Body Template</label>
+                  <textarea
+                    id="webhook-body"
+                    value={webhookBodyTemplate}
+                    onChange={(e) => setWebhookBodyTemplate(e.target.value)}
+                    placeholder={'{"title":"{title}","price":"{price} {currency}","url":"{url}","type":"{type}"}'}
+                    rows={6}
+                    style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                  />
+                  <p className="hint">
+                    Optional. Leave blank to use a sensible JSON default. Tokens like
+                    {' '}<code>{'{title}'}</code> are substituted at send time.
+                  </p>
+                </div>
+
+                <div className="settings-form-actions">
+                  <button
+                    className="btn btn-primary"
+                    onClick={handleSaveWebhook}
+                    disabled={isSavingNotifications}
+                  >
+                    {isSavingNotifications ? 'Saving...' : 'Save Webhook Settings'}
+                  </button>
+                  {notificationSettings?.webhook_url && (
+                    <button
+                      className="btn btn-secondary"
+                      onClick={handleTestWebhook}
+                      disabled={isTesting === 'webhook'}
+                    >
+                      {isTesting === 'webhook' ? 'Sending...' : 'Send Test'}
                     </button>
                   )}
                 </div>


### PR DESCRIPTION
Closes #4. Adds a 'Custom Webhook' provider that routes notifications to any HTTP endpoint (Apprise, Home Assistant, n8n, Zapier, custom services).

Users configure URL, method (GET/POST/PUT/PATCH/DELETE), optional headers (JSON object), and a body template with placeholders:
`{title}`, `{type}`, `{url}`, `{currency}`, `{price}`, `{new_price}`, `{old_price}`, `{threshold}`, `{target_price}`, `{timestamp}`.

Sensible defaults: blank template uses a reasonable JSON shape; Content-Type defaults to application/json for non-GET; GET requests omit the body.

Idempotent DB migration; no breaking changes.

## Test plan

- [ ] Save a webhook config with a test URL (webhook.site or similar). Verify the PUT response includes the saved fields.
- [ ] Click 'Send Test' — confirm the test receiver gets a POST with the template substituted (Test Product, $19.99, etc.).
- [ ] Trigger a real notification (price drop / target / restock / any-change). Confirm the webhook fires alongside any other configured providers.
- [ ] Invalid headers JSON → 400 on save with the validation error surfaced.
- [ ] Unsupported HTTP method → 400 on save.
- [ ] Disable toggle stops the webhook firing while leaving other providers untouched.