### PR TITLE
Fix: textareas now follow theme + .code-input monospace modifier

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,7 +81,8 @@ input, button {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
   width: 100%;
   padding: 0.75rem;
   border: 1px solid var(--border);
@@ -90,13 +91,31 @@ input, button {
   background-color: var(--surface);
   color: var(--text);
   transition: border-color 0.2s, box-shadow 0.2s;
+  font-family: inherit;
 }
 
 .form-group input:focus,
-.form-group select:focus {
+.form-group select:focus,
+.form-group textarea:focus {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+/* Monospace variant for code-like content (JSON headers, body templates,
+   CSS selectors etc.). Overrides only the font + line-height; everything
+   else inherits from the textarea base rules above so theme tokens apply. */
+.form-group .code-input {
+  font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 5rem;
+}
+
+.form-group .code-input::placeholder {
+  color: var(--text-muted);
+  opacity: 0.7;
 }
 
 /* Button styles */

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1883,11 +1883,12 @@ export default function Settings() {
                   <label htmlFor="webhook-headers">Headers (JSON object)</label>
                   <textarea
                     id="webhook-headers"
+                    className="code-input"
                     value={webhookHeaders}
                     onChange={(e) => setWebhookHeaders(e.target.value)}
                     placeholder={'{\n  "Authorization": "Bearer xxx",\n  "X-Source": "PriceStalker"\n}'}
                     rows={4}
-                    style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                    spellCheck={false}
                   />
                   <p className="hint">
                     Optional. JSON object of header name → string value. Content-Type defaults to
@@ -1899,11 +1900,12 @@ export default function Settings() {
                   <label htmlFor="webhook-body">Body Template</label>
                   <textarea
                     id="webhook-body"
+                    className="code-input"
                     value={webhookBodyTemplate}
                     onChange={(e) => setWebhookBodyTemplate(e.target.value)}
                     placeholder={'{"title":"{title}","price":"{price} {currency}","url":"{url}","type":"{type}"}'}
                     rows={6}
-                    style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                    spellCheck={false}
                   />
                   <p className="hint">
                     Optional. Leave blank to use a sensible JSON default. Tokens like


### PR DESCRIPTION
Webhook headers + body template textareas didn't follow dark mode because the global `.form-group input, .form-group select` selector didn't include `textarea`. Fixed by extending the selector and adding a `.code-input` modifier for monospace fields.

Side effect: any other textareas in the app inside a `.form-group` now get themed automatically.