### PR TITLE
Add BETA pill to Settings sidebar for :beta channel builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -89,6 +89,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CHANNEL=${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'beta' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -139,5 +141,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CHANNEL=${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'beta' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,6 +50,12 @@ RUN apt-get update && apt-get install -y \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
+# Distribution channel — set by the CI workflow at build time. `stable` for
+# tag-built images (vX.Y.Z), `beta` for main-branch builds. Surfaced via
+# /api/version/check so the frontend can render a BETA pill.
+ARG CHANNEL=stable
+ENV PRICESTALKER_CHANNEL=$CHANNEL
+
 # Copy package files
 COPY package*.json ./
 

--- a/backend/src/routes/version.ts
+++ b/backend/src/routes/version.ts
@@ -21,6 +21,7 @@ router.get('/check', authMiddleware, async (_req: AuthRequest, res: Response) =>
       checkedAt: new Date().toISOString(),
       disabled: false,
       error: 'check failed',
+      channel: process.env.PRICESTALKER_CHANNEL === 'beta' ? 'beta' : 'stable',
     });
   }
 });

--- a/backend/src/services/updateCheck.ts
+++ b/backend/src/services/updateCheck.ts
@@ -16,6 +16,7 @@ export interface UpdateCheckResult {
   checkedAt: string;
   disabled: boolean;
   error: string | null;
+  channel: 'stable' | 'beta';
 }
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -36,6 +37,8 @@ function loadVersion(): string {
 }
 
 const CURRENT_VERSION = loadVersion();
+const CURRENT_CHANNEL: 'stable' | 'beta' =
+  process.env.PRICESTALKER_CHANNEL === 'beta' ? 'beta' : 'stable';
 
 function compareVersions(a: string, b: string): number {
   const parts = (v: string) => v.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
@@ -54,6 +57,7 @@ async function fetchLatestRelease(): Promise<UpdateCheckResult> {
     checkedAt: new Date().toISOString(),
     disabled: false,
     error: null,
+    channel: CURRENT_CHANNEL,
   };
 
   try {
@@ -92,6 +96,7 @@ export async function checkForUpdate(force = false): Promise<UpdateCheckResult> 
       checkedAt: new Date().toISOString(),
       disabled: true,
       error: null,
+      channel: CURRENT_CHANNEL,
     };
   }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -518,6 +518,7 @@ export interface UpdateCheckResult {
   checkedAt: string;
   disabled: boolean;
   error: string | null;
+  channel: 'stable' | 'beta';
 }
 
 export const versionApi = {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import {
   profileApi,
   adminApi,
   adminAuthApi,
+  versionApi,
   NotificationSettings,
   AISettings,
   UserProfile,
@@ -41,6 +42,7 @@ export default function Settings() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+  const [channel, setChannel] = useState<'stable' | 'beta' | null>(null);
 
   // Profile state
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -140,6 +142,11 @@ export default function Settings() {
       .then(res => res.json())
       .then(data => setVersionInfo(data))
       .catch(() => {}); // Silently fail if version.json not found
+    // Pull the build channel (beta vs stable) for the BETA pill next to
+    // the version display.
+    versionApi.check()
+      .then(res => setChannel(res.data.channel))
+      .catch(() => {});
   }, []);
 
   const fetchInitialData = async () => {
@@ -1293,7 +1300,26 @@ export default function Settings() {
               flexDirection: 'column',
               gap: '0.25rem',
             }}>
-              <span>PriceStalker v{versionInfo.version}</span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem', flexWrap: 'wrap' }}>
+                PriceStalker v{versionInfo.version}
+                {channel === 'beta' && (
+                  <span
+                    title="This deployment was built from the main branch — pre-release. May contain unfinished features."
+                    style={{
+                      fontSize: '0.65rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.05em',
+                      padding: '0.1rem 0.4rem',
+                      borderRadius: '0.25rem',
+                      background: 'linear-gradient(90deg, #f59e0b, #ef4444)',
+                      color: 'white',
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    BETA
+                  </span>
+                )}
+              </span>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <a
                   href="https://github.com/mikeknight85/PriceStalker/blob/main/CHANGELOG.md"


### PR DESCRIPTION
CI workflow passes a CHANNEL build-arg (`stable` for tag pushes, `beta` otherwise). Backend surfaces it via `/api/version/check`. Settings sidebar renders a small BETA pill next to the version string when on a beta build.

## Test plan

- [ ] After this merges and demo redeploys: Settings sidebar shows 'PriceStalker vX.Y.Z [BETA]'.
- [ ] On a tagged release deploy (`:latest`): no pill rendered.
- [ ] Pill has a tooltip explaining what beta means.