### PR TITLE
Release v1.3.1 — docs catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to PriceStalker will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-06-05
+
+### Documentation
+
+- README "What's new" table caught up to the 1.3.x line (was stale at
+  1.1.x).
+- New Notifications → Custom Webhook config section with the full
+  placeholder reference table.
+- Notifications feature blurb now mentions the Custom Webhook provider
+  and the any-change alert added in 1.2.8.
+
+No code changes — pure docs/version-bump release so `:latest` users on
+prod see the most recent README on the GitHub release page.
+
 ## [1.3.0] - 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ No more accidentally tracking:
 
 | Version | Highlights |
 |---------|-----------|
+| **1.3.x** | **Custom Webhook** notification provider (any HTTP endpoint). **`:beta` Docker channel** + BETA pill in Settings. Shopify-aware extraction (`/products/<handle>.js`). Per-product currency override + "Detected via …" hint. Any-price-change alert (#5). Self-healing product images. In-app update notification. Themed textareas + UI polish. |
 | **1.1.2** | New logo (ghost with binoculars). `/version.json` caching hardened. |
 | **1.1.1** | Fix version display stuck at 1.0.6 post-release. |
 | **1.1.0** | Rebrand to PriceStalker. **Groq** and **OpenRouter** AI providers. Multi-currency parser fixes (BRL, Swiss apostrophe, EUR thousands-only). Base image bumped to Node 22 LTS. Default insecure port mappings removed. Migration path from upstream PriceGhost. |
@@ -97,10 +98,11 @@ Full history in [CHANGELOG.md](CHANGELOG.md).
 - Display formatter centralised — notifications, charts, tables all speak the same currency
 
 ### Notifications
-Telegram · Discord · Pushover · ntfy.sh (self-hosted supported) · Gotify · per-channel toggles · test buttons for every provider.
+Telegram · Discord · Pushover · ntfy.sh (self-hosted supported) · Gotify · **Custom Webhook** (any HTTP endpoint — Apprise, Home Assistant, n8n, Zapier, your own backend) · per-channel toggles · test buttons for every provider.
 
 - **Price drop alerts** — set a CHF/USD/EUR threshold
 - **Target price alerts** — get notified when a specific price is reached
+- **Any-change alerts** — fire on every price movement (up or down), useful for a complete log
 - **Back-in-stock alerts** — know when out-of-stock items return
 
 ### Stock tracking
@@ -251,6 +253,31 @@ npm run dev
 1. Deploy [Gotify](https://gotify.net/docs/install)
 2. Create an application in Gotify to get an App Token
 3. Enter server URL + App Token in Settings → Notifications; use "Test Connection" before saving.
+</details>
+
+<details><summary><b>Custom Webhook</b> (Apprise, Home Assistant, n8n, Zapier, custom services)</summary>
+
+For everything that isn't one of the providers above. Settings → Notifications → Custom Webhook.
+
+Configure:
+- **URL** of the receiver
+- **HTTP method** — `GET` / `POST` / `PUT` / `PATCH` / `DELETE`
+- **Headers** — optional JSON object of header → value (e.g. `{"Authorization": "Bearer ..."}`); `Content-Type` defaults to `application/json` for non-GET when not set
+- **Body template** — optional. Leave blank to send a sensible JSON default. Tokens in `{braces}` are substituted at send time:
+
+| Token | Meaning |
+|-------|---------|
+| `{title}` | Product name |
+| `{type}` | `price_drop` · `price_change` · `target_price` · `back_in_stock` |
+| `{url}` | Product URL |
+| `{currency}` | ISO currency code |
+| `{price}` / `{new_price}` | Current price |
+| `{old_price}` | Previous price (when applicable) |
+| `{threshold}` | Configured drop threshold |
+| `{target_price}` | Configured target price |
+| `{timestamp}` | ISO-8601 send time |
+
+Hit **Send Test** to fire the configured template against a stub payload. `webhook.site` is the quickest receiver for first-time testing.
 </details>
 
 ### AI

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pricestalker-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pricestalker-backend",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.24.0",
         "@google/generative-ai": "^0.24.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricestalker-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "PriceStalker price tracking API",
   "main": "dist/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pricestalker-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pricestalker-frontend",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "axios": "^1.6.0",
         "react": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pricestalker-frontend",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pricestalker-v1.3.0';
+const CACHE_NAME = 'pricestalker-v1.3.1';
 const STATIC_ASSETS = [
   '/',
   '/icon.svg',

--- a/frontend/public/version.json
+++ b/frontend/public/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.3.0",
+  "version": "1.3.1",
   "releaseDate": "2026-06-05"
 }


### PR DESCRIPTION
Pure documentation release. README 'What's new' table caught up to 1.3.x; new Notifications → Custom Webhook section with the placeholder reference table; feature blurb updated. Version bumps to 1.3.1.