### PR TITLE
fix(dev): align native frontend port with Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Native hot-reload development now serves the frontend on port 8080 by
+  default, matching the Docker stack and avoiding API connection failures from
+  opening the wrong local URL.
 - Native backend development now loads the repository `.env` when pnpm starts
   the backend from its workspace directory.
 

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,13 @@ dev-env: ## Add missing local-development settings to .env without replacing con
 	@LOCAL_POSTGRES_PORT=$(LOCAL_POSTGRES_PORT) node scripts/create-local-env.mjs
 
 dev: check-local-tools dev-env check-local-env dev-db-up ## Start backend and frontend with hot reload and a Docker PostgreSQL database.
-	pnpm --parallel --filter pricestalker-backend --filter pricestalker-frontend run dev
+	VITE_PORT=$(FRONTEND_PORT) pnpm --parallel --filter pricestalker-backend --filter pricestalker-frontend run dev
 
 dev-backend: check-local-tools check-local-env ## Start only the backend with hot reload on port 3001.
 	pnpm --filter pricestalker-backend run dev
 
-dev-frontend: check-local-tools ## Start only the Vite frontend on port 5173.
-	pnpm --filter pricestalker-frontend run dev
+dev-frontend: check-local-tools ## Start only the Vite frontend on FRONTEND_PORT (default: 8080).
+	VITE_PORT=$(FRONTEND_PORT) pnpm --filter pricestalker-frontend run dev
 
 dev-migrate: check-local-tools check-local-env ## Apply migrations to the DATABASE_URL configured for local development.
 	pnpm --filter pricestalker-backend run db:migrate:dev

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -101,7 +101,10 @@ repair the local configuration without starting services.
 
 `make dev` starts PostgreSQL without building application images, then starts
 the backend on `http://localhost:3001` and the Vite frontend on
-`http://localhost:5173`; Vite proxies `/api` requests to the backend. The
+`http://localhost:8080` by default; Vite proxies `/api` requests to the backend.
+Set `FRONTEND_PORT` to use another port. Vite fails immediately when that port
+is occupied, so the displayed local-development URL always matches the running
+server. The
 backend runs pending migrations at startup. Use `make dev-db-up` to start only
 the database, `make dev-db-down` to stop it while keeping its volume,
 `make dev-migrate` to apply migrations without starting the server, and

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,8 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: Number(process.env.VITE_PORT || 8080),
+    strictPort: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',


### PR DESCRIPTION
## Why

Native hot-reload development served Vite on port 5173 while the Docker stack
and developer-facing local URL use port 8080. Opening the app at 8080 during
`make dev` therefore loaded no local API proxy, and product creation failed
with `ERR_CONNECTION_REFUSED`.

## What changed

- Serve the native Vite frontend on `FRONTEND_PORT` (8080 by default).
- Make Vite fail if the requested port is occupied rather than silently
  changing URLs.
- Document the unified local-development URL and port override.

## Validation

- `pnpm --filter pricestalker-frontend run build`
- `pnpm run lint`
