### PR TITLE
feat(frontend): modernize API data layer with Fetch and Query

### DIFF
--- a/.github/workflows/workspace-verify.yml
+++ b/.github/workflows/workspace-verify.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run backend tests
         run: pnpm --filter pricestalker-backend exec vitest run
 
+      - name: Run frontend unit tests
+        run: pnpm --filter pricestalker-frontend test
+
       - name: Install Playwright Chromium
         run: pnpm --filter pricestalker-frontend exec playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ test-results/
 # Misc
 *.tgz
 .cache/
+.pnpm-store/
 
 # From the v2 (PriceGhost) tree
 out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the frontend Axios client with native Fetch and TanStack Query-backed server-state caching.
 - Removed legacy dashboard, product-detail, settings, admin, and debug URL
   redirects. Use the canonical nested frontend routes instead.
 

--- a/frontend/e2e/routes.spec.ts
+++ b/frontend/e2e/routes.spec.ts
@@ -259,3 +259,24 @@ test('lists notification history and marks every alert as read', async ({ page }
   await page.getByRole('button', { name: 'Mark all read' }).click();
   await expect.poll(() => readAllRequests).toBe(1);
 });
+
+test('removes a deleted detail product from the dashboard cache', async ({ page }) => {
+  await page.addInitScript((user) => {
+    localStorage.setItem('token', 'acceptance-token');
+    localStorage.setItem('user', JSON.stringify(user));
+  }, authenticatedUser);
+  let deleted = false;
+  await page.route('**/api/products/1', async (route) => {
+    if (route.request().method() === 'DELETE') {
+      deleted = true;
+      return route.fulfill({ status: 204 });
+    }
+    return route.fulfill({ json: { ...product, stats: { min_price: 25, max_price: 25, avg_price: 25, price_count: 1 } } });
+  });
+  await page.route('**/api/products', async (route) => route.fulfill({ json: deleted ? [] : [product] }));
+  await page.goto('/products/1');
+  await page.getByRole('button', { name: 'Stop Tracking' }).click();
+  await page.getByRole('button', { name: 'Stop Tracking' }).last().click();
+  await expect(page).toHaveURL(/\/products$/);
+  await expect(page.getByText('Acceptance Product')).not.toBeVisible();
+});

--- a/frontend/e2e/routes.spec.ts
+++ b/frontend/e2e/routes.spec.ts
@@ -76,6 +76,48 @@ test('redirects unauthenticated protected routes to login with a return URL', as
   await expect(page.getByRole('heading', { name: 'PriceStalker' })).toBeVisible();
 });
 
+test('clears an expired session and redirects a protected API request to login', async ({ page }) => {
+  await page.addInitScript((user) => {
+    if (sessionStorage.getItem('expired-session-seeded')) return;
+    sessionStorage.setItem('expired-session-seeded', 'true');
+    localStorage.setItem('token', 'expired-token');
+    localStorage.setItem('user', JSON.stringify(user));
+  }, authenticatedUser);
+  await page.route('**/api/products', async (route) => {
+    await route.fulfill({ status: 401, json: { error: 'Expired token' } });
+  });
+
+  await page.goto('/products');
+
+  await expect(page).toHaveURL(/\/login\?redirect=/);
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.evaluate(() => localStorage.getItem('token'))).resolves.toBeNull();
+  await expect(page.evaluate(() => localStorage.getItem('user'))).resolves.toBeNull();
+});
+
+test('shows a retryable dashboard error instead of the empty state', async ({ page }) => {
+  let failRequests = true;
+  await page.addInitScript((user) => {
+    localStorage.setItem('token', 'acceptance-token');
+    localStorage.setItem('user', JSON.stringify(user));
+  }, authenticatedUser);
+  await page.route('**/api/products', async (route) => {
+    if (failRequests) {
+      await route.fulfill({ status: 500, json: { error: 'Temporary failure' } });
+      return;
+    }
+    await route.fulfill({ json: [product] });
+  });
+
+  await page.goto('/products');
+  await expect(page.getByText('Failed to load products. Please try again.')).toBeVisible();
+  await expect(page.getByText('No products found')).not.toBeVisible();
+
+  failRequests = false;
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText('Acceptance Product')).toBeVisible();
+});
+
 test('falls back from an unknown route to the protected products flow', async ({ page }) => {
   await page.goto('/not-a-route');
 
@@ -98,7 +140,7 @@ test('uses canonical defaults when retired tab state is supplied', async ({ page
   await expect(page).toHaveURL(/\/admin\/system$/);
 });
 
-test('preserves product detail state while changing nested sections', async ({ page }) => {
+test('uses the preloaded detail cache while preserving state across nested sections', async ({ page }) => {
   let productRequests = 0;
   await page.addInitScript((user) => {
     localStorage.setItem('token', 'acceptance-token');
@@ -191,4 +233,29 @@ test('allows admins into every admin section and exposes guarded debug', async (
 
   await page.goto('/admin/debug');
   await expect(page.getByRole('heading', { name: 'Debug Access Restricted' })).toBeVisible();
+});
+
+test('lists notification history and marks every alert as read', async ({ page }) => {
+  await page.addInitScript((user) => {
+    localStorage.setItem('token', 'acceptance-token');
+    localStorage.setItem('user', JSON.stringify(user));
+  }, authenticatedUser);
+  let readAllRequests = 0;
+  const alert = { id: 9, user_id: 1, type: 'price_drop', title: 'Price dropped', message: 'Now $20', is_read: false, data: {}, created_at: '2026-01-01T00:00:00.000Z' };
+  await page.route('**/api/notifications/**', async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path === '/api/notifications/history') return route.fulfill({ json: { notifications: [alert], pagination: { page: 1, limit: 20, totalCount: 1, totalPages: 1 } } });
+    if (path === '/api/notifications/read-all' && request.method() === 'POST') {
+      readAllRequests += 1;
+      return route.fulfill({ json: {} });
+    }
+    return route.fulfill({ json: { notifications: [], unreadCount: 0 } });
+  });
+
+  await page.goto('/notifications');
+  await page.getByRole('button', { name: 'Alert History' }).click();
+  await expect(page.getByText('Price dropped')).toBeVisible();
+  await page.getByRole('button', { name: 'Mark all read' }).click();
+  await expect.poll(() => readAllRequests).toBe(1);
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,12 @@
     "dev": "vite",
     "build": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json && vite build",
     "preview": "vite preview",
+    "test": "vitest run src",
     "test:routes": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-router": "1.168.14",
-    "axios": "1.18.1",
+    "@tanstack/react-query": "5.100.3",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "recharts": "3.10.0"
@@ -26,6 +27,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.4",
+    "vitest": "4.1.10",
     "typescript": "7.0.2",
     "vite": "8.1.5"
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,26 @@
 import { RouterProvider } from '@tanstack/react-router';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider, useAuth } from './features/auth';
 import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { router } from './router';
+import { queryClient } from './api/queryClient';
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <ToastProvider>
-          <AppRouter />
-        </ToastProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <AuthProvider>
+          <ToastProvider>
+            <AppRouter />
+          </ToastProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }
 
 function AppRouter() {
   const auth = useAuth();
-  return <RouterProvider router={router} context={{ auth }} />;
+  return <RouterProvider router={router} context={{ auth, queryClient }} />;
 }

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from './client';
+import { ApiError } from './error';
+import { queryClient } from './queryClient';
+import { syncProductCaches } from './productCache';
+import type { Product, ProductWithStats } from '../types/api';
+
+const location = { origin: 'http://localhost', pathname: '/products', search: '', hash: '', href: '' };
+const storage = new Map<string, string>();
+
+const product: ProductWithStats = {
+  id: 1, user_id: 1, url: 'https://example.test/product', name: 'Original', image_url: null,
+  refresh_interval: 3600, last_checked: null, next_check_at: null, stock_status: 'in_stock',
+  price_drop_threshold: null, target_price: null, notify_back_in_stock: false,
+  ai_verification_disabled: false, ai_extraction_disabled: false, checking_paused: false,
+  category: null, created_at: '2026-01-01T00:00:00Z', current_price: 10, member_price: null,
+  original_price: null, currency: 'USD', converted_price: null, converted_currency: null,
+  ai_status: null, stats: { min_price: 8, max_price: 12, avg_price: 10, price_count: 3 },
+};
+
+beforeEach(() => {
+  vi.stubGlobal('window', { location });
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  });
+});
+
+afterEach(() => {
+  storage.clear();
+  location.href = '';
+  queryClient.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('api client', () => {
+  it('returns decoded data and sends auth/query parameters', async () => {
+    storage.set('token', 'token-value');
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ enabled: true }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.get<{ enabled: boolean }>('/settings/discovery/status', { params: { q: 'test' } })).resolves.toEqual({ enabled: true });
+    expect(fetchMock).toHaveBeenCalledWith('/api/settings/discovery/status?q=test', expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer token-value' }),
+    }));
+  });
+
+  it('throws ApiError for an HTTP error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'Conflict' }), { status: 409 })));
+    await expect(api.post('/products', {})).rejects.toMatchObject({ status: 409, message: 'Conflict' } satisfies Partial<ApiError>);
+  });
+
+  it('merges a product mutation into caches without losing detail stats', () => {
+    queryClient.setQueryData(['products'], [product]);
+    queryClient.setQueryData(['products', product.id], product);
+    const updated: Product = { ...product, name: 'Renamed' };
+
+    syncProductCaches(updated);
+
+    expect(queryClient.getQueryData<Product[]>(['products'])?.[0].name).toBe('Renamed');
+    expect(queryClient.getQueryData<ProductWithStats>(['products', product.id])?.stats).toEqual(product.stats);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,57 +1,96 @@
-import axios from 'axios';
 import { logger } from '../utils/logger';
+import { queryClient } from './queryClient';
+import { ApiError } from './error';
+
+export { ApiError, isApiError } from './error';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
-export const api = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+type QueryParams = Record<string, string | number | boolean | null | undefined>;
+export interface RequestOptions extends Omit<RequestInit, 'body' | 'method'> {
+  params?: QueryParams;
+  signal?: AbortSignal;
+}
 
-// Add auth token to requests
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+function requestUrl(path: string, params?: QueryParams): string {
+  const base = API_BASE_URL.startsWith('http') ? API_BASE_URL : `${window.location.origin}${API_BASE_URL}`;
+  const url = new URL(`${base.replace(/\/$/, '')}/${path.replace(/^\//, '')}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
+    }
   }
+  return API_BASE_URL.startsWith('http') ? url.toString() : url.pathname + url.search;
+}
 
-  // Track start time for performance logging
-  (config as any).metadata = { startTime: new Date() };
-  return config;
-});
+async function parseBody(response: Response): Promise<unknown> {
+  if (response.status === 204) return undefined;
+  const text = await response.text();
+  if (!text) return undefined;
+  try { return JSON.parse(text); } catch { return text; }
+}
 
-// Handle authentication errors and log responses
-api.interceptors.response.use(
-  (response) => {
-    const startTime = (response.config as any).metadata.startTime;
-    const duration = new Date().getTime() - startTime.getTime();
-    logger.info(response.config.method?.toUpperCase() + ' ' + response.config.url + ' ' + response.status + ' (' + duration + 'ms)', 'API');
-    return response;
-  },
-  (error) => {
-    const duration = error.config?.metadata ? new Date().getTime() - error.config.metadata.startTime.getTime() : 0;
-    const status = error.response?.status || 'Error';
-    const msg = error.config?.method?.toUpperCase() + ' ' + error.config?.url + ' ' + status + ' (' + duration + 'ms)';
+function errorMessage(body: unknown, status: number): string {
+  if (body && typeof body === 'object') {
+    const candidate = body as { error?: unknown; message?: unknown };
+    if (typeof candidate.error === 'string') return candidate.error;
+    if (typeof candidate.message === 'string') return candidate.message;
+  }
+  return `Request failed (${status})`;
+}
 
-    if (error.response?.status === 401) {
+function isAuthRequest(path: string): boolean {
+  return path.includes('/auth/login') || path.includes('/auth/register');
+}
+
+async function request<T>(method: string, path: string, body?: unknown, options: RequestOptions = {}): Promise<T> {
+  const { params, headers, ...init } = options;
+  const url = requestUrl(path, params);
+  const started = performance.now();
+  const token = localStorage.getItem('token');
+  const response = await fetch(url, {
+    ...init,
+    method,
+    headers: {
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...headers,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const duration = Math.round(performance.now() - started);
+  const responseBody = await parseBody(response);
+  const message = `${method} ${url} ${response.status} (${duration}ms)`;
+
+  if (!response.ok) {
+    const error = new ApiError(errorMessage(responseBody, response.status), response.status, responseBody, method, url);
+    if (response.status === 401 && !isAuthRequest(path)) {
       localStorage.removeItem('token');
-      
-      const url = error.config?.url || '';
-      const isAuthRequest = url.includes('/auth/login') || url.includes('/auth/register');
-      const isAlreadyOnAuthPage = window.location.pathname.startsWith('/login') || window.location.pathname.startsWith('/register');
-
-      if (!isAuthRequest && !isAlreadyOnAuthPage) {
-        logger.warn(msg + ': Unauthorized, logging out', 'API');
+      localStorage.removeItem('user');
+      queryClient.clear();
+      const onAuthPage = window.location.pathname.startsWith('/login') || window.location.pathname.startsWith('/register');
+      if (!onAuthPage) {
+        logger.warn(`${message}: Unauthorized, logging out`, 'API');
         const currentPath = window.location.pathname + window.location.search + window.location.hash;
         window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
-      } else {
-        logger.warn(msg + ': Unauthorized request (auth page or auth endpoint), bypassing redirect', 'API');
       }
     } else {
-      logger.error(msg, 'API', error);
+      logger.error(message, 'API', error);
     }
-    return Promise.reject(error);
+    throw error;
   }
-);
+
+  logger.info(message, 'API');
+  return responseBody as T;
+}
+
+export const api = {
+  get: <T>(path: string, options?: RequestOptions) => request<T>('GET', path, undefined, options),
+  post: <T>(path: string, body?: unknown, options?: RequestOptions) => request<T>('POST', path, body, options),
+  put: <T>(path: string, body?: unknown, options?: RequestOptions) => request<T>('PUT', path, body, options),
+  patch: <T>(path: string, body?: unknown, options?: RequestOptions) => request<T>('PATCH', path, body, options),
+  delete: <T>(path: string, options?: RequestOptions & { data?: unknown }) => {
+    const { data, ...requestOptions } = options ?? {};
+    return request<T>('DELETE', path, data, requestOptions);
+  },
+};

--- a/frontend/src/api/error.ts
+++ b/frontend/src/api/error.ts
@@ -1,0 +1,21 @@
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+    readonly method: string,
+    readonly url: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
+export function apiErrorMessage(error: unknown, fallback = 'Request failed'): string {
+  if (isApiError(error)) return error.message || fallback;
+  return error instanceof Error ? error.message : fallback;
+}

--- a/frontend/src/api/productCache.ts
+++ b/frontend/src/api/productCache.ts
@@ -1,0 +1,13 @@
+import type { Product, ProductWithStats } from '../types/api';
+import { queryClient } from './queryClient';
+import { queryKeys } from './queries';
+
+/** Applies a canonical product mutation response without discarding detail-only stats. */
+export function syncProductCaches(updated: Product): void {
+  queryClient.setQueryData<Product[]>(queryKeys.products.all, (products) =>
+    products?.map((product) => product.id === updated.id ? { ...product, ...updated } : product),
+  );
+  queryClient.setQueryData<ProductWithStats>(queryKeys.products.detail(updated.id), (product) =>
+    product ? { ...product, ...updated } : product,
+  );
+}

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,0 +1,84 @@
+import { queryOptions } from '@tanstack/react-query';
+import { ProductService } from '../features/products/services/ProductService';
+import { ProfileService } from '../features/settings/services/ProfileService';
+import { NotificationService } from '../features/notifications/services/NotificationService';
+import { SharedService } from '../services/SharedService';
+import { AdminSystemService } from '../features/admin/services/AdminSystemService';
+
+export const queryKeys = {
+  products: { all: ['products'] as const, detail: (id: number) => ['products', id] as const },
+  discoveryStatus: ['settings', 'discovery-status'] as const,
+  profile: ['profile'] as const,
+  currencies: ['settings', 'currencies'] as const,
+  notificationSettings: ['settings', 'notifications'] as const,
+  adminSystemSettings: ['admin', 'system-settings'] as const,
+  priceHistory: (productId: number, days: number) => ['products', productId, 'price-history', days] as const,
+  stockHistory: (productId: number, days: number) => ['products', productId, 'stock-history', days] as const,
+  notifications: { recent: (limit: number) => ['notifications', 'recent', limit] as const, history: (page: number, limit: number) => ['notifications', 'history', page, limit] as const },
+};
+
+export const productListQuery = () => queryOptions({
+  queryKey: queryKeys.products.all,
+  queryFn: ({ signal }) => ProductService.getAll({ signal }),
+  staleTime: 30_000,
+});
+
+export const productDetailQuery = (id: number) => queryOptions({
+  queryKey: queryKeys.products.detail(id),
+  queryFn: ({ signal }) => ProductService.getById(id, { signal }),
+  staleTime: 30_000,
+});
+
+export const discoveryStatusQuery = () => queryOptions({
+  queryKey: queryKeys.discoveryStatus,
+  queryFn: ({ signal }) => ProductService.getSearchStatus({ signal }),
+  staleTime: 10 * 60_000,
+});
+
+export const profileQuery = () => queryOptions({
+  queryKey: queryKeys.profile,
+  queryFn: ({ signal }) => ProfileService.getProfile({ signal }),
+  staleTime: 10 * 60_000,
+});
+
+export const currenciesQuery = () => queryOptions({
+  queryKey: queryKeys.currencies,
+  queryFn: ({ signal }) => SharedService.getCurrencies({ signal }),
+  staleTime: 10 * 60_000,
+});
+
+export const notificationSettingsQuery = () => queryOptions({
+  queryKey: queryKeys.notificationSettings,
+  queryFn: ({ signal }) => ProfileService.getNotificationSettings({ signal }),
+  staleTime: 10 * 60_000,
+});
+
+export const adminSystemSettingsQuery = () => queryOptions({
+  queryKey: queryKeys.adminSystemSettings,
+  queryFn: ({ signal }) => AdminSystemService.getSystemSettings({ signal }),
+  staleTime: 10 * 60_000,
+});
+
+export const priceHistoryQuery = (productId: number, days = 30) => queryOptions({
+  queryKey: queryKeys.priceHistory(productId, days),
+  queryFn: ({ signal }) => ProductService.getPriceHistory(productId, days, { signal }),
+  staleTime: 5 * 60_000,
+});
+
+export const stockHistoryQuery = (productId: number, days = 30) => queryOptions({
+  queryKey: queryKeys.stockHistory(productId, days),
+  queryFn: ({ signal }) => ProductService.getStockHistory(productId, days, { signal }),
+  staleTime: 5 * 60_000,
+});
+
+export const recentNotificationsQuery = (limit: number) => queryOptions({
+  queryKey: queryKeys.notifications.recent(limit),
+  queryFn: ({ signal }) => NotificationService.getRecent(limit, { signal }),
+  staleTime: 30_000,
+});
+
+export const notificationHistoryQuery = (page: number, limit: number) => queryOptions({
+  queryKey: queryKeys.notifications.history(page, limit),
+  queryFn: ({ signal }) => NotificationService.getHistory(page, limit, { signal }),
+  staleTime: 30_000,
+});

--- a/frontend/src/api/queryClient.ts
+++ b/frontend/src/api/queryClient.ts
@@ -1,0 +1,17 @@
+import { QueryClient } from '@tanstack/react-query';
+import { ApiError } from './error';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      retry: (failureCount, error) => {
+        if (failureCount >= 1 || error instanceof DOMException && error.name === 'AbortError') return false;
+        return !(error instanceof ApiError) || error.status >= 500;
+      },
+      gcTime: 5 * 60 * 1000,
+    },
+    mutations: { retry: false },
+  },
+});

--- a/frontend/src/features/admin/components/sections/AIModelTester.tsx
+++ b/frontend/src/features/admin/components/sections/AIModelTester.tsx
@@ -11,7 +11,7 @@ export default function AIModelTester() {
     if (!aiTestUrl) return;
     setAiTestResult(null);
     const res = await AIService.testAI(aiTestUrl);
-    setAiTestResult(res.data);
+    setAiTestResult(res);
   }, { onSuccessMessage: 'AI extraction complete', onErrorMessage: 'AI Test failed' });
 
   return (

--- a/frontend/src/features/admin/components/sections/AIProviderConfig.tsx
+++ b/frontend/src/features/admin/components/sections/AIProviderConfig.tsx
@@ -33,7 +33,7 @@ export default function AIProviderConfig({
     try {
       await AIService.refreshGeminiModels(aiSettings?.gemini_api_key || undefined);
       const res = await AIService.getGeminiModels();
-      setAiModels(res.data.models);
+      setAiModels(res.models);
     } finally {
       setIsRefreshingModels(false);
     }
@@ -67,7 +67,7 @@ export default function AIProviderConfig({
       res = await AIService.testOllama(aiSettings.ollama_base_url);
     }
 
-    const msg = res?.data?.message || `${provider} API connection successful`;
+    const msg = res?.message || `${provider} API connection successful`;
     showToast(msg, 'success');
   }, { onErrorMessage: `${provider} Test failed` });
 

--- a/frontend/src/features/admin/components/sections/AISection.tsx
+++ b/frontend/src/features/admin/components/sections/AISection.tsx
@@ -28,8 +28,8 @@ export default function AISection() {
       AIService.getAI(),
       AIService.getGeminiModels(),
     ]);
-    setAiSettings(settingsRes.data);
-    setAiModels(modelsRes.data.models);
+    setAiSettings(settingsRes);
+    setAiModels(modelsRes.models);
   }, { onErrorFallback: 'Failed to load AI settings' });
 
   useEffect(() => {
@@ -70,4 +70,3 @@ export default function AISection() {
     </div>
   );
 }
-

--- a/frontend/src/features/admin/components/sections/AuthSection.tsx
+++ b/frontend/src/features/admin/components/sections/AuthSection.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from '../../../../components/LoadingSpinner';
 import PasswordInput from '../../../../components/PasswordInput';
 import { CollapsibleCard, ToggleSwitch } from '../../components';
 import Icon from '../../../../components/Icon';
+import { ApiError, apiErrorMessage } from '../../../../api/error';
 
 const toggleRow: React.CSSProperties = {
   display: 'flex',
@@ -64,7 +65,7 @@ export default function AuthSection() {
   const load = async () => {
     setIsLoading(true);
     try {
-      const { data } = await AuthConfigService.get();
+      const data = await AuthConfigService.get();
       applyConfig(data);
     } catch {
       showToast('Failed to load authentication settings', 'error');
@@ -95,12 +96,13 @@ export default function AuthSection() {
     setIsTesting(true);
     setDiscovery(null);
     try {
-      const { data } = await AuthConfigService.testDiscovery(issuerUrl);
+      const data = await AuthConfigService.testDiscovery(issuerUrl);
       setDiscovery(data);
       showToast('Discovery succeeded', 'success');
     } catch (err) {
-      const e = err as { response?: { data?: DiscoveryResult } };
-      const result = e.response?.data ?? { ok: false, error: 'Discovery request failed' };
+      const result = err instanceof ApiError && err.body && typeof err.body === 'object'
+        ? err.body as DiscoveryResult
+        : { ok: false, error: 'Discovery request failed' };
       setDiscovery(result);
       showToast(result.error || 'Discovery failed', 'error');
     } finally {
@@ -123,12 +125,11 @@ export default function AuthSection() {
         oidc_jit_enabled: jitEnabled,
         oidc_require_email_verified: requireEmailVerified,
       };
-      const { data } = await AuthConfigService.update(payload);
+      const data = await AuthConfigService.update(payload);
       applyConfig(data);
       showToast('Authentication settings saved', 'success');
     } catch (err) {
-      const e = err as { response?: { data?: { error?: string } } };
-      showToast(e.response?.data?.error || 'Failed to save authentication settings', 'error');
+      showToast(apiErrorMessage(err, 'Failed to save authentication settings'), 'error');
     } finally {
       setIsSaving(false);
     }

--- a/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
+++ b/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
@@ -7,6 +7,8 @@ import {
   UnifiedSelectorManager 
 } from '../../components';
 import Icon from '../../../../components/Icon';
+import { queryClient } from '../../../../api/queryClient';
+import { adminSystemSettingsQuery, queryKeys } from '../../../../api/queries';
 
 export default function GlobalSelectorsSection() {
   const { showToast } = useToast();
@@ -56,8 +58,8 @@ export default function GlobalSelectorsSection() {
   const fetchSelectorData = async () => {
     setIsLoading(true);
     try {
-      const res = await AdminSystemService.getSystemSettings();
-      const settings = res.data;
+      const res = await queryClient.fetchQuery(adminSystemSettingsQuery());
+      const settings = res;
       
       try { setGlobalPriceSelectors(JSON.parse(settings.generic_price_selectors || '[]')); } catch { setGlobalPriceSelectors([]); }
       try { setGlobalDealPriceSelectors(JSON.parse(settings.generic_deal_price_selectors || '[]')); } catch { setGlobalDealPriceSelectors([]); }
@@ -97,7 +99,8 @@ export default function GlobalSelectorsSection() {
         generic_pre_order_phrases: JSON.stringify(globalPreOrderPhrases),
       };
 
-      await AdminSystemService.updateSystemSettings(payload);
+      const updated = await AdminSystemService.updateSystemSettings(payload);
+      queryClient.setQueryData(queryKeys.adminSystemSettings, updated);
       showToast('Global selectors saved successfully', 'success');
     } catch {
       showToast('Failed to save selectors', 'error');

--- a/frontend/src/features/admin/components/sections/LogsSection.tsx
+++ b/frontend/src/features/admin/components/sections/LogsSection.tsx
@@ -36,11 +36,11 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
         level: logLevel, 
         context: logContext 
       });
-      setLogs(res.data.logs);
-      setTotalCount(res.data.total);
-      setLogPage(res.data.page);
-      setLogPages(res.data.pages);
-      setAvailableContexts(res.data.availableContexts || []);
+      setLogs(res.logs);
+      setTotalCount(res.total);
+      setLogPage(res.page);
+      setLogPages(res.pages);
+      setAvailableContexts(res.availableContexts || []);
     } catch {
       showToast('Failed to load logs', 'error');
     } finally {

--- a/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
+++ b/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
@@ -168,7 +168,7 @@ export default function RetailerConfigEditor({
     };
     
     const res = await RetailerAdminService.testRetailerConfig(config, testUrl);
-    setTestResult(res.data);
+    setTestResult(res);
   }, { onErrorMessage: 'Live test failed' });
 
   return (

--- a/frontend/src/features/admin/components/sections/RetailersSection.tsx
+++ b/frontend/src/features/admin/components/sections/RetailersSection.tsx
@@ -1,8 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { RetailerAdminService } from '../../services/RetailerAdminService';
 import { RetailerConfig, GlobalCurrency } from '../../../../types/api';
 import RetailerConfigEditor from './RetailerConfigEditor';
 import Icon from '../../../../components/Icon';
+import { queryClient } from '../../../../api/queryClient';
+
+const retailersQuery = () => queryOptions({
+  queryKey: ['admin', 'retailers'] as const,
+  queryFn: RetailerAdminService.getRetailers,
+  staleTime: 10 * 60_000,
+});
 
 interface RetailersSectionProps {
   globalCurrencies: GlobalCurrency[];
@@ -10,24 +18,10 @@ interface RetailersSectionProps {
 }
 
 export default function RetailersSection({ globalCurrencies, initialSearch }: RetailersSectionProps) {
-  const [retailers, setRetailers] = useState<RetailerConfig[]>([]);
   const [retailerSearch, setRetailerSearch] = useState(initialSearch || '');
   const [editingRetailer, setEditingRetailer] = useState<Partial<RetailerConfig> | null>(null);
-
-  useEffect(() => {
-    fetchRetailers();
-    let interval = setInterval(fetchRetailers, 5000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const fetchRetailers = async () => {
-    try {
-      const res = await RetailerAdminService.getRetailers();
-      setRetailers(res.data);
-    } catch (err) {
-      console.error('Failed to fetch retailers:', err);
-    }
-  };
+  const retailersResult = useQuery(retailersQuery());
+  const retailers = retailersResult.data ?? [];
 
   const handleEditRetailer = (r: Partial<RetailerConfig>) => {
     setEditingRetailer(r);
@@ -50,7 +44,7 @@ export default function RetailersSection({ globalCurrencies, initialSearch }: Re
 
   const handleSave = () => {
     setEditingRetailer(null);
-    fetchRetailers();
+    void queryClient.invalidateQueries({ queryKey: ['admin', 'retailers'] });
   };
 
   const handleCancel = () => {
@@ -59,11 +53,12 @@ export default function RetailersSection({ globalCurrencies, initialSearch }: Re
 
   const handleDelete = () => {
     setEditingRetailer(null);
-    fetchRetailers();
+    void queryClient.invalidateQueries({ queryKey: ['admin', 'retailers'] });
   };
 
   return (
     <div className="admin-section-wrapper">
+      {retailersResult.isError && <div className="alert alert-error">Failed to load retailers. <button className="btn btn-secondary btn-sm" onClick={() => void retailersResult.refetch()}>Retry</button></div>}
       <div className="settings-card" style={{ marginBottom: editingRetailer ? '2rem' : '1.25rem' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
           <h2 className="settings-card-title" style={{ margin: 0 }}>Retailers</h2>

--- a/frontend/src/features/admin/components/sections/SystemApiTokensSection.tsx
+++ b/frontend/src/features/admin/components/sections/SystemApiTokensSection.tsx
@@ -22,7 +22,7 @@ export default function SystemApiTokensSection() {
   const fetchTokens = async () => {
     try {
       const res = await AdminSystemService.getSystemApiTokens();
-      setTokens(res.data);
+      setTokens(res);
     } catch {
       showToast('Failed to load system API tokens', 'error');
     }
@@ -40,7 +40,7 @@ export default function SystemApiTokensSection() {
         label: newTokenLabel,
         description: newTokenDescription
       });
-      setGeneratedToken(res.data.token);
+      setGeneratedToken(res.token);
       showToast('System API token created successfully', 'success');
       fetchTokens();
     } catch (err) {

--- a/frontend/src/features/admin/components/sections/SystemSection.tsx
+++ b/frontend/src/features/admin/components/sections/SystemSection.tsx
@@ -2,12 +2,15 @@ import { useState, useEffect } from 'react';
 import { AdminSystemService } from '../../services/AdminSystemService';
 import { SystemSettings } from '../../../../types/api';
 import { useToast } from '../../../../context/ToastContext';
+import { apiErrorMessage } from '../../../../api/error';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import { 
   CollapsibleCard, 
   ToggleSwitch
 } from '../../components';
 import Icon from '../../../../components/Icon';
+import { queryClient } from '../../../../api/queryClient';
+import { adminSystemSettingsQuery, queryKeys } from '../../../../api/queries';
 
 export default function SystemSection() {
   const { showToast } = useToast();
@@ -36,8 +39,8 @@ export default function SystemSection() {
   const fetchSystemData = async () => {
     setIsLoading(true);
     try {
-      const res = await AdminSystemService.getSystemSettings();
-      const settings = res.data;
+      const res = await queryClient.fetchQuery(adminSystemSettingsQuery());
+      const settings = res;
       setSystemSettings(settings);
     } catch {
       showToast('Failed to load system settings', 'error');
@@ -51,7 +54,8 @@ export default function SystemSection() {
       const res = await AdminSystemService.updateSystemSettings({ 
         registration_enabled: !(systemSettings?.registration_enabled === true || systemSettings?.registration_enabled === 'true') 
       });
-      setSystemSettings(res.data);
+      setSystemSettings(res);
+      queryClient.setQueryData(queryKeys.adminSystemSettings, res);
       showToast('Registration toggled', 'success');
     } catch {
       showToast('Update failed', 'error');
@@ -63,7 +67,8 @@ export default function SystemSection() {
       const res = await AdminSystemService.updateSystemSettings({ 
         debug_page_enabled: !(systemSettings?.debug_page_enabled === true || systemSettings?.debug_page_enabled === 'true') 
       });
-      setSystemSettings(res.data);
+      setSystemSettings(res);
+      queryClient.setQueryData(queryKeys.adminSystemSettings, res);
       showToast('Debug page toggled', 'success');
     } catch {
       showToast('Update failed', 'error');
@@ -75,13 +80,13 @@ export default function SystemSection() {
     setIsTestingSearXNG(true);
     try {
       const res = await AdminSystemService.testSearXNG(systemSettings.searxng_url);
-      if (res.data?.success) {
-        showToast(res.data.message, 'success');
+      if (res?.success) {
+        showToast(res.message, 'success');
       } else {
-        showToast(res.data?.error || 'Test failed', 'error');
+        showToast(res?.error || 'Test failed', 'error');
       }
     } catch (err: any) {
-      showToast(err.response?.data?.error || 'Failed to connect to SearXNG', 'error');
+      showToast(apiErrorMessage(err, 'Failed to connect to SearXNG'), 'error');
     } finally {
       setIsTestingSearXNG(false);
     }
@@ -100,7 +105,8 @@ export default function SystemSection() {
       };
 
       const res = await AdminSystemService.updateSystemSettings(payload);
-      setSystemSettings(res.data);
+      setSystemSettings(res);
+      queryClient.setQueryData(queryKeys.adminSystemSettings, res);
       showToast('Admin settings saved', 'success');
     } catch { showToast('Save failed', 'error'); } finally { setIsSavingAdmin(false); }
   };
@@ -187,7 +193,7 @@ export default function SystemSection() {
               const res = await AdminSystemService.updateSystemSettings({ 
                 scheduler_disabled: !(systemSettings?.scheduler_disabled === true || systemSettings?.scheduler_disabled === 'true') 
               });
-              setSystemSettings(res.data);
+              setSystemSettings(res);
             }} 
             disabled={isSavingAdmin} 
           />
@@ -200,7 +206,7 @@ export default function SystemSection() {
               const res = await AdminSystemService.updateSystemSettings({ 
                 retailer_updates_disabled: !(systemSettings?.retailer_updates_disabled === true || systemSettings?.retailer_updates_disabled === 'true') 
               });
-              setSystemSettings(res.data);
+              setSystemSettings(res);
             }} 
             disabled={isSavingAdmin} 
           />

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { UserAdminService } from '../../services/UserAdminService';
 import { UserProfile, GlobalCurrency } from '../../../../types/api';
 import { useToast } from '../../../../context/ToastContext';
+import { apiErrorMessage } from '../../../../api/error';
 import { useAuth } from '../../../auth';
 import PasswordInput from '../../../../components/PasswordInput';
 import SearchableSelect from '../../../../components/SearchableSelect';
@@ -38,7 +39,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   const fetchUsers = async () => {
     try {
       const res = await UserAdminService.getUsers();
-      setUsers(res.data);
+      setUsers(res);
     } catch {
       showToast('Failed to load users', 'error');
     }
@@ -52,7 +53,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
       setIsAddingUser(false);
       setNewUserEmail(''); setNewUserPassword('');
       fetchUsers();
-    } catch (err: any) { showToast(err.response?.data?.error || 'Failed to create user'); }
+    } catch (err) { showToast(apiErrorMessage(err, 'Failed to create user')); }
   };
 
   const handleUpdateUser = async () => {

--- a/frontend/src/features/admin/pages/AdminPage.tsx
+++ b/frontend/src/features/admin/pages/AdminPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { adminRoute } from '../../../routes/-admin-api';
 import Layout from '../../../layouts/Layout';
 import Icon from '../../../components/Icon';
-import { SharedService } from '../../../services/SharedService';
-import { GlobalCurrency } from '../../../types/api';
+import { currenciesQuery } from '../../../api/queries';
 
 // Section Components
 import SystemSection from '../components/sections/SystemSection';
@@ -22,29 +22,17 @@ export default function Admin({ activeSection }: { activeSection: AdminSection }
   const navigate = useNavigate();
   const { retailer } = adminRoute.useSearch();
   
-  const [globalCurrencies, setGlobalCurrencies] = useState<GlobalCurrency[]>([]);
   const [retailerSearch, setRetailerSearch] = useState(retailer || '');
+  const currenciesResult = useQuery(currenciesQuery());
+  const globalCurrencies = currenciesResult.data ?? [];
 
   const setActiveSection = (section: AdminSection) => {
     navigate({ to: `/admin/${section}` });
   };
 
   useEffect(() => {
-    fetchGlobalData();
-  }, []);
-
-  useEffect(() => {
     setRetailerSearch(retailer || '');
   }, [retailer]);
-
-  const fetchGlobalData = async () => {
-    try {
-      const res = await SharedService.getCurrencies();
-      setGlobalCurrencies(res.data || []);
-    } catch (err) {
-      console.error('Failed to fetch global currencies:', err);
-    }
-  };
 
   const handleSearchRetailer = (domain: string) => {
     navigate({ to: '/admin/retailers', search: { retailer: domain } });

--- a/frontend/src/features/admin/services/AdminSystemService.ts
+++ b/frontend/src/features/admin/services/AdminSystemService.ts
@@ -1,4 +1,4 @@
-import { api } from '../../../api/client';
+import { api, type RequestOptions } from '../../../api/client';
 import { 
   SystemSettings, 
   SystemApiToken, 
@@ -7,7 +7,7 @@ import {
 
 export const AdminSystemService = {
   getDebugStatus: () => api.get<{ enabled: boolean }>('/admin/debug/status'),
-  getSystemSettings: () => api.get<SystemSettings>('/admin/settings'),
+  getSystemSettings: (options?: RequestOptions) => api.get<SystemSettings>('/admin/settings', options),
   updateSystemSettings: (settings: Partial<SystemSettings>) => api.put<SystemSettings>('/admin/settings', settings),
   testSearXNG: (url: string) => api.post<{ success: boolean; message: string; error?: string }>('/admin/command', { command: 'test-searxng', params: { url } }),
   executeCommand: (command: string, params?: any) => api.post('/admin/command', { command, params }),

--- a/frontend/src/features/auth/components/AuthForm.tsx
+++ b/frontend/src/features/auth/components/AuthForm.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '../../../context/ThemeContext';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import './AuthForm.css';
 import Icon from '../../../components/Icon';
+import { apiErrorMessage } from '../../../api/error';
 
 interface AuthFormProps {
   mode: 'login' | 'register';
@@ -25,13 +26,13 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode, onSubmit }) => {
   useEffect(() => {
     // Check if registration is enabled
     AuthService.getRegistrationStatus()
-      .then(res => setRegistrationEnabled(res.data.enabled))
+      .then(res => setRegistrationEnabled(res.enabled))
       .catch(() => setRegistrationEnabled(true)); // Default to true on error
 
     // 404s when SSO is disabled on the server; that is the normal
     // local-login-only case, not an error worth surfacing.
     AuthService.getPublicAuthConfig()
-      .then(res => setSsoConfig(res.data))
+      .then(res => setSsoConfig(res))
       .catch(() => setSsoConfig(null));
   }, []);
 
@@ -64,8 +65,7 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode, onSubmit }) => {
     } catch (err) {
       if (err instanceof Error) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const axiosError = err as any;
-        setError(axiosError.response?.data?.error || 'An error occurred');
+        setError(apiErrorMessage(err, 'An error occurred'));
       } else {
         setError('An error occurred');
       }

--- a/frontend/src/features/auth/components/AuthForm.tsx
+++ b/frontend/src/features/auth/components/AuthForm.tsx
@@ -64,7 +64,6 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode, onSubmit }) => {
       await onSubmit(email, password);
     } catch (err) {
       if (err instanceof Error) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         setError(apiErrorMessage(err, 'An error occurred'));
       } else {
         setError('An error occurred');

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -5,17 +5,10 @@ import {
   useEffect,
   ReactNode,
 } from 'react';
-import { AuthService } from '../services/AuthService';
+import { AuthService, type AuthenticatedUser } from '../services/AuthService';
+import { queryClient } from '../../../api/queryClient';
 
-interface User {
-  id: number;
-  email: string;
-  name: string | null;
-  currency: string;
-  locale: string;
-  is_admin: boolean;
-  categories: string[];
-}
+type User = AuthenticatedUser;
 
 export interface AuthContextType {
   user: User | null;
@@ -51,7 +44,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = async (email: string, password: string) => {
     const response = await AuthService.login(email, password);
-    const { token, user: userData } = response.data;
+    const { token, user: userData } = response;
 
     localStorage.setItem('token', token);
     localStorage.setItem('user', JSON.stringify(userData));
@@ -60,7 +53,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const register = async (email: string, password: string) => {
     const response = await AuthService.register(email, password);
-    const { token, user: userData } = response.data;
+    const { token, user: userData } = response;
 
     localStorage.setItem('token', token);
     localStorage.setItem('user', JSON.stringify(userData));
@@ -76,7 +69,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.setItem('token', token);
     try {
       const response = await AuthService.getProfile();
-      const userData = response.data;
+      const userData = response;
       localStorage.setItem('user', JSON.stringify(userData));
       setUser(userData);
     } catch (error) {
@@ -91,6 +84,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('user');
+    queryClient.clear();
     setUser(null);
   };
 

--- a/frontend/src/features/auth/services/AuthService.ts
+++ b/frontend/src/features/auth/services/AuthService.ts
@@ -6,12 +6,27 @@ export interface PublicAuthConfig {
   oidc_provider_name: string | null;
 }
 
+export interface AuthenticatedUser {
+  id: number;
+  email: string;
+  name: string | null;
+  currency: string;
+  locale: string;
+  is_admin: boolean;
+  categories: string[];
+}
+
+export interface AuthResponse {
+  token: string;
+  user: AuthenticatedUser;
+}
+
 export const AuthService = {
   register: (email: string, password: string) =>
-    api.post('/auth/register', { email, password }),
+    api.post<AuthResponse>('/auth/register', { email, password }),
 
   login: (email: string, password: string) =>
-    api.post('/auth/login', { email, password }),
+    api.post<AuthResponse>('/auth/login', { email, password }),
 
   getRegistrationStatus: () =>
     api.get<{ enabled: boolean }>('/auth/registration-status'),
@@ -25,7 +40,7 @@ export const AuthService = {
     api.get<PublicAuthConfig>('/auth/oidc/config/public'),
 
   /** Fetch the current user with an existing token, after an SSO redirect. */
-  getProfile: () => api.get('/profile'),
+  getProfile: () => api.get<AuthenticatedUser>('/profile'),
 };
 
 /** Full-page navigation: the OIDC flow is a browser redirect, not an XHR. */

--- a/frontend/src/features/debug/pages/DebugPage.tsx
+++ b/frontend/src/features/debug/pages/DebugPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Layout from '../../../layouts/Layout';
 import { useAuth } from '../../auth';
 import { useToast } from '../../../context/ToastContext';
+import { apiErrorMessage } from '../../../api/error';
 import { AdminSystemService, RetailerAdminService } from '../../admin';
 
 import { useDebugScraper } from './useDebugScraper';
@@ -79,7 +80,7 @@ export default function Debug() {
       });
       showToast(`Retailer config for ${domain} updated successfully!`);
     } catch (err: any) {
-      showToast('Failed to save config: ' + (err.response?.data?.error || err.message), 'error');
+      showToast('Failed to save config: ' + apiErrorMessage(err), 'error');
     }
   };
 

--- a/frontend/src/features/debug/pages/useDebugScraper.ts
+++ b/frontend/src/features/debug/pages/useDebugScraper.ts
@@ -3,6 +3,7 @@ import { AdminSystemService, RetailerAdminService } from '../../admin';
 import { ProductService } from '../../products/services/ProductService';
 import { RetailerConfig, SystemSettings } from '../../../types/api';
 import { useToast } from '../../../context/ToastContext';
+import { apiErrorMessage } from '../../../api/error';
 
 export function useDebugScraper() {
   const { showToast } = useToast();
@@ -76,7 +77,7 @@ export function useDebugScraper() {
     const checkStatus = async () => {
       try {
         const res = await AdminSystemService.getDebugStatus();
-        setIsEnabled(res.data.enabled);
+        setIsEnabled(res.enabled);
       } catch {
         setIsEnabled(false);
       }
@@ -86,7 +87,7 @@ export function useDebugScraper() {
     const fetchSystemSettings = async () => {
       try {
         const res = await AdminSystemService.getSystemSettings();
-        setGlobalSettings(res.data);
+        setGlobalSettings(res);
       } catch (e) {
         console.error('Failed to fetch system settings', e);
       }
@@ -170,9 +171,9 @@ export function useDebugScraper() {
     setIsLoading(true);
     try {
       const res = await ProductService.getById(id);
-      if (res.data && res.data.url) {
-        setUrl(res.data.url);
-        showToast(`Loaded product: ${res.data.name || res.data.url}`);
+      if (res && res.url) {
+        setUrl(res.url);
+        showToast(`Loaded product: ${res.name || res.url}`);
         
         // Optionally trigger config fetch if needed, 
         // but url change will likely be enough for the user to then click "Fetch Config" if that's a feature
@@ -180,7 +181,7 @@ export function useDebugScraper() {
         // No, let's keep it simple: just load the URL.
       }
     } catch (err: any) {
-      showToast('Failed to load product: ' + (err.response?.data?.error || err.message), 'error');
+      showToast('Failed to load product: ' + apiErrorMessage(err), 'error');
     } finally {
       setIsLoading(false);
     }
@@ -272,7 +273,7 @@ export function useDebugScraper() {
 
     try {
       const res = await RetailerAdminService.debugExtract(processedUrl, finalConfig, mode, true, useAI, forceAI);
-      setResult(res.data);
+      setResult(res);
       
       // Save to history
       try {
@@ -285,7 +286,7 @@ export function useDebugScraper() {
       } catch {}
       
     } catch (err: any) {
-      showToast(err.response?.data?.error || err.message || 'Failed to run extraction', 'error');
+      showToast(apiErrorMessage(err, 'Failed to run extraction'), 'error');
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/features/notifications/components/NotificationBell.tsx
+++ b/frontend/src/features/notifications/components/NotificationBell.tsx
@@ -1,51 +1,39 @@
-import { useState, useEffect, useRef } from 'react';
-import { NotificationService } from '../services/NotificationService';
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useToast } from '../../../context/ToastContext';
-import { logger } from '../../../utils/logger';
 import './NotificationBell.css';
 import Icon from '../../../components/Icon';
+import { queryClient } from '../../../api/queryClient';
+import { queryKeys, recentNotificationsQuery } from '../../../api/queries';
 
 export default function NotificationBell() {
   const { setDrawerOpen, showToast } = useToast();
-  const [recentCount, setRecentCount] = useState(0);
   const lastCountRef = useRef(0);
+  const recentQuery = useQuery(recentNotificationsQuery(1));
+  const recentCount = recentQuery.data?.unreadCount ?? 0;
 
   useEffect(() => {
-    fetchStatus();
+    const refreshNotifications = () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.notifications.recent(1) });
+    };
+    window.addEventListener('notifications-cleared', refreshNotifications);
+    window.addEventListener('notification-read', refreshNotifications);
 
-    const handleUpdate = () => fetchStatus();
-    window.addEventListener('notifications-cleared', handleUpdate);
-    window.addEventListener('notification-read', handleUpdate);
-
-    // Poll for new notifications every 60 seconds
-    const interval = setInterval(fetchStatus, 60000);
     return () => {
-      clearInterval(interval);
-      window.removeEventListener('notifications-cleared', handleUpdate);
-      window.removeEventListener('notification-read', handleUpdate);
+      window.removeEventListener('notifications-cleared', refreshNotifications);
+      window.removeEventListener('notification-read', refreshNotifications);
     };
   }, []);
 
-  const fetchStatus = async () => {
-    try {
-      const response = await NotificationService.getRecent(1);
-      const data = response.data;
-      const newCount = data.unreadCount || 0;
-      
-      // If we have new unread high-priority alerts, show a toast
-      if (newCount > lastCountRef.current && lastCountRef.current !== 0) {
-        showToast('New notification detected!', 'info', null, {
-          label: 'VIEW',
-          onClick: () => setDrawerOpen(true)
-        });
-      }
-      
-      setRecentCount(newCount);
-      lastCountRef.current = newCount;
-    } catch (error) {
-      logger.error('Failed to fetch notification status', 'Bell', error);
+  useEffect(() => {
+    if (recentCount > lastCountRef.current && lastCountRef.current !== 0) {
+      showToast('New notification detected!', 'info', null, {
+        label: 'VIEW',
+        onClick: () => setDrawerOpen(true),
+      });
     }
-  };
+    lastCountRef.current = recentCount;
+  }, [recentCount, setDrawerOpen, showToast]);
 
   return (
     <div className="notification-bell-wrapper">

--- a/frontend/src/features/notifications/components/NotificationDrawer.tsx
+++ b/frontend/src/features/notifications/components/NotificationDrawer.tsx
@@ -10,7 +10,7 @@ import './NotificationDrawer.css';
 import { getNotificationIcon } from '../pages/utils';
 import Icon from '../../../components/Icon';
 import { queryClient } from '../../../api/queryClient';
-import { queryKeys, recentNotificationsQuery } from '../../../api/queries';
+import { recentNotificationsQuery } from '../../../api/queries';
 
 const NotificationDrawer: React.FC = () => {
   const { user } = useAuth();

--- a/frontend/src/features/notifications/components/NotificationDrawer.tsx
+++ b/frontend/src/features/notifications/components/NotificationDrawer.tsx
@@ -1,29 +1,27 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { NotificationService } from '../services/NotificationService';
-import { NotificationEntry } from '../../../types/api';
 import { useAuth } from '../../auth';
 import { useToast } from '../../../context/ToastContext';
 import { formatPrice, formatRelativeDate } from '../../../utils/format';
 import LoadingSpinner from '../../../components/LoadingSpinner';
-import { logger } from '../../../utils/logger';
 import './NotificationDrawer.css';
 import { getNotificationIcon } from '../pages/utils';
 import Icon from '../../../components/Icon';
+import { queryClient } from '../../../api/queryClient';
+import { queryKeys, recentNotificationsQuery } from '../../../api/queries';
 
 const NotificationDrawer: React.FC = () => {
   const { user } = useAuth();
   const { isDrawerOpen, setDrawerOpen, activityLog, clearActivityLog } = useToast();
   const [activeTab, setActiveTab] = useState<'activity' | 'alerts'>('activity');
-  const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
-  const [loading, setLoading] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isDrawerOpen) {
-      fetchAlerts();
-    }
-  }, [isDrawerOpen]);
+  const recentQuery = useQuery({ ...recentNotificationsQuery(40), enabled: isDrawerOpen });
+  const notifications = recentQuery.data?.notifications?.filter(n => !['session_activity', 'system_info'].includes(n.type)) ?? [];
+  const invalidateNotifications = () => queryClient.invalidateQueries({ queryKey: ['notifications'] });
+  const markAllRead = useMutation({ mutationFn: NotificationService.markAllAsRead, onSuccess: invalidateNotifications });
+  const markRead = useMutation({ mutationFn: NotificationService.markAsRead, onSuccess: invalidateNotifications });
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -37,37 +35,18 @@ const NotificationDrawer: React.FC = () => {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isDrawerOpen, setDrawerOpen]);
 
-  const fetchAlerts = async () => {
-    setLoading(true);
-    try {
-      const response = await NotificationService.getRecent(40);
-      // Alerts are only price/stock/system events
-      setNotifications(response.data.notifications?.filter(n => !['session_activity', 'system_info'].includes(n.type)) || []);
-    } catch (error) {
-      logger.error('Failed to fetch alerts', 'Drawer', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const handleMarkAllRead = async () => {
     try {
-      await NotificationService.markAllAsRead();
-      setNotifications(prev => prev.map(n => ({ ...n, is_read: true })));
+      await markAllRead.mutateAsync();
       window.dispatchEvent(new CustomEvent('notifications-cleared'));
-    } catch (error) {
-      logger.error('Failed to clear alerts', 'Drawer', error);
-    }
+    } catch { /* the drawer remains usable; the next open can retry */ }
   };
 
   const handleMarkRead = async (id: number) => {
     try {
-      await NotificationService.markAsRead(id);
-      setNotifications(prev => prev.map(n => n.id === id ? { ...n, is_read: true } : n));
+      await markRead.mutateAsync(id);
       window.dispatchEvent(new CustomEvent('notification-read', { detail: { id } }));
-    } catch (error) {
-      logger.error('Failed to mark alert as read', 'Drawer', error);
-    }
+    } catch { /* the notification remains unread until a successful retry */ }
   };
 
   if (!isDrawerOpen) return null;
@@ -120,7 +99,7 @@ const NotificationDrawer: React.FC = () => {
               ))
             )
           ) : (
-            loading && notifications.length === 0 ? (
+            recentQuery.isLoading && notifications.length === 0 ? (
               <div className="drawer-empty"><LoadingSpinner size="1.5rem" centered /></div>
             ) : notifications.length === 0 ? (
               <div className="drawer-empty">

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import Layout from '../../../layouts/Layout';
 import { NotificationService } from '../services/NotificationService';
-import { NotificationEntry } from '../../../types/api';
 import { useAuth } from '../../auth';
 import { useToast } from '../../../context/ToastContext';
-import { logger } from '../../../utils/logger';
 
 import NotificationFilters from './NotificationFilters';
 import NotificationTable from './NotificationTable';
@@ -14,61 +13,36 @@ import Tabs, { Tab } from '../../../components/Tabs';
 
 import './NotificationHistoryPage.css';
 import Icon from '../../../components/Icon';
+import { queryClient } from '../../../api/queryClient';
+import { notificationHistoryQuery } from '../../../api/queries';
 
 export default function NotificationHistory() {
   const { user } = useAuth();
   const { activityLog, clearActivityLog } = useToast();
   const [activeTab, setActiveTab] = useState<'activity' | 'alerts'>('activity');
-  const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
-  const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
   const [filter, setFilter] = useState<string>('all');
-
-  useEffect(() => {
-    if (activeTab === 'alerts') {
-      fetchNotifications();
-    }
-  }, [page, activeTab]);
-
-  const fetchNotifications = async () => {
-    setLoading(true);
-    try {
-      const response = await NotificationService.getHistory(page, 20);
-      const data = response.data;
-      // Alerts are only price/stock/system events
-      setNotifications(data.notifications?.filter(n => !['session_activity', 'system_info'].includes(n.type)) || []);
-      if (data.pagination) {
-        setTotalPages(data.pagination.totalPages);
-      }
-    } catch (error) {
-      logger.error('Failed to fetch notification history', 'Notifications', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const historyQuery = useQuery({ ...notificationHistoryQuery(page, 20), enabled: activeTab === 'alerts' });
+  const notifications = historyQuery.data?.notifications?.filter(n => !['session_activity', 'system_info'].includes(n.type)) ?? [];
+  const totalPages = historyQuery.data?.pagination?.totalPages ?? 1;
+  const invalidateNotifications = () => queryClient.invalidateQueries({ queryKey: ['notifications'] });
+  const markAllRead = useMutation({ mutationFn: NotificationService.markAllAsRead, onSuccess: invalidateNotifications });
+  const deleteAll = useMutation({ mutationFn: NotificationService.deleteAll, onSuccess: invalidateNotifications });
 
   const handleMarkAllRead = async () => {
     try {
-      await NotificationService.markAllAsRead();
-      setNotifications(prev => prev.map(n => ({ ...n, is_read: true })));
+      await markAllRead.mutateAsync();
       window.dispatchEvent(new CustomEvent('notifications-cleared'));
-    } catch (error) {
-      logger.error('Failed to mark all as read', 'Notifications', error);
-    }
+    } catch { /* keep the cached state untouched after a failed mutation */ }
   };
 
   const handleClearHistory = async () => {
     if (!window.confirm('Are you sure you want to permanently delete all your alert history?')) return;
     try {
-      await NotificationService.deleteAll();
-      setNotifications([]);
-      setTotalPages(1);
+      await deleteAll.mutateAsync();
       setPage(1);
       window.dispatchEvent(new CustomEvent('notifications-cleared'));
-    } catch (error) {
-      logger.error('Failed to clear notifications', 'Notifications', error);
-    }
+    } catch { /* keep the cached history intact after a failed mutation */ }
   };
 
   const filteredNotifications = useMemo(() => {
@@ -96,14 +70,14 @@ export default function NotificationHistory() {
           <button 
             className="btn btn-secondary btn-sm" 
             onClick={handleMarkAllRead}
-            disabled={loading || notifications.every(n => n.is_read) || notifications.length === 0}
+            disabled={markAllRead.isPending || notifications.every(n => n.is_read) || notifications.length === 0}
           >
             Mark all read
           </button>
           <button 
             className="btn btn-secondary btn-sm" 
             onClick={handleClearHistory}
-            disabled={loading || notifications.length === 0}
+            disabled={deleteAll.isPending || notifications.length === 0}
             style={{ color: 'var(--danger)', borderColor: 'var(--danger)' }}
           >
             Delete all
@@ -134,7 +108,7 @@ export default function NotificationHistory() {
 
             <NotificationTable 
               notifications={filteredNotifications} 
-              loading={loading} 
+              loading={historyQuery.isLoading} 
               userLocale={user?.locale}
             />
 

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
@@ -108,7 +108,7 @@ export default function NotificationHistory() {
 
             <NotificationTable 
               notifications={filteredNotifications} 
-              loading={historyQuery.isLoading} 
+              loading={historyQuery.isLoading}
               userLocale={user?.locale}
             />
 

--- a/frontend/src/features/notifications/services/NotificationService.ts
+++ b/frontend/src/features/notifications/services/NotificationService.ts
@@ -1,12 +1,15 @@
-import { api } from '../../../api/client';
+import { api, type RequestOptions } from '../../../api/client';
 import { NotificationEntry } from '../../../types/api';
 
 export const NotificationService = {
-  getHistory: (page: number = 1, limit: number = 20) =>
-    api.get<{ notifications: NotificationEntry[], pagination: { page: number, limit: number, totalCount: number, totalPages: number } }>(`/notifications/history?page=${page}&limit=${limit}`),
+  getHistory: (page: number = 1, limit: number = 20, options?: RequestOptions) =>
+    api.get<{ notifications: NotificationEntry[], pagination: { page: number, limit: number, totalCount: number, totalPages: number } }>('/notifications/history', {
+      ...options,
+      params: { ...options?.params, page, limit },
+    }),
   
-  getRecent: (limit: number = 10) =>
-    api.get<{ notifications: NotificationEntry[], unreadCount: number }>(`/notifications/recent?limit=${limit}`),
+  getRecent: (limit: number = 10, options?: RequestOptions) =>
+    api.get<{ notifications: NotificationEntry[], unreadCount: number }>('/notifications/recent', { ...options, params: { ...options?.params, limit } }),
   
   markAsRead: (id: number) => api.post(`/notifications/${id}/read`),
   

--- a/frontend/src/features/products/components/ProductForm/ProductForm.tsx
+++ b/frontend/src/features/products/components/ProductForm/ProductForm.tsx
@@ -95,7 +95,6 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
       }
     } catch (err) {
       if (err instanceof Error) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const apiError = isApiError(err) ? err : undefined;
         const status = apiError?.status;
         const body = apiError?.body as { error?: string; message?: string; existingProductId?: number } | undefined;

--- a/frontend/src/features/products/components/ProductForm/ProductForm.tsx
+++ b/frontend/src/features/products/components/ProductForm/ProductForm.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, FormEvent, ReactNode } from 'react';
+import React, { useState, FormEvent, ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import { ProductService } from '../../services/ProductService';
@@ -12,11 +13,14 @@ interface ProductFormProps {
 
 import { REFRESH_INTERVALS } from '../../constants';
 import Icon from '../../../../components/Icon';
+import { isApiError } from '../../../../api/error';
+import { discoveryStatusQuery } from '../../../../api/queries';
 
 const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories }) => {
   const [url, setUrl] = useState('');
   const [mode, setMode] = useState<'url' | 'search'>('url');
-  const [isSearchEnabled, setIsSearchEnabled] = useState(false);
+  const discoveryStatus = useQuery(discoveryStatusQuery());
+  const isSearchEnabled = discoveryStatus.data?.enabled ?? false;
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -27,12 +31,6 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ReactNode>('');
 
-  useEffect(() => {
-    ProductService.getSearchStatus()
-      .then(res => setIsSearchEnabled(res.data.enabled))
-      .catch(() => setIsSearchEnabled(false));
-  }, []);
-
   const handleSearch = async (e: FormEvent) => {
     e.preventDefault();
     if (!searchQuery.trim()) return;
@@ -41,9 +39,9 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
     setError('');
     try {
       const res = await ProductService.search(searchQuery);
-      setSearchResults(res.data);
-    } catch (err: any) {
-      setError('Search failed: ' + (err.response?.data?.error || err.message));
+      setSearchResults(res);
+    } catch (err) {
+      setError('Search failed: ' + (err instanceof Error ? err.message : 'Request failed'));
     } finally {
       setIsSearching(false);
     }
@@ -98,13 +96,14 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
     } catch (err) {
       if (err instanceof Error) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const axiosError = err as any;
-        const status = axiosError.response?.status;
-        const serverError = axiosError.response?.data?.error;
-        const message = axiosError.response?.data?.message;
+        const apiError = isApiError(err) ? err : undefined;
+        const status = apiError?.status;
+        const body = apiError?.body as { error?: string; message?: string; existingProductId?: number } | undefined;
+        const serverError = body?.error;
+        const message = body?.message;
 
         if (status === 409) {
-          const id = axiosError.response?.data?.existingProductId;
+          const id = body?.existingProductId;
           setError(
             <span>
               {message || 'You are already tracking this product.'}{' '}

--- a/frontend/src/features/products/hooks/useDashboardState.ts
+++ b/frontend/src/features/products/hooks/useDashboardState.ts
@@ -1,20 +1,25 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
 import { ProductService } from '../services/ProductService';
-import { ProfileService } from '../../settings/services/ProfileService';
 import { Product, PriceReviewResponse } from '../../../types/api';
 import { useToast } from '../../../context/ToastContext';
 import { isPriceReviewResponse, calculateDashboardSummary } from '../pages/dashboard/utils';
 import { useProductFilters } from './useProductFilters';
 import { useProductActions } from './useProductActions';
 import { truncateUrl } from '../../../utils/format';
+import { productListQuery, profileQuery, queryKeys } from '../../../api/queries';
+import { queryClient } from '../../../api/queryClient';
+import { isApiError } from '../../../api/client';
 
 export function useDashboardState() {
   const { showToast } = useToast();
   const navigate = useNavigate();
-  const [products, setProducts] = useState<Product[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [userCategories, setUserCategories] = useState<string[]>([]);
+  const productsQuery = useQuery(productListQuery());
+  const profile = useQuery(profileQuery());
+  const products = productsQuery.data ?? [];
+  const userCategories = profile.data?.categories ?? [];
+  const loadError = productsQuery.error ?? profile.error;
   const [productToDelete, setProductToDelete] = useState<Product | null>(null);
 
   // Product Actions Hook
@@ -30,14 +35,14 @@ export function useDashboardState() {
     isRefreshing
   } = useProductActions({
     onProductDeleted: (id) => {
-      setProducts(prev => prev.filter(p => p.id !== id));
+      queryClient.setQueryData<Product[]>(queryKeys.products.all, previous => previous?.filter(p => p.id !== id) ?? []);
       setProductToDelete(null);
     },
     onProductDeleteFailed: () => {
       fetchProducts();
     },
     onProductUpdated: (id, data) => {
-      setProducts(prev => prev.map(p => p.id === id ? data : p));
+      queryClient.setQueryData<Product[]>(queryKeys.products.all, previous => previous?.map(p => p.id === id ? data : p) ?? []);
     }
   });
 
@@ -49,37 +54,22 @@ export function useDashboardState() {
   const filterState = useProductFilters({ products, userCategories });
 
   const fetchProducts = useCallback(async () => {
-    try {
-      const [productsRes, profileRes] = await Promise.all([
-        ProductService.getAll(),
-        ProfileService.getProfile()
-      ]);
-      setProducts(productsRes.data);
-      setUserCategories(profileRes.data.categories || []);
-    } catch {
-      showToast('Failed to load products', 'error');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [showToast]);
-
-  useEffect(() => {
-    fetchProducts();
-  }, [fetchProducts]);
+    await Promise.all([productsQuery.refetch(), profile.refetch()]);
+  }, [productsQuery, profile]);
 
   const handleAddProduct = async (url: string, refreshInterval: number, category: string) => {
     try {
       const response = await ProductService.create({ url, refreshInterval, category: category || null });
 
-      if (isPriceReviewResponse(response.data)) {
-        setPriceReviewData(response.data);
+      if (isPriceReviewResponse(response)) {
+        setPriceReviewData(response);
         setPendingRefreshInterval(refreshInterval);
         setShowPriceModal(true);
         return false;
       }
 
-      const newProduct = response.data as Product;
-      setProducts((prev) => [newProduct, ...prev]);
+      const newProduct = response as Product;
+      queryClient.setQueryData<Product[]>(queryKeys.products.all, previous => [newProduct, ...(previous ?? [])]);
       navigate({ to: '/products/$productId', params: { productId: String(newProduct.id) } });
 
       const displayName = newProduct.name || truncateUrl(newProduct.url);
@@ -87,11 +77,11 @@ export function useDashboardState() {
       showToast(`Product added: ${truncatedName}`, 'success');
 
       return true;
-    } catch (err: any) {
-      if (err.response?.status === 409) {
+    } catch (err) {
+      if (isApiError(err) && err.status === 409) {
         showToast('You are already tracking this product.', 'error');
       } else {
-        showToast('Failed to add product', 'error', err.response?.data?.error || err.message);
+        showToast('Failed to add product', 'error', err instanceof Error ? err.message : undefined);
       }
       return false;
     }
@@ -115,9 +105,9 @@ export function useDashboardState() {
         category
       });
 
-      if (!isPriceReviewResponse(response.data)) {
-        const newProduct = response.data as Product;
-        setProducts((prev) => [newProduct, ...prev]);
+      if (!isPriceReviewResponse(response)) {
+        const newProduct = response as Product;
+        queryClient.setQueryData<Product[]>(queryKeys.products.all, previous => [newProduct, ...(previous ?? [])]);
         navigate({ to: '/products/$productId', params: { productId: String(newProduct.id) } });
 
         const displayName = newProduct.name || truncateUrl(newProduct.url);
@@ -128,11 +118,11 @@ export function useDashboardState() {
       setShowPriceModal(false);
       setPriceReviewData(null);
 
-    } catch (err: any) {
-      if (err.response?.status === 409) {
+    } catch (err) {
+      if (isApiError(err) && err.status === 409) {
         showToast('You are already tracking this product.', 'error');
       } else {
-        showToast('Failed to add product', 'error', err.response?.data?.error || err.message);
+        showToast('Failed to add product', 'error', err instanceof Error ? err.message : undefined);
       }
       setShowPriceModal(false);
       setPriceReviewData(null);
@@ -148,19 +138,21 @@ export function useDashboardState() {
     return calculateDashboardSummary(products);
   }, [products]);
 
-  const updateProduct = (id: number, data: any) => {
-    setProducts(prev => prev.map(p => p.id === id ? { ...p, ...data } : p));
+  const updateProduct = (id: number, data: Partial<Product>) => {
+    queryClient.setQueryData<Product[]>(queryKeys.products.all, previous => previous?.map(p => p.id === id ? { ...p, ...data } : p) ?? []);
   };
 
   const removeProduct = (id: number) => {
-    setProducts(prev => prev.filter(p => p.id !== id));
+    queryClient.setQueryData<Product[]>(queryKeys.products.all, previous => previous?.filter(p => p.id !== id) ?? []);
   };
 
   return {
     products,
     updateProduct,
     removeProduct,
-    isLoading: isLoading,
+    isLoading: productsQuery.isLoading || profile.isLoading,
+    loadError,
+    retryLoad: fetchProducts,
     ...filterState,
     dashboardSummary,
     showPriceModal: showPriceModal || showRescanPriceModal,

--- a/frontend/src/features/products/hooks/useProductActions.ts
+++ b/frontend/src/features/products/hooks/useProductActions.ts
@@ -2,6 +2,10 @@ import { useState } from 'react';
 import { ProductService } from '../services/ProductService';
 import { useToast } from '../../../context/ToastContext';
 import { useAsyncAction } from '../../../hooks/useAsyncAction';
+import { apiErrorMessage } from '../../../api/error';
+import { queryClient } from '../../../api/queryClient';
+import { queryKeys } from '../../../api/queries';
+import { syncProductCaches } from '../../../api/productCache';
 import { PriceReviewResponse } from '../../../types/api';
 
 interface UseProductActionsProps {
@@ -21,19 +25,21 @@ export function useProductActions({ onProductDeleted, onProductDeleteFailed, onP
   const handleRefresh = (id: number) => runAction(async () => {
     await ProductService.refreshPrice(id);
     const updatedProductRes = await ProductService.getById(id);
-    if (onProductUpdated) onProductUpdated(id, updatedProductRes.data);
+    syncProductCaches(updatedProductRes);
+    if (onProductUpdated) onProductUpdated(id, updatedProductRes);
   }, { onSuccessMessage: 'Price refreshed', onErrorFallback: 'Failed to refresh price' });
 
   const handleRescan = (id: number) => runAction(async () => {
     setActiveProductId(id);
     const res = await ProductService.scan(id);
-    setPriceReviewData(res.data);
+    setPriceReviewData(res);
     setShowPriceModal(true);
   }, { onErrorMessage: 'Failed to start re-scan' });
 
   const handleDelete = (id: number) => {
     return runAction(async () => {
       await ProductService.delete(id);
+      queryClient.removeQueries({ queryKey: queryKeys.products.detail(id) });
       if (onProductDeleted) onProductDeleted(id);
     }, { 
       onSuccessMessage: 'Product deleted', 
@@ -47,7 +53,8 @@ export function useProductActions({ onProductDeleted, onProductDeleteFailed, onP
 
   const handleTogglePause = (id: number, targetPaused: boolean) => runAction(async () => {
     const res = await ProductService.update(id, { checking_paused: targetPaused });
-    if (onProductUpdated) onProductUpdated(id, res.data);
+    syncProductCaches(res);
+    if (onProductUpdated) onProductUpdated(id, res);
   }, { onSuccessMessage: targetPaused ? 'Tracking paused' : 'Tracking resumed', onErrorFallback: 'Failed to toggle pause state' });
 
   const handlePriceSelected = async (selectedPrice: number, selectedMethod: string, selectedCurrency: string, _category: string | null, selector?: string) => {
@@ -65,13 +72,14 @@ export function useProductActions({ onProductDeleted, onProductDeleteFailed, onP
         selector
       });
       
-      if (onProductUpdated) onProductUpdated(activeProductId, res.data);
+      syncProductCaches(res);
+      if (onProductUpdated) onProductUpdated(activeProductId, res);
       setShowPriceModal(false);
       setPriceReviewData(null);
       setActiveProductId(null);
       showToast('Product updated via re-scan', 'success');
     } catch (err: any) {
-      showToast('Failed to confirm selection', 'error', err.response?.data?.error || err.message);
+      showToast('Failed to confirm selection', 'error', apiErrorMessage(err));
     }
   };
 

--- a/frontend/src/features/products/hooks/useProductActions.ts
+++ b/frontend/src/features/products/hooks/useProductActions.ts
@@ -6,7 +6,7 @@ import { apiErrorMessage } from '../../../api/error';
 import { queryClient } from '../../../api/queryClient';
 import { queryKeys } from '../../../api/queries';
 import { syncProductCaches } from '../../../api/productCache';
-import { PriceReviewResponse } from '../../../types/api';
+import { PriceReviewResponse, Product } from '../../../types/api';
 
 interface UseProductActionsProps {
   onProductDeleted?: (id: number) => void;
@@ -40,6 +40,9 @@ export function useProductActions({ onProductDeleted, onProductDeleteFailed, onP
     return runAction(async () => {
       await ProductService.delete(id);
       queryClient.removeQueries({ queryKey: queryKeys.products.detail(id) });
+      queryClient.setQueryData<Product[]>(queryKeys.products.all, (products) =>
+        products?.filter((product) => product.id !== id) ?? [],
+      );
       if (onProductDeleted) onProductDeleted(id);
     }, { 
       onSuccessMessage: 'Product deleted', 

--- a/frontend/src/features/products/hooks/useProductDetailState.ts
+++ b/frontend/src/features/products/hooks/useProductDetailState.ts
@@ -4,6 +4,9 @@ import { ProductService } from '../services/ProductService';
 import { ProfileService } from '../../settings/services/ProfileService';
 import { useAsyncAction } from '../../../hooks/useAsyncAction';
 import { useProductActions } from './useProductActions';
+import { queryClient } from '../../../api/queryClient';
+import { priceHistoryQuery, productDetailQuery, profileQuery } from '../../../api/queries';
+import { syncProductCaches } from '../../../api/productCache';
 import { 
   ProductWithStats, 
   PriceHistory, 
@@ -69,34 +72,34 @@ export function useProductDetailState(
 
   const fetchData = (days?: number) => runFetch(async () => {
     const [productRes, pricesRes, profileRes] = await Promise.all([
-      ProductService.getById(productId),
-      ProductService.getPriceHistory(productId, days),
-      ProfileService.getProfile(),
+      queryClient.fetchQuery(productDetailQuery(productId)),
+      queryClient.fetchQuery(priceHistoryQuery(productId, days ?? 30)),
+      queryClient.fetchQuery(profileQuery()),
     ]);
-    setProduct(productRes.data);
-    setPrices(pricesRes.data.prices);
-    setEditName(productRes.data.name || '');
-    setEditCategories(productRes.data.category ? productRes.data.category.split(',').map((c: string) => c.trim()).filter(Boolean) : []);
-    setEditImageUrl(productRes.data.image_url || '');
+    setProduct(productRes);
+    setPrices(pricesRes.prices);
+    setEditName(productRes.name || '');
+    setEditCategories(productRes.category ? productRes.category.split(',').map((c: string) => c.trim()).filter(Boolean) : []);
+    setEditImageUrl(productRes.image_url || '');
     
-    setAvailableCategories(profileRes.data.categories || []);
+    setAvailableCategories(profileRes.categories || []);
 
-    if (productRes.data.price_drop_threshold !== null && productRes.data.price_drop_threshold !== undefined) {
-      setPriceDropThreshold(productRes.data.price_drop_threshold.toString());
+    if (productRes.price_drop_threshold !== null && productRes.price_drop_threshold !== undefined) {
+      setPriceDropThreshold(productRes.price_drop_threshold.toString());
     }
-    if (productRes.data.target_price !== null && productRes.data.target_price !== undefined) {
-      setTargetPrice(productRes.data.target_price.toString());
+    if (productRes.target_price !== null && productRes.target_price !== undefined) {
+      setTargetPrice(productRes.target_price.toString());
     }
-    setNotifyBackInStock(productRes.data.notify_back_in_stock || false);
-    setAiVerificationDisabled(productRes.data.ai_verification_disabled || false);
-    setAiExtractionDisabled(productRes.data.ai_extraction_disabled || false);
-    setCheckingPaused(productRes.data.checking_paused || false);
+    setNotifyBackInStock(productRes.notify_back_in_stock || false);
+    setAiVerificationDisabled(productRes.ai_verification_disabled || false);
+    setAiExtractionDisabled(productRes.ai_extraction_disabled || false);
+    setCheckingPaused(productRes.checking_paused || false);
   }, { onErrorFallback: 'Failed to load product details' });
 
   const fetchNotificationSettings = async () => {
     try {
       const response = await ProfileService.getNotificationSettings();
-      setNotificationSettings(response.data);
+      setNotificationSettings(response);
     } catch {
       // Silently fail
     }
@@ -115,16 +118,18 @@ export function useProductDetailState(
       setIsEditingName(false);
       return;
     }
-    await ProductService.update(productId, { name: editName });
-    setProduct({ ...product, name: editName });
+    const updated = await ProductService.update(productId, { name: editName });
+    syncProductCaches(updated);
+    setProduct({ ...product, ...updated });
     setIsEditingName(false);
     if (onUpdated) onUpdated(productId, { name: editName });
   }, { onSuccessMessage: 'Product name updated', onErrorFallback: 'Failed to update name' });
 
   const handleSaveImage = () => runSave(async () => {
     if (!product) return;
-    await ProductService.update(productId, { image_url: editImageUrl });
-    setProduct({ ...product, image_url: editImageUrl });
+    const updated = await ProductService.update(productId, { image_url: editImageUrl });
+    syncProductCaches(updated);
+    setProduct({ ...product, ...updated });
     setIsEditingImage(false);
     if (onUpdated) onUpdated(productId, { image_url: editImageUrl });
   }, { onSuccessMessage: 'Image URL updated', onErrorFallback: 'Failed to update image' });
@@ -132,8 +137,9 @@ export function useProductDetailState(
   const handleSaveCategory = () => runSave(async () => {
     if (!product) return;
     const catString = editCategories.join(', ');
-    await ProductService.update(productId, { category: catString });
-    setProduct({ ...product, category: catString });
+    const updated = await ProductService.update(productId, { category: catString });
+    syncProductCaches(updated);
+    setProduct({ ...product, ...updated });
     setIsEditingCategory(false);
     if (onUpdated) onUpdated(productId, { category: catString });
   }, { onSuccessMessage: 'Categories updated', onErrorFallback: 'Failed to update categories' });
@@ -165,8 +171,9 @@ export function useProductDetailState(
       ai_extraction_disabled: aiExtractionDisabled,
       checking_paused: checkingPaused
     };
-    await ProductService.update(productId, data);
-    setProduct({ ...product, ...data });
+    const updated = await ProductService.update(productId, data);
+    syncProductCaches(updated);
+    setProduct({ ...product, ...updated });
     if (onUpdated) onUpdated(productId, data);
   }, { onSuccessMessage: 'Settings updated', onErrorFallback: 'Failed to update settings' });
 
@@ -179,8 +186,9 @@ export function useProductDetailState(
 
   const handleRefreshIntervalChange = (newInterval: number) => runSave(async () => {
     if (!product) return;
-    await ProductService.update(productId, { refresh_interval: newInterval });
-    setProduct({ ...product, refresh_interval: newInterval });
+    const updated = await ProductService.update(productId, { refresh_interval: newInterval });
+    syncProductCaches(updated);
+    setProduct({ ...product, ...updated });
     if (onUpdated) onUpdated(productId, { refresh_interval: newInterval });
   }, { onSuccessMessage: 'Check interval updated', onErrorFallback: 'Failed to update refresh interval' });
 

--- a/frontend/src/features/products/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/products/pages/dashboard/DashboardPage.tsx
@@ -13,6 +13,8 @@ const Dashboard: React.FC = () => {
   const {
     products,
     isLoading,
+    loadError,
+    retryLoad,
     searchQuery,
     setSearchQuery,
     pauseFilter,
@@ -87,7 +89,14 @@ const Dashboard: React.FC = () => {
 
       <div className="section-container">
         <main className="dashboard-main">
-          <>
+          {loadError ? (
+            <div className="alert alert-error">
+              <span>Failed to load products. Please try again.</span>
+              <button type="button" className="btn btn-secondary" onClick={() => void retryLoad()}>
+                Retry
+              </button>
+            </div>
+          ) : <>
                 {!isLoading && products.length > 0 && (
                   <DashboardControls
                     searchQuery={searchQuery}
@@ -118,7 +127,7 @@ const Dashboard: React.FC = () => {
                   hasAnyProducts={products.length > 0}
                   onSelect={(id) => navigate({ to: '/products/$productId', params: { productId: String(id) } })}
                 />
-          </>
+          </>}
         </main>
       </div>
     </Layout>

--- a/frontend/src/features/products/pages/product-detail/StockAvailabilitySection.tsx
+++ b/frontend/src/features/products/pages/product-detail/StockAvailabilitySection.tsx
@@ -1,39 +1,20 @@
-import React, { useState, useEffect } from 'react';
-import { ProductService } from '../../services/ProductService';
-import { StockStatusHistoryEntry, StockStatusStats } from '../../../../types/api';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import StockTimeline from '../../components/StockTimeline';
 import StockHistoryList from '../../components/StockHistoryList';
+import { stockHistoryQuery } from '../../../../api/queries';
 
 interface StockAvailabilitySectionProps {
   productId: number;
 }
 
 const StockAvailabilitySection: React.FC<StockAvailabilitySectionProps> = ({ productId }) => {
-  const [history, setHistory] = useState<StockStatusHistoryEntry[]>([]);
-  const [stats, setStats] = useState<StockStatusStats | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const stockQuery = useQuery(stockHistoryQuery(productId, 30));
+  const history = stockQuery.data?.history ?? [];
+  const stats = stockQuery.data?.stats ?? null;
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setIsLoading(true);
-        const response = await ProductService.getStockHistory(productId, 30);
-        setHistory(response.data.history);
-        setStats(response.data.stats);
-        setError(null);
-      } catch {
-        setError('Failed to load stock history');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [productId]);
-
-  if (isLoading) {
+  if (stockQuery.isLoading) {
     return (
       <div className="stock-timeline-loading" style={{ display: 'flex', justifyContent: 'center', padding: '3rem 0' }}>
         <LoadingSpinner centered />
@@ -41,8 +22,12 @@ const StockAvailabilitySection: React.FC<StockAvailabilitySectionProps> = ({ pro
     );
   }
 
-  if (error) {
-    return <div className="alert alert-error">{error}</div>;
+  if (stockQuery.isError) {
+    return (
+      <div className="alert alert-error">
+        Failed to load stock history. <button className="btn btn-secondary btn-sm" onClick={() => void stockQuery.refetch()}>Retry</button>
+      </div>
+    );
   }
 
   if (!stats || history.length === 0) {

--- a/frontend/src/features/products/services/ProductService.ts
+++ b/frontend/src/features/products/services/ProductService.ts
@@ -1,4 +1,4 @@
-import { api } from '../../../api/client';
+import { api, type RequestOptions } from '../../../api/client';
 import { 
   Product, 
   ProductWithStats, 
@@ -11,9 +11,9 @@ import {
 } from '../../../types/api';
 
 export const ProductService = {
-  getAll: () => api.get<Product[]>('/products'),
+  getAll: (options?: RequestOptions) => api.get<Product[]>('/products', options),
 
-  getById: (id: number) => api.get<ProductWithStats>(`/products/${id}`),
+  getById: (id: number, options?: RequestOptions) => api.get<ProductWithStats>(`/products/${id}`, options),
 
   create: (data: {
     url: string,
@@ -62,20 +62,26 @@ export const ProductService = {
   bulkPause: (ids: number[], paused: boolean) => 
     api.post('/products/bulk/pause', { ids, paused }),
 
-  getSearchStatus: () =>
-    api.get<{ enabled: boolean }>('/settings/discovery/status'),
+  getSearchStatus: (options?: RequestOptions) =>
+    api.get<{ enabled: boolean }>('/settings/discovery/status', options),
 
   search: (query: string) => 
     api.get<SearchResult[]>('/products/search', { params: { q: query } }),
 
   // Price related
-  getPriceHistory: (productId: number, days?: number) =>
-    api.get<{ product: Product; prices: PriceHistory[] }>(`/prices/${productId}/history${days ? `?days=${days}` : ''}`),
+  getPriceHistory: (productId: number, days?: number, options?: RequestOptions) =>
+    api.get<{ product: Product; prices: PriceHistory[] }>(`/prices/${productId}/history`, {
+      ...options,
+      params: { ...options?.params, ...(days ? { days } : {}) },
+    }),
 
   refreshPrice: (productId: number) =>
     api.post<{ price: number; currency: string }>(`/prices/${productId}/refresh`),
 
   // Stock related
-  getStockHistory: (productId: number, days?: number) =>
-    api.get<{ history: ProductSourceHistory[], stats: StockStatusStats }>(`/prices/${productId}/stock-history${days ? `?days=${days}` : ''}`),
+  getStockHistory: (productId: number, days?: number, options?: RequestOptions) =>
+    api.get<{ history: ProductSourceHistory[], stats: StockStatusStats }>(`/prices/${productId}/stock-history`, {
+      ...options,
+      params: { ...options?.params, ...(days ? { days } : {}) },
+    }),
 };

--- a/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
+++ b/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
@@ -4,6 +4,9 @@ import { useToast } from '../../../context/ToastContext';
 import PasswordInput from '../../../components/PasswordInput';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import NotificationChannelCard from '../components/NotificationChannelCard';
+import { queryClient } from '../../../api/queryClient';
+import { notificationSettingsQuery, queryKeys } from '../../../api/queries';
+import { NotificationSettings } from '../../../types/api';
 
 const DEFAULT_EMAIL_SUBJECT = 'PriceStalker Alert: {{product_name}}';
 const DEFAULT_EMAIL_BODY = 'Hi,\n\n{{product_name}} has dropped to {{current_price}}!\n\nView it here: {{product_url}}';
@@ -65,8 +68,8 @@ export default function NotificationChannelsSection() {
 
   const fetchSettings = async () => {
     try {
-      const res = await ProfileService.getNotificationSettings();
-      const s = res.data;
+      const res = await queryClient.fetchQuery(notificationSettingsQuery());
+      const s = res;
       setDraftSettings({
         telegram_bot_token: s.telegram_bot_token || '',
         telegram_chat_id: s.telegram_chat_id || '',
@@ -109,7 +112,8 @@ export default function NotificationChannelsSection() {
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      await ProfileService.updateNotificationSettings(draftSettings);
+      const updated = await ProfileService.updateNotificationSettings(draftSettings);
+      queryClient.setQueryData<NotificationSettings>(queryKeys.notificationSettings, updated);
       showToast('Notification settings saved', 'success');
     } catch { 
       showToast('Save failed', 'error'); 

--- a/frontend/src/features/settings/pages/ProfileSection.tsx
+++ b/frontend/src/features/settings/pages/ProfileSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { ProfileService } from '../services/ProfileService';
 import { UserProfile } from '../../../types/api';
@@ -12,6 +12,7 @@ export default function ProfileSection() {
   const { showToast } = useToast();
   const { updateUser } = useAuth();
   const [profileName, setProfileName] = useState('');
+  const initializedProfileId = useRef<number | null>(null);
   const profileResult = useQuery(profileQuery());
   const profile = profileResult.data ?? null;
   const updateProfile = useMutation({
@@ -20,7 +21,9 @@ export default function ProfileSection() {
   });
 
   useEffect(() => {
-    if (profile) setProfileName(profile.name || '');
+    if (!profile || initializedProfileId.current === profile.id) return;
+    initializedProfileId.current = profile.id;
+    setProfileName(profile.name || '');
   }, [profile]);
 
   const handleSaveProfile = async () => {

--- a/frontend/src/features/settings/pages/ProfileSection.tsx
+++ b/frontend/src/features/settings/pages/ProfileSection.tsx
@@ -1,54 +1,44 @@
 import { useState, useEffect } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { ProfileService } from '../services/ProfileService';
 import { UserProfile } from '../../../types/api';
 import { useToast } from '../../../context/ToastContext';
 import { useAuth } from '../../auth';
 import LoadingSpinner from '../../../components/LoadingSpinner';
+import { queryClient } from '../../../api/queryClient';
+import { profileQuery, queryKeys } from '../../../api/queries';
 
 export default function ProfileSection() {
   const { showToast } = useToast();
   const { updateUser } = useAuth();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
   const [profileName, setProfileName] = useState('');
-  const [isSaving, setIsSaving] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const profileResult = useQuery(profileQuery());
+  const profile = profileResult.data ?? null;
+  const updateProfile = useMutation({
+    mutationFn: ProfileService.updateProfile,
+    onSuccess: (profile) => queryClient.setQueryData<UserProfile>(queryKeys.profile, profile),
+  });
 
   useEffect(() => {
-    fetchProfile();
-  }, []);
-
-  const fetchProfile = async () => {
-    try {
-      const res = await ProfileService.getProfile();
-      setProfile(res.data);
-      setProfileName(res.data.name || '');
-    } catch {
-      showToast('Failed to load profile', 'error');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    if (profile) setProfileName(profile.name || '');
+  }, [profile]);
 
   const handleSaveProfile = async () => {
-    if (isSaving) return;
-    setIsSaving(true);
     try {
-      const res = await ProfileService.updateProfile({
+      const res = await updateProfile.mutateAsync({
         name: profileName,
         currency: profile?.currency || 'AUD',
         locale: profile?.locale || 'en-AU',
         preferred_currency: profile?.currency || 'AUD'
       });
-      setProfile(res.data);
-      updateUser({ name: res.data.name, currency: res.data.currency, locale: res.data.locale });
+      updateUser({ name: res.name, currency: res.currency, locale: res.locale });
       showToast('Profile updated', 'success');
     } catch {
       showToast('Failed to update profile', 'error');
-    } finally {
-      setIsSaving(false);
     }
   };
-  if (isLoading) return <LoadingSpinner centered />;
+  if (profileResult.isLoading) return <LoadingSpinner centered />;
+  if (profileResult.isError || !profile) return <div className="alert alert-error">Failed to load profile. <button className="btn btn-secondary btn-sm" onClick={() => void profileResult.refetch()}>Retry</button></div>;
 
   return (
     <section className="settings-card">
@@ -63,9 +53,9 @@ export default function ProfileSection() {
       </div>
 
       <div className="settings-actions">
-        <button className="btn btn-secondary" onClick={fetchProfile}>Cancel</button>
-        <button className="btn btn-primary" onClick={handleSaveProfile} disabled={isSaving}>
-          {isSaving ? 'Saving...' : 'Save Profile'}
+        <button className="btn btn-secondary" onClick={() => setProfileName(profile.name || '')}>Cancel</button>
+        <button className="btn btn-primary" onClick={handleSaveProfile} disabled={updateProfile.isPending}>
+          {updateProfile.isPending ? 'Saving...' : 'Save Profile'}
         </button>
       </div>
     </section>

--- a/frontend/src/features/settings/pages/RegionalSection.tsx
+++ b/frontend/src/features/settings/pages/RegionalSection.tsx
@@ -1,63 +1,51 @@
 import { useState, useEffect } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { ProfileService } from '../services/ProfileService';
-import { SharedService } from '../../../services/SharedService';
 import { UserProfile, GlobalCurrency } from '../../../types/api';
 import { useToast } from '../../../context/ToastContext';
 import { useAuth } from '../../auth';
 import SearchableSelect from '../../../components/SearchableSelect';
 import LoadingSpinner from '../../../components/LoadingSpinner';
+import { queryClient } from '../../../api/queryClient';
+import { currenciesQuery, profileQuery, queryKeys } from '../../../api/queries';
 
 export default function RegionalSection() {
   const { showToast } = useToast();
   const { updateUser } = useAuth();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
   const [profileCurrency, setProfileCurrency] = useState('AUD');
   const [profileLocale, setProfileLocale] = useState('en-AU');
-  const [globalCurrencies, setGlobalCurrencies] = useState<GlobalCurrency[]>([]);
-  const [isSaving, setIsSaving] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const profileResult = useQuery(profileQuery());
+  const currenciesResult = useQuery(currenciesQuery());
+  const profile = profileResult.data ?? null;
+  const globalCurrencies: GlobalCurrency[] = currenciesResult.data ?? [];
+  const updateProfile = useMutation({
+    mutationFn: ProfileService.updateProfile,
+    onSuccess: (profile) => queryClient.setQueryData<UserProfile>(queryKeys.profile, profile),
+  });
 
   useEffect(() => {
-    fetchData();
-  }, []);
-
-  const fetchData = async () => {
-    try {
-      const [profileRes, currenciesRes] = await Promise.all([
-        ProfileService.getProfile(),
-        SharedService.getCurrencies(),
-      ]);
-      setProfile(profileRes.data);
-      setProfileCurrency(profileRes.data.currency || 'AUD');
-      setProfileLocale(profileRes.data.locale || 'en-AU');
-      setGlobalCurrencies(currenciesRes.data || []);
-    } catch {
-      showToast('Failed to load regional settings', 'error');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    if (!profile) return;
+    setProfileCurrency(profile.currency || 'AUD');
+    setProfileLocale(profile.locale || 'en-AU');
+  }, [profile]);
 
   const handleSaveRegional = async () => {
-    setIsSaving(true);
     try {
-      const res = await ProfileService.updateProfile({ 
+      const res = await updateProfile.mutateAsync({ 
         name: profile?.name || '', 
         currency: profileCurrency, 
         locale: profileLocale, 
         preferred_currency: profileCurrency 
       });
-      setProfile(res.data);
-      updateUser({ name: res.data.name, currency: res.data.currency, locale: res.data.locale });
+      updateUser({ name: res.name, currency: res.currency, locale: res.locale });
       showToast('Regional settings updated', 'success');
     } catch {
       showToast('Failed to update regional settings', 'error');
-    } finally {
-      setIsSaving(false);
     }
   };
 
-  if (isLoading) return <LoadingSpinner centered />;
+  if (profileResult.isLoading || currenciesResult.isLoading) return <LoadingSpinner centered />;
+  if (profileResult.isError || currenciesResult.isError || !profile) return <div className="alert alert-error">Failed to load regional settings. <button className="btn btn-secondary btn-sm" onClick={() => { void profileResult.refetch(); void currenciesResult.refetch(); }}>Retry</button></div>;
 
   return (
     <section className="settings-card">
@@ -98,9 +86,9 @@ export default function RegionalSection() {
       </div>
 
       <div className="settings-actions">
-        <button className="btn btn-secondary" onClick={fetchData}>Cancel</button>
-        <button className="btn btn-primary" onClick={handleSaveRegional} disabled={isSaving}>
-          {isSaving ? 'Saving...' : 'Save Regional Settings'}
+        <button className="btn btn-secondary" onClick={() => { setProfileCurrency(profile.currency || 'AUD'); setProfileLocale(profile.locale || 'en-AU'); }}>Cancel</button>
+        <button className="btn btn-primary" onClick={handleSaveRegional} disabled={updateProfile.isPending}>
+          {updateProfile.isPending ? 'Saving...' : 'Save Regional Settings'}
         </button>
       </div>
     </section>

--- a/frontend/src/features/settings/pages/RegionalSection.tsx
+++ b/frontend/src/features/settings/pages/RegionalSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { ProfileService } from '../services/ProfileService';
 import { UserProfile, GlobalCurrency } from '../../../types/api';
@@ -14,6 +14,7 @@ export default function RegionalSection() {
   const { updateUser } = useAuth();
   const [profileCurrency, setProfileCurrency] = useState('AUD');
   const [profileLocale, setProfileLocale] = useState('en-AU');
+  const initializedProfileId = useRef<number | null>(null);
   const profileResult = useQuery(profileQuery());
   const currenciesResult = useQuery(currenciesQuery());
   const profile = profileResult.data ?? null;
@@ -24,14 +25,15 @@ export default function RegionalSection() {
   });
 
   useEffect(() => {
-    if (!profile) return;
+    if (!profile || initializedProfileId.current === profile.id) return;
+    initializedProfileId.current = profile.id;
     setProfileCurrency(profile.currency || 'AUD');
     setProfileLocale(profile.locale || 'en-AU');
   }, [profile]);
 
   const handleSaveRegional = async () => {
     try {
-      const res = await updateProfile.mutateAsync({ 
+      const res = await updateProfile.mutateAsync({
         name: profile?.name || '', 
         currency: profileCurrency, 
         locale: profileLocale, 

--- a/frontend/src/features/settings/pages/SecuritySection.tsx
+++ b/frontend/src/features/settings/pages/SecuritySection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ProfileService } from '../services/ProfileService';
 import { useToast } from '../../../context/ToastContext';
+import { apiErrorMessage } from '../../../api/error';
 import PasswordInput from '../../../components/PasswordInput';
 
 export default function SecuritySection() {
@@ -21,7 +22,7 @@ export default function SecuritySection() {
       showToast('Password updated', 'success'); 
       setCurrentPassword(''); setNewPassword(''); setConfirmPassword(''); 
     }
-    catch (err: any) { showToast(err.response?.data?.error || 'Failed to update password'); }
+    catch (err) { showToast(apiErrorMessage(err, 'Failed to update password')); }
     finally { setIsSaving(false); }
   };
 

--- a/frontend/src/features/settings/services/ProfileService.ts
+++ b/frontend/src/features/settings/services/ProfileService.ts
@@ -1,8 +1,8 @@
-import { api } from '../../../api/client';
+import { api, type RequestOptions } from '../../../api/client';
 import { UserProfile, NotificationSettings } from '../../../types/api';
 
 export const ProfileService = {
-  getProfile: () => api.get<UserProfile>('/profile'),
+  getProfile: (options?: RequestOptions) => api.get<UserProfile>('/profile', options),
 
   updateProfile: (data: { name?: string; currency?: string; locale?: string; preferred_currency?: string }) =>
     api.put<UserProfile>('/profile', data),
@@ -10,8 +10,8 @@ export const ProfileService = {
   changePassword: (current: string, next: string) => 
     api.put('/profile/password', { current_password: current, new_password: next }),
 
-  getNotificationSettings: () =>
-    api.get<NotificationSettings>('/settings/notifications'),
+  getNotificationSettings: (options?: RequestOptions) =>
+    api.get<NotificationSettings>('/settings/notifications', options),
 
   updateNotificationSettings: (data: Partial<NotificationSettings>) =>
     api.put<NotificationSettings>('/settings/notifications', data),

--- a/frontend/src/hooks/useAsyncAction.ts
+++ b/frontend/src/hooks/useAsyncAction.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { apiErrorMessage } from '../api/error';
 import { useToast } from '../context/ToastContext';
 
 interface UseAsyncActionOptions {
@@ -26,7 +27,7 @@ export function useAsyncAction(initialLoadingState = false) {
       }
       return result;
     } catch (err: any) {
-      const errorStr = err.response?.data?.error || err.message;
+      const errorStr = apiErrorMessage(err);
       const msg = options?.onErrorMessage 
         ? `${options.onErrorMessage}: ${errorStr}`
         : (options?.onErrorFallback || 'An error occurred');

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -2,15 +2,18 @@ import { createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import LoadingSpinner from './components/LoadingSpinner';
 import type { AuthContextType } from './features/auth/context/AuthContext';
+import type { QueryClient } from '@tanstack/react-query';
 
 export interface RouterContext {
   auth: AuthContextType;
+  queryClient: QueryClient;
 }
 
 export const router = createRouter({
   routeTree,
-  context: { auth: undefined! },
+  context: { auth: undefined!, queryClient: undefined! },
   defaultPreload: 'intent',
+  defaultPreloadStaleTime: 0,
   defaultPendingComponent: () => <LoadingSpinner fullPage size="3rem" />,
 });
 

--- a/frontend/src/routes/_authenticated/products/$productId/route.tsx
+++ b/frontend/src/routes/_authenticated/products/$productId/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 import ProductDetail from '../../../../pages/ProductDetail';
+import { productDetailQuery, profileQuery } from '../../../../api/queries';
 
 function validProductId(value: string): boolean {
   const id = Number(value);
@@ -9,6 +10,11 @@ function validProductId(value: string): boolean {
 export const Route = createFileRoute('/_authenticated/products/$productId')({
   beforeLoad: ({ params }) => {
     if (!validProductId(params.productId)) throw redirect({ to: '/products', replace: true });
+  },
+  loader: ({ context, params }) => {
+    const productId = Number(params.productId);
+    void context.queryClient.prefetchQuery(productDetailQuery(productId));
+    void context.queryClient.prefetchQuery(profileQuery());
   },
   component: () => <ProductDetail productId={Number(Route.useParams().productId)}><Outlet /></ProductDetail>,
 });

--- a/frontend/src/routes/_authenticated/products/index.tsx
+++ b/frontend/src/routes/_authenticated/products/index.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
 import Dashboard from '../../../pages/Dashboard';
+import { productListQuery, profileQuery } from '../../../api/queries';
 
 export const Route = createFileRoute('/_authenticated/products/')({
   validateSearch: (search): { category?: string } => ({ category: typeof search.category === 'string' && search.category.length > 0 ? search.category : undefined }),
+  loader: ({ context }) => {
+    void context.queryClient.prefetchQuery(productListQuery());
+    void context.queryClient.prefetchQuery(profileQuery());
+  },
   component: Dashboard,
 });

--- a/frontend/src/services/SharedService.ts
+++ b/frontend/src/services/SharedService.ts
@@ -1,6 +1,6 @@
-import { api } from '../api/client';
+import { api, type RequestOptions } from '../api/client';
 import { GlobalCurrency } from '../types/api';
 
 export const SharedService = {
-  getCurrencies: () => api.get<GlobalCurrency[]>('/settings/currencies'),
+  getCurrencies: (options?: RequestOptions) => api.get<GlobalCurrency[]>('/settings/currencies', options),
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,12 +114,12 @@ importers:
 
   frontend:
     dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.3
+        version: 5.100.3(react@19.2.8)
       '@tanstack/react-router':
         specifier: 1.168.14
         version: 1.168.14(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      axios:
-        specifier: 1.18.1
-        version: 1.18.1
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -151,6 +151,9 @@ importers:
       vite:
         specifier: 8.1.5
         version: 8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@20.19.39)(jsdom@29.1.1)(vite@8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
 
   remotescraper:
     dependencies:
@@ -1004,6 +1007,14 @@ packages:
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/query-core@5.100.3':
+    resolution: {integrity: sha512-oMO1imV4qStH+GqddafkI7Q7r2ktPL7/0Mu74W1XEhfHHd3oTIrwP3OOIsbtpnnbe8y/IU+8Lm7Bi2LlMhVdNA==}
+
+  '@tanstack/react-query@5.100.3':
+    resolution: {integrity: sha512-8Fgb4vKmBHllRHUjz3ZOwgV0v9b7cxCdN5T0iFQvvWJJVs6xvaxHERO1BclTL03bbK8vZAuXVKN3IeVS1sUdeQ==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tanstack/react-router@1.168.14':
     resolution: {integrity: sha512-p3TRwTuYtElG8u3L1MRX2dCLkTqmirw2qU/QwYfrFXa55dC1dtqO8275hKk4KEmgqzv/ENWdsPg6QsyB9zlIWw==}
     engines: {node: '>=20.19'}
@@ -1473,10 +1484,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1541,9 +1548,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.18.1:
-    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -2413,10 +2417,6 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4725,6 +4725,13 @@ snapshots:
 
   '@tanstack/history@1.162.0': {}
 
+  '@tanstack/query-core@5.100.3': {}
+
+  '@tanstack/react-query@5.100.3(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.100.3
+      react: 19.2.8
+
   '@tanstack/react-router@1.168.14(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -5169,6 +5176,14 @@ snapshots:
     optionalDependencies:
       vite: 8.1.5(@types/node@20.19.39)(esbuild@0.20.2)(jiti@2.7.0)(tsx@4.21.0)
 
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
@@ -5235,12 +5250,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
@@ -5293,16 +5302,6 @@ snapshots:
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-
-  axios@1.18.1:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   b4a@1.8.0: {}
 
@@ -6255,13 +6254,6 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -7671,6 +7663,34 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.5(@types/node@20.19.39)(esbuild@0.20.2)(jiti@2.7.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@20.19.39)(jsdom@29.1.1)(vite@8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39


### PR DESCRIPTION
## Why

The frontend used Axios response-shaped APIs and independent component fetch lifecycles, which made cancellation, auth-expiry cleanup, cache freshness, and error handling inconsistent. This change modernizes the client-only frontend around native Fetch and TanStack Query while keeping Axios unchanged in the backend and remote scraper, where its proxy and scraper transport remains required.

## What changed

- Replaced frontend Axios with a typed Fetch client and normalized API error handling.
- Added shared TanStack Query cache configuration, route prefetching, auth-expiry cache clearing, and canonical mutation cache updates.
- Migrated product, history, notifications, settings, discovery, retailer, and shared admin data paths to centralized query options.
- Removed notification and retailer polling in favor of cache invalidation and focus/reconnect refetching.
- Added API, route, auth-expiry, cache, and notification-history regression coverage.

## Verification

- pnpm --filter pricestalker-frontend run build
- pnpm --filter pricestalker-frontend test
- pnpm --filter pricestalker-frontend run test:routes
- pnpm run lint
- git diff --check