### PR TITLE
fix(frontend): prevent Vite config artifact emission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ tmp/
 
 # Ignore Gemini project dir
 .gemini/
-

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
-    "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "strict": true
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
## Why

The frontend build ran `tsc -b` over an app config that referenced the Vite-config project. TypeScript build mode rejects referenced projects that use `noEmit`; removing `noEmit` caused TypeScript to generate `vite.config.js` and `vite.config.d.ts` beside the source configuration.

## Change

- Keep the Vite-config project typecheck-only with `noEmit`.
- Typecheck the app and Vite config independently before running Vite.
- Remove the now-unneeded TypeScript project reference and `composite` setting.

## Verification

- App typecheck
- Vite-config typecheck
- Frontend production build
- Confirmed neither Vite config artifact is recreated beside its source file.