### PR TITLE
feat(regional): add targeted locale formats and neutral defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- New accounts now start with automatic browser locale formatting and no
+  conversion-currency preference; existing regional settings are unchanged.
+- Exchange-rate refreshes now use Frankfurter v2's EUR-based daily reference
+  rates and retain the rate date/source for conversion metadata.
 - Replaced the frontend Axios client with native Fetch and TanStack Query-backed server-state caching.
 - Removed legacy dashboard, product-detail, settings, admin, and debug URL
   redirects. Use the canonical nested frontend routes instead.
 
 ### Added
 
+- Added Icelandic króna support and targeted regional locale formats for
+  PriceStalker's existing shopping markets.
 - Makefile commands for native hot-reload development with a host-accessible
   Docker PostgreSQL database and no application image builds.
 - `make dev-env` to generate secure local database and application credentials,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Icelandic króna support and targeted regional locale formats for
   PriceStalker's existing shopping markets.
+- Prices whose currency cannot be determined now go through a manual currency
+  confirmation step instead of being silently recorded as USD; scheduled
+  refreshes flag such products for review rather than freezing their history.
 - Makefile commands for native hot-reload development with a host-accessible
   Docker PostgreSQL database and no application image builds.
 - `make dev-env` to generate secure local database and application credentials,
@@ -29,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Currency conversion now triangulates via the EUR reference base, so
+  conversions between two non-EUR currencies keep working after the switch to
+  EUR-based reference rates.
+- Conversion tooltips now show the rate date in the user's locale instead of a
+  raw timestamp, and the price chart follows the user's saved locale.
 - Restored a persistent Add Product action on the products dashboard.
 - Added the standard mobile web app capability metadata alongside Apple's
   platform-specific PWA metadata.

--- a/backend/src/migrations/007_add_icelandic_currency.ts
+++ b/backend/src/migrations/007_add_icelandic_currency.ts
@@ -1,0 +1,40 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Add Iceland to the deliberately curated regional currency reference data.
+ *
+ * ISK is supported by the application's exchange-rate provider, but was
+ * absent from the original reference seed. The migration only inserts missing
+ * rows so installations with locally maintained reference data are untouched.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    await client.query(
+      `INSERT INTO global_currencies
+         (country_territory, currency_name, iso, symbol, locale, separation, position)
+       SELECT 'Iceland', 'Icelandic Króna', 'ISK', 'kr', 'is-IS', ',', 'after'
+       WHERE NOT EXISTS (SELECT 1 FROM global_currencies WHERE iso = 'ISK')`
+    );
+
+    await client.query(
+      `INSERT INTO regional_currency_mappings (pattern, currency, match_type, active)
+       SELECT '.is', 'ISK', 'tld', true
+       WHERE NOT EXISTS (SELECT 1 FROM regional_currency_mappings WHERE pattern = '.is')`
+    );
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async () => {
+  // Intentionally a no-op. These rows are reference data and may be relied on
+  // by existing user settings or retailer mappings after the migration runs.
+};

--- a/backend/src/migrations/008_neutral_preferences_and_fx_rates.ts
+++ b/backend/src/migrations/008_neutral_preferences_and_fx_rates.ts
@@ -1,0 +1,36 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Remove inherited country defaults from new accounts and rebuild the
+ * disposable exchange-rate cache around the Frankfurter v2 EUR reference base.
+ * Existing user preferences are deliberately preserved.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`
+      ALTER TABLE users
+        ALTER COLUMN currency DROP DEFAULT,
+        ALTER COLUMN locale DROP DEFAULT,
+        ALTER COLUMN preferred_currency DROP DEFAULT;
+      ALTER TABLE site_configs
+        ALTER COLUMN default_currency DROP DEFAULT;
+      ALTER TABLE exchange_rates
+        ADD COLUMN IF NOT EXISTS rate_date DATE,
+        ADD COLUMN IF NOT EXISTS source VARCHAR(100);
+    `);
+    await client.query('DELETE FROM exchange_rates');
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async () => {
+  // Intentionally a no-op: restoring country-specific defaults would affect
+  // future accounts and cannot restore a discarded cache safely.
+};

--- a/backend/src/models/types/currency.ts
+++ b/backend/src/models/types/currency.ts
@@ -23,4 +23,6 @@ export interface ExchangeRate {
   to_currency: string;
   rate: number;
   updated_at: Date;
+  rate_date: string | null;
+  source: string | null;
 }

--- a/backend/src/models/types/product.ts
+++ b/backend/src/models/types/product.ts
@@ -28,6 +28,8 @@ export interface ProductWithLatestPrice extends Product {
   currency: string | null;
   converted_price: number | null;
   converted_currency: string | null;
+  conversion_rate_date?: string | null;
+  conversion_source?: string | null;
   retailer_name?: string | null;
 }
 

--- a/backend/src/models/types/user.ts
+++ b/backend/src/models/types/user.ts
@@ -4,8 +4,8 @@ export interface User {
   /** NULL for SSO-provisioned accounts, which have no password. */
   password_hash: string | null;
   name: string | null;
-  currency: string;
-  locale: string;
+  currency: string | null;
+  locale: string | null;
   is_admin: boolean;
   auth_provider: string;
   oidc_subject: string | null;
@@ -43,7 +43,8 @@ export interface User {
   email_to: string | null;
   email_subject_template: string | null;
   email_body_template: string | null;
-  preferred_currency: string;
+  /** @deprecated Currency guessing no longer uses a user preference. */
+  preferred_currency: string | null;
   categories: string[];
   created_at: Date;
 }
@@ -52,9 +53,10 @@ export interface UserProfile {
   id: number;
   email: string;
   name: string | null;
-  currency: string;
-  locale: string;
-  preferred_currency: string;
+  currency: string | null;
+  locale: string | null;
+  /** @deprecated Currency guessing no longer uses a user preference. */
+  preferred_currency: string | null;
   is_admin: boolean;
   disabled: boolean;
   categories: string[];

--- a/backend/src/routes/products/scan.ts
+++ b/backend/src/routes/products/scan.ts
@@ -44,6 +44,9 @@ router.post('/:id/confirm', async (req: AuthRequest, res: Response) => {
     if (error.message === 'Product not found') {
       return res.status(404).json({ error: error.message });
     }
+    if (error.statusCode && error.statusCode < 500) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
     logger.error(`Product ${req.params.id} | Confirm Failed | ${error}`, 'Products');
     res.status(500).json({ error: 'Failed to confirm selection' });
   }

--- a/backend/src/services/ai/parsers/extraction.ts
+++ b/backend/src/services/ai/parsers/extraction.ts
@@ -29,7 +29,8 @@ export function parseAIResponse(responseText: string, productId?: number): AIExt
 
     return {
       name: data.name || null,
-      price: data.price ? { price: data.price, currency: data.currency || 'USD' } : null,
+      // '' (not a fabricated 'USD') keeps unresolved currencies in the manual review flow.
+      price: data.price ? { price: data.price, currency: data.currency || '' } : null,
       imageUrl: data.imageUrl || null,
       stockStatus,
       confidence: data.confidence || 0,

--- a/backend/src/services/ai/parsers/verification.ts
+++ b/backend/src/services/ai/parsers/verification.ts
@@ -26,7 +26,8 @@ export function parseVerificationResponse(
     if (data.suggestedPrice !== undefined && data.suggestedPrice !== null) {
       suggestedPrice = {
         price: Number(data.suggestedPrice),
-        currency: data.suggestedCurrency || currencyContext || 'USD'
+        // '' (not a fabricated 'USD') keeps unresolved currencies in the manual review flow.
+        currency: data.suggestedCurrency || currencyContext || ''
       };
     }
 

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -145,28 +145,33 @@ export class ProductPersistenceService {
     scrapedData: ScrapedProductWithVoting,
     source: string
   ) {
-    if (!scrapedData.price?.currency) return;
-
     // A. Standard Price
-    const latestStandardPrice = await priceHistoryRepository.getLatest(productId, 'standard');
-    if (!latestStandardPrice || latestStandardPrice.price !== scrapedData.price.price) {
-      await priceHistoryRepository.create(
-        productId,
-        scrapedData.price.price,
-        scrapedData.price.currency,
-        scrapedData.aiStatus,
-        null,
-        'standard'
-      );
+    if (scrapedData.price && !scrapedData.price.currency) {
+      // A price without a resolved currency must never enter history, but the
+      // skip has to be loud: arbitration flags it for review, and this log is
+      // the trace for why the history did not advance.
+      logger.warn(`Product ${productId} | Price | Skipped recording ${scrapedData.price.price}: no currency resolved (${source})`, 'Products', { product_id: productId });
+    } else if (scrapedData.price?.currency) {
+      const latestStandardPrice = await priceHistoryRepository.getLatest(productId, 'standard');
+      if (!latestStandardPrice || latestStandardPrice.price !== scrapedData.price.price) {
+        await priceHistoryRepository.create(
+          productId,
+          scrapedData.price.price,
+          scrapedData.price.currency,
+          scrapedData.aiStatus,
+          null,
+          'standard'
+        );
 
-      logger.info(`Product ${productId} | Price | Recorded: ${scrapedData.price.currency} ${scrapedData.price.price} (${source})`, 'Products', { product_id: productId });
+        logger.info(`Product ${productId} | Price | Recorded: ${scrapedData.price.currency} ${scrapedData.price.price} (${source})`, 'Products', { product_id: productId });
 
-      // Update anchor price for drift tracking
-      await productRepository.updateAnchorPrice(productId, scrapedData.price.price);
+        // Update anchor price for drift tracking
+        await productRepository.updateAnchorPrice(productId, scrapedData.price.price);
 
-      // Record extraction method if we're moving to a stable one
-      if (scrapedData.selectedMethod) {
-        await productRepository.updateExtractionMethod(productId, scrapedData.selectedMethod);
+        // Record extraction method if we're moving to a stable one
+        if (scrapedData.selectedMethod) {
+          await productRepository.updateExtractionMethod(productId, scrapedData.selectedMethod);
+        }
       }
     }
 

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -145,7 +145,7 @@ export class ProductPersistenceService {
     scrapedData: ScrapedProductWithVoting,
     source: string
   ) {
-    if (!scrapedData.price) return;
+    if (!scrapedData.price?.currency) return;
 
     // A. Standard Price
     const latestStandardPrice = await priceHistoryRepository.getLatest(productId, 'standard');
@@ -153,13 +153,13 @@ export class ProductPersistenceService {
       await priceHistoryRepository.create(
         productId,
         scrapedData.price.price,
-        scrapedData.price.currency || 'AUD',
+        scrapedData.price.currency,
         scrapedData.aiStatus,
         null,
         'standard'
       );
 
-      logger.info(`Product ${productId} | Price | Recorded: ${scrapedData.price.currency || 'AUD'} ${scrapedData.price.price} (${source})`, 'Products', { product_id: productId });
+      logger.info(`Product ${productId} | Price | Recorded: ${scrapedData.price.currency} ${scrapedData.price.price} (${source})`, 'Products', { product_id: productId });
 
       // Update anchor price for drift tracking
       await productRepository.updateAnchorPrice(productId, scrapedData.price.price);
@@ -171,13 +171,13 @@ export class ProductPersistenceService {
     }
 
     // B. Member Price
-    if (scrapedData.memberPrice) {
+    if (scrapedData.memberPrice?.currency) {
       const latestMemberPrice = await priceHistoryRepository.getLatest(productId, 'member-price');
       if (!latestMemberPrice || latestMemberPrice.price !== scrapedData.memberPrice.price) {
         await priceHistoryRepository.create(
           productId,
           scrapedData.memberPrice.price,
-          scrapedData.memberPrice.currency || 'AUD',
+          scrapedData.memberPrice.currency,
           scrapedData.aiStatus,
           null,
           'member-price'
@@ -186,13 +186,13 @@ export class ProductPersistenceService {
     }
 
     // C. Original Price
-    if (scrapedData.originalPrice) {
+    if (scrapedData.originalPrice?.currency) {
       const latestOriginalPrice = await priceHistoryRepository.getLatest(productId, 'original-price');
       if (!latestOriginalPrice || latestOriginalPrice.price !== scrapedData.originalPrice.price) {
         await priceHistoryRepository.create(
           productId,
           scrapedData.originalPrice.price,
-          scrapedData.originalPrice.currency || 'AUD',
+          scrapedData.originalPrice.currency,
           scrapedData.aiStatus,
           null,
           'original-price'

--- a/backend/src/services/domain/product/add/confirmation.ts
+++ b/backend/src/services/domain/product/add/confirmation.ts
@@ -22,7 +22,9 @@ export class ProductConfirmationService {
       originalPrice
     } = options;
     if (typeof selectedPrice !== 'number' || !selectedCurrency) {
-      throw new Error('A price and currency are required to confirm a product');
+      const err: Error & { statusCode?: number } = new Error('A price and currency are required to confirm a product');
+      err.statusCode = 400;
+      throw err;
     }
 
     const product = await productRepository.create(
@@ -63,7 +65,9 @@ export class ProductConfirmationService {
 
     const { selectedPrice, selectedCurrency, selectedMethod, memberPrice, originalPrice } = selection;
     if (selectedPrice !== undefined && !selectedCurrency) {
-      throw new Error('A currency is required when confirming a price');
+      const err: Error & { statusCode?: number } = new Error('A currency is required when confirming a price');
+      err.statusCode = 400;
+      throw err;
     }
 
     await productPersistenceService.saveScrapeResult(

--- a/backend/src/services/domain/product/add/confirmation.ts
+++ b/backend/src/services/domain/product/add/confirmation.ts
@@ -21,6 +21,9 @@ export class ProductConfirmationService {
       memberPrice,
       originalPrice
     } = options;
+    if (typeof selectedPrice !== 'number' || !selectedCurrency) {
+      throw new Error('A price and currency are required to confirm a product');
+    }
 
     const product = await productRepository.create(
       userId,
@@ -38,7 +41,7 @@ export class ProductConfirmationService {
       userId, 
       {
         ...options,
-        price: { price: selectedPrice, currency: selectedCurrency || 'AUD' },
+        price: { price: selectedPrice, currency: selectedCurrency },
         memberPrice,
         originalPrice,
         selectedMethod,
@@ -59,13 +62,16 @@ export class ProductConfirmationService {
     if (!product) throw new Error('Product not found');
 
     const { selectedPrice, selectedCurrency, selectedMethod, memberPrice, originalPrice } = selection;
+    if (selectedPrice !== undefined && !selectedCurrency) {
+      throw new Error('A currency is required when confirming a price');
+    }
 
     await productPersistenceService.saveScrapeResult(
       productId,
       userId,
       {
         ...selection,
-        price: selectedPrice !== undefined ? { price: selectedPrice, currency: selectedCurrency || 'AUD' } : undefined,
+        price: selectedPrice !== undefined ? { price: selectedPrice, currency: selectedCurrency } : undefined,
         memberPrice,
         originalPrice,
         selectedMethod

--- a/backend/src/services/domain/product/add/discovery.ts
+++ b/backend/src/services/domain/product/add/discovery.ts
@@ -13,8 +13,11 @@ export class ProductDiscoveryService {
       throw new Error('Could not extract price from the provided URL');
     }
 
-    // AUTO-TRACK: Consensus is clear (either we have a price, or it's out of stock / pre-order)
-    if (scrapedData.needsReview === false && (scrapedData.price || scrapedData.stockStatus === 'out_of_stock' || scrapedData.stockStatus === 'pre_order')) {
+    const requiresCurrencyReview = Boolean(scrapedData.price && !scrapedData.price.currency);
+
+    // AUTO-TRACK: Consensus is clear (either we have a price, or it's out of stock / pre-order).
+    // A numeric price without a known currency must be confirmed manually.
+    if (!requiresCurrencyReview && scrapedData.needsReview === false && (scrapedData.price || scrapedData.stockStatus === 'out_of_stock' || scrapedData.stockStatus === 'pre_order')) {
       const product = await productRepository.create(
         userId,
         url,

--- a/backend/src/services/domain/product/repositories/product-core.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-core.repository.ts
@@ -7,10 +7,10 @@ export const productQueryCoreRepository = {
   findByUserId: async (userId: number): Promise<ProductWithLatestPrice[]> => {
     const result = await pool.query(
       `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status,
-              u.currency as converted_currency, er.rate_date as conversion_rate_date, er.source as conversion_source,
-              CASE 
+              u.currency as converted_currency, er.rate_date::text as conversion_rate_date, er.source as conversion_source,
+              CASE
                 WHEN ph.currency = u.currency THEN ph.price
-                ELSE ph.price * er.rate 
+                ELSE ph.price * er.rate
               END as converted_price,
               COALESCE(rc.name, rc.domain) as retailer_name
        FROM products p
@@ -21,7 +21,22 @@ export const productQueryCoreRepository = {
          ORDER BY recorded_at DESC
          LIMIT 1
        ) ph ON true
-       LEFT JOIN exchange_rates er ON er.from_currency = ph.currency AND er.to_currency = u.currency
+       -- Rates are stored as EUR<->X pairs only; cross pairs triangulate via EUR.
+       LEFT JOIN LATERAL (
+         SELECT r.rate, r.rate_date, r.source
+         FROM (
+           SELECT d.rate, d.rate_date, d.source, 1 AS priority
+           FROM exchange_rates d
+           WHERE d.from_currency = ph.currency AND d.to_currency = u.currency
+           UNION ALL
+           SELECT ef.rate * et.rate, LEAST(ef.rate_date, et.rate_date), et.source, 2
+           FROM exchange_rates ef
+           JOIN exchange_rates et ON et.from_currency = 'EUR' AND et.to_currency = u.currency
+           WHERE ef.from_currency = ph.currency AND ef.to_currency = 'EUR'
+         ) r
+         ORDER BY r.priority
+         LIMIT 1
+       ) er ON ph.currency IS NOT NULL AND ph.currency <> '' AND ph.currency <> u.currency
        LEFT JOIN LATERAL (
          SELECT name, domain FROM retailer_configs
          WHERE p.url LIKE '%' || domain || '%'
@@ -41,7 +56,7 @@ export const productQueryCoreRepository = {
       `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status,
               ph_m.price as member_price,
               ph_o.price as original_price,
-              u.currency as converted_currency, er.rate_date as conversion_rate_date, er.source as conversion_source,
+              u.currency as converted_currency, er.rate_date::text as conversion_rate_date, er.source as conversion_source,
               CASE
                 WHEN ph.currency = u.currency THEN ph.price
                 ELSE ph.price * er.rate
@@ -68,7 +83,22 @@ export const productQueryCoreRepository = {
          ORDER BY recorded_at DESC
          LIMIT 1
        ) ph_o ON true
-       LEFT JOIN exchange_rates er ON er.from_currency = ph.currency AND er.to_currency = u.currency
+       -- Rates are stored as EUR<->X pairs only; cross pairs triangulate via EUR.
+       LEFT JOIN LATERAL (
+         SELECT r.rate, r.rate_date, r.source
+         FROM (
+           SELECT d.rate, d.rate_date, d.source, 1 AS priority
+           FROM exchange_rates d
+           WHERE d.from_currency = ph.currency AND d.to_currency = u.currency
+           UNION ALL
+           SELECT ef.rate * et.rate, LEAST(ef.rate_date, et.rate_date), et.source, 2
+           FROM exchange_rates ef
+           JOIN exchange_rates et ON et.from_currency = 'EUR' AND et.to_currency = u.currency
+           WHERE ef.from_currency = ph.currency AND ef.to_currency = 'EUR'
+         ) r
+         ORDER BY r.priority
+         LIMIT 1
+       ) er ON ph.currency IS NOT NULL AND ph.currency <> '' AND ph.currency <> u.currency
        LEFT JOIN LATERAL (
          SELECT name, domain FROM retailer_configs
          WHERE p.url LIKE '%' || domain || '%'

--- a/backend/src/services/domain/product/repositories/product-core.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-core.repository.ts
@@ -7,7 +7,7 @@ export const productQueryCoreRepository = {
   findByUserId: async (userId: number): Promise<ProductWithLatestPrice[]> => {
     const result = await pool.query(
       `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status,
-              u.currency as converted_currency,
+              u.currency as converted_currency, er.rate_date as conversion_rate_date, er.source as conversion_source,
               CASE 
                 WHEN ph.currency = u.currency THEN ph.price
                 ELSE ph.price * er.rate 
@@ -41,7 +41,7 @@ export const productQueryCoreRepository = {
       `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status,
               ph_m.price as member_price,
               ph_o.price as original_price,
-              u.currency as converted_currency,
+              u.currency as converted_currency, er.rate_date as conversion_rate_date, er.source as conversion_source,
               CASE
                 WHEN ph.currency = u.currency THEN ph.price
                 ELSE ph.price * er.rate

--- a/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
@@ -13,7 +13,7 @@ export const productDashboardRepository = {
       `SELECT p.*, ph.price as current_price, ph.currency, 
               ph_m.price as member_price,
               ph_o.price as original_price,
-              u.currency as converted_currency,
+              u.currency as converted_currency, er.rate_date as conversion_rate_date, er.source as conversion_source,
               CASE 
                 WHEN ph.currency = u.currency THEN ph.price
                 ELSE ph.price * er.rate 

--- a/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
@@ -13,7 +13,7 @@ export const productDashboardRepository = {
       `SELECT p.*, ph.price as current_price, ph.currency, 
               ph_m.price as member_price,
               ph_o.price as original_price,
-              u.currency as converted_currency, er.rate_date as conversion_rate_date, er.source as conversion_source,
+              u.currency as converted_currency, er.rate_date::text as conversion_rate_date, er.source as conversion_source,
               CASE 
                 WHEN ph.currency = u.currency THEN ph.price
                 ELSE ph.price * er.rate 
@@ -40,7 +40,22 @@ export const productDashboardRepository = {
          ORDER BY recorded_at DESC
          LIMIT 1
        ) ph_o ON true
-       LEFT JOIN exchange_rates er ON er.from_currency = ph.currency AND er.to_currency = u.currency
+       -- Rates are stored as EUR<->X pairs only; cross pairs triangulate via EUR.
+       LEFT JOIN LATERAL (
+         SELECT r.rate, r.rate_date, r.source
+         FROM (
+           SELECT d.rate, d.rate_date, d.source, 1 AS priority
+           FROM exchange_rates d
+           WHERE d.from_currency = ph.currency AND d.to_currency = u.currency
+           UNION ALL
+           SELECT ef.rate * et.rate, LEAST(ef.rate_date, et.rate_date), et.source, 2
+           FROM exchange_rates ef
+           JOIN exchange_rates et ON et.from_currency = 'EUR' AND et.to_currency = u.currency
+           WHERE ef.from_currency = ph.currency AND ef.to_currency = 'EUR'
+         ) r
+         ORDER BY r.priority
+         LIMIT 1
+       ) er ON ph.currency IS NOT NULL AND ph.currency <> '' AND ph.currency <> u.currency
        LEFT JOIN LATERAL (
          SELECT name, domain FROM retailer_configs
          WHERE p.url LIKE '%' || domain || '%'

--- a/backend/src/services/domain/system/CurrencyConversionService.ts
+++ b/backend/src/services/domain/system/CurrencyConversionService.ts
@@ -19,17 +19,19 @@ class CurrencyConversionService {
         params: { base }
       });
 
-      if (response.data.length > 0) {
-        const promises = response.data.map(({ base: rateBase, quote, rate, date }) =>
-          exchangeRateRepository.upsert(rateBase, quote, rate, date, this.SOURCE)
-        );
-        const inversePromises = response.data.map(({ base: rateBase, quote, rate, date }) =>
-          exchangeRateRepository.upsert(quote, rateBase, 1 / rate, date, this.SOURCE)
-        );
-
-        await Promise.all([...promises, ...inversePromises]);
-        logger.info(`Currency | Successfully updated ${response.data.length * 2} exchange rates.`, 'Currency');
+      if (!Array.isArray(response.data) || response.data.length === 0) {
+        throw new Error(`Unexpected rates response (status ${response.status}): ${JSON.stringify(response.data).slice(0, 300)}`);
       }
+
+      const promises = response.data.map(({ base: rateBase, quote, rate, date }) =>
+        exchangeRateRepository.upsert(rateBase, quote, rate, date, this.SOURCE)
+      );
+      const inversePromises = response.data.map(({ base: rateBase, quote, rate, date }) =>
+        exchangeRateRepository.upsert(quote, rateBase, 1 / rate, date, this.SOURCE)
+      );
+
+      await Promise.all([...promises, ...inversePromises]);
+      logger.info(`Currency | Successfully updated ${response.data.length * 2} exchange rates.`, 'Currency');
     } catch (error: any) {
       logger.error(`Currency | Failed to update exchange rates: ${error.message}`, 'Currency', error);
       throw error;

--- a/backend/src/services/domain/system/CurrencyConversionService.ts
+++ b/backend/src/services/domain/system/CurrencyConversionService.ts
@@ -3,34 +3,32 @@ import { exchangeRateRepository } from '../../../models';
 import { logger } from '../../../utils/system/logger';
 
 class CurrencyConversionService {
-  private readonly API_URL = 'https://api.frankfurter.app/latest';
-  private readonly DEFAULT_BASE = 'AUD';
+  private readonly API_URL = 'https://api.frankfurter.dev/v2/rates';
+  private readonly DEFAULT_BASE = 'EUR';
+  private readonly SOURCE = 'frankfurter-v2-blended';
 
   /**
    * Fetches latest exchange rates and updates the database.
-   * By default, fetches rates relative to AUD.
+   * Fetches the provider's complete daily reference-rate set relative to EUR.
    */
   async updateRates(base: string = this.DEFAULT_BASE): Promise<void> {
     try {
       logger.info(`Currency | Updating rates relative to ${base}...`, 'Currency');
       
-      const response = await axios.get(this.API_URL, {
-        params: { from: base }
+      const response = await axios.get<Array<{ date: string; base: string; quote: string; rate: number }>>(this.API_URL, {
+        params: { base }
       });
 
-      if (response.data && response.data.rates) {
-        const rates = response.data.rates;
-        const promises = Object.keys(rates).map(currency => 
-          exchangeRateRepository.upsert(base, currency, rates[currency])
+      if (response.data.length > 0) {
+        const promises = response.data.map(({ base: rateBase, quote, rate, date }) =>
+          exchangeRateRepository.upsert(rateBase, quote, rate, date, this.SOURCE)
         );
-        
-        // Also add the inverse rates for easier lookups
-        const inversePromises = Object.keys(rates).map(currency => 
-          exchangeRateRepository.upsert(currency, base, 1 / rates[currency])
+        const inversePromises = response.data.map(({ base: rateBase, quote, rate, date }) =>
+          exchangeRateRepository.upsert(quote, rateBase, 1 / rate, date, this.SOURCE)
         );
 
         await Promise.all([...promises, ...inversePromises]);
-        logger.info(`Currency | Successfully updated ${Object.keys(rates).length * 2} exchange rates.`, 'Currency');
+        logger.info(`Currency | Successfully updated ${response.data.length * 2} exchange rates.`, 'Currency');
       }
     } catch (error: any) {
       logger.error(`Currency | Failed to update exchange rates: ${error.message}`, 'Currency', error);

--- a/backend/src/services/domain/system/repositories/currency.repository.ts
+++ b/backend/src/services/domain/system/repositories/currency.repository.ts
@@ -44,14 +44,16 @@ export const globalCurrencyRepository = {
 
 
 export const exchangeRateRepository = {
-  upsert: async (from: string, to: string, rate: number): Promise<void> => {
+  upsert: async (from: string, to: string, rate: number, rateDate: string, source: string): Promise<void> => {
     await pool.query(
-      `INSERT INTO exchange_rates (from_currency, to_currency, rate, updated_at)
-       VALUES ($1, $2, $3, NOW())
+      `INSERT INTO exchange_rates (from_currency, to_currency, rate, rate_date, source, updated_at)
+       VALUES ($1, $2, $3, $4, $5, NOW())
        ON CONFLICT (from_currency, to_currency) DO UPDATE SET
          rate = EXCLUDED.rate,
+         rate_date = EXCLUDED.rate_date,
+         source = EXCLUDED.source,
          updated_at = NOW()`,
-      [from.toUpperCase(), to.toUpperCase(), rate]
+      [from.toUpperCase(), to.toUpperCase(), rate, rateDate, source]
     );
   },
 

--- a/backend/src/services/domain/user/UserAccountService.ts
+++ b/backend/src/services/domain/user/UserAccountService.ts
@@ -10,8 +10,8 @@ export class UserAccountService {
     email: string;
     password: string;
     is_admin?: boolean;
-    currency?: string;
-    locale?: string;
+    currency?: string | null;
+    locale?: string | null;
   }): Promise<User> {
     const { email, password, is_admin, currency, locale } = data;
 
@@ -25,7 +25,7 @@ export class UserAccountService {
     const saltRounds = 12;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    const user = await userRepository.create(email, passwordHash, currency, locale);
+    const user = await userRepository.create(email, passwordHash, currency || null, locale || null);
 
     if (is_admin) {
       await userRepository.setAdmin(user.id, true);
@@ -51,8 +51,8 @@ export class UserAccountService {
     }
 
     if (name !== undefined) updates.name = name;
-    if (currency !== undefined) updates.currency = currency;
-    if (locale !== undefined) updates.locale = locale;
+    if (currency !== undefined) updates.currency = currency || null;
+    if (locale !== undefined) updates.locale = locale || null;
 
     if (is_admin !== undefined) {
       if (targetId === currentUserId && !is_admin) {

--- a/backend/src/services/domain/user/UserProfileService.ts
+++ b/backend/src/services/domain/user/UserProfileService.ts
@@ -16,10 +16,10 @@ export class UserProfileService {
    * User: Update personal profile
    */
   async updateProfile(userId: number, data: any): Promise<UserProfile | null> {
-    const { name, currency, locale, preferred_currency } = data;
+    const { name, currency, locale } = data;
 
     const oldProfile = await userRepository.getProfile(userId);
-    const profile = await userRepository.updateProfile(userId, { name, currency, locale, preferred_currency });
+    const profile = await userRepository.updateProfile(userId, { name, currency, locale });
 
     if (!profile) return null;
 

--- a/backend/src/services/domain/user/repositories/user-account.repository.ts
+++ b/backend/src/services/domain/user/repositories/user-account.repository.ts
@@ -18,7 +18,7 @@ export const userAccountRepository = {
     return result.rows[0] || null;
   },
 
-  create: async (email: string, passwordHash: string, currency: string = 'AUD', locale: string = 'en-AU'): Promise<User> => {
+  create: async (email: string, passwordHash: string, currency: string | null = null, locale: string | null = null): Promise<User> => {
     const result = await pool.query(
       'INSERT INTO users (email, password_hash, currency, locale) VALUES ($1, $2, $3, $4) RETURNING *',
       [email, passwordHash, currency, locale]
@@ -56,8 +56,8 @@ export const userAccountRepository = {
    */
   createOidc: async (
     params: { email: string; name: string | null; issuer: string; subject: string },
-    currency: string = 'AUD',
-    locale: string = 'en-AU'
+    currency: string | null = null,
+    locale: string | null = null
   ): Promise<User> => {
     const result = await pool.query(
       `INSERT INTO users (email, name, oidc_issuer, oidc_subject, auth_provider, currency, locale)
@@ -107,7 +107,7 @@ export const userAccountRepository = {
 
   adminUpdateUser: async (
     id: number,
-    updates: { email?: string; name?: string; currency?: string; locale?: string; password_hash?: string; is_admin?: boolean; disabled?: boolean }
+    updates: { email?: string; name?: string; currency?: string | null; locale?: string | null; password_hash?: string; is_admin?: boolean; disabled?: boolean }
   ): Promise<UserProfile | null> => {
     const fields: string[] = [];
     const values: (string | boolean | number | null)[] = [];

--- a/backend/src/services/domain/user/repositories/user-profile.repository.ts
+++ b/backend/src/services/domain/user/repositories/user-profile.repository.ts
@@ -30,10 +30,10 @@ export const userProfileRepository = {
 
   updateProfile: async (
     id: number,
-    updates: { name?: string; currency?: string; locale?: string; preferred_currency?: string }
+    updates: { name?: string; currency?: string | null; locale?: string | null; preferred_currency?: string | null }
   ): Promise<UserProfile | null> => {
     const fields: string[] = [];
-    const values: (string | number)[] = [];
+    const values: (string | number | null)[] = [];
     let paramIndex = 1;
 
     if (updates.name !== undefined) {

--- a/backend/src/services/scheduler/tasks/ExchangeRateTask.ts
+++ b/backend/src/services/scheduler/tasks/ExchangeRateTask.ts
@@ -15,7 +15,14 @@ export async function checkInitialExchangeRates(): Promise<void> {
     const rates = await exchangeRateRepository.getAll();
     if (rates.length === 0) {
       logger.info('System | Scheduler | Initial exchange rate fetch triggered', 'Scheduler');
-      await updateExchangeRates();
+      // An empty table means every conversion is unavailable until the next
+      // scheduled run, so retry the boot fetch instead of giving up on one failure.
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        await currencyConversionService.updateRates().catch(() => null);
+        if ((await exchangeRateRepository.getAll()).length > 0) return;
+        logger.warn(`Currency | Initial rate fetch attempt ${attempt}/3 left the table empty${attempt < 3 ? ', retrying in 30s' : ''}.`, 'Currency');
+        if (attempt < 3) await new Promise(resolve => setTimeout(resolve, 30_000));
+      }
     } else {
       // Check for staleness (older than 36 hours)
       const oldestRate = rates.reduce((oldest, current) => {

--- a/backend/src/services/scraper/arbitrators/consensus.ts
+++ b/backend/src/services/scraper/arbitrators/consensus.ts
@@ -2,6 +2,19 @@ import { PriceCandidate } from '../../../types/scraper';
 import { groupPriceCandidates, pricesMatch } from './utils';
 
 /**
+ * Returns the group's first candidate, backfilling its currency from another
+ * group member when the first one could not resolve a currency. Candidates
+ * group by price alone, so a currency-less candidate can otherwise win a group
+ * whose other members positively identified the currency.
+ */
+function withGroupCurrency(group: PriceCandidate[]): PriceCandidate {
+  const first = group[0];
+  if (first.currency) return first;
+  const donor = group.find(c => c.currency);
+  return donor ? { ...first, currency: donor.currency } : first;
+}
+
+/**
  * Arbitrates between multiple price candidates to find a consensus value.
  * Splits results into Primary (Normal) price, Member price, and Original price.
  */
@@ -18,7 +31,7 @@ export function findPriceConsensus(candidates: PriceCandidate[]) {
   if (memberCandidates.length > 0) {
     const groups = groupPriceCandidates(memberCandidates);
     groups.sort((a, b) => b.length - a.length);
-    memberPrice = groups[0][0];
+    memberPrice = withGroupCurrency(groups[0]);
   }
 
   // --- 2. Find Original Price Consensus ---
@@ -26,7 +39,7 @@ export function findPriceConsensus(candidates: PriceCandidate[]) {
   if (originalCandidates.length > 0) {
     const groups = groupPriceCandidates(originalCandidates);
     groups.sort((a, b) => b.length - a.length);
-    originalPrice = groups[0][0];
+    originalPrice = withGroupCurrency(groups[0]);
   }
 
   // --- 3. Find Primary (Normal) Price Consensus ---
@@ -41,7 +54,7 @@ export function findPriceConsensus(candidates: PriceCandidate[]) {
     groups.sort((a, b) => b.length - a.length);
     const hasConsensus = !(groups.length > 1 && groups[0].length === groups[1].length);
     const winningGroupSources = new Set(groups[0].map(c => `${c.method}:${c.selector || ''}`));
-    return { price: groups[0][0], memberPrice, originalPrice, hasConsensus, winningGroupSources };
+    return { price: withGroupCurrency(groups[0]), memberPrice, originalPrice, hasConsensus, winningGroupSources };
   }
 
   // 2. Next Priority: Pre-order Prices (Public)
@@ -51,7 +64,7 @@ export function findPriceConsensus(candidates: PriceCandidate[]) {
      groups.sort((a, b) => b.length - a.length);
      const hasConsensus = !(groups.length > 1 && groups[0].length === groups[1].length);
      const winningGroupSources = new Set(groups[0].map(c => `${c.method}:${c.selector || ''}`));
-     return { price: groups[0][0], memberPrice, originalPrice, hasConsensus, winningGroupSources };
+     return { price: withGroupCurrency(groups[0]), memberPrice, originalPrice, hasConsensus, winningGroupSources };
   }
 
   // 3. Weighted Fallback (Custom CSS > JSON-LD > Generic)
@@ -98,8 +111,8 @@ export function findPriceConsensus(candidates: PriceCandidate[]) {
     hasConsensus = false;
   }
 
-  return { 
-    price: topGroup.candidates[0], 
+  return {
+    price: withGroupCurrency(topGroup.candidates),
     memberPrice,
     originalPrice,
     hasConsensus,

--- a/backend/src/services/scraper/context.ts
+++ b/backend/src/services/scraper/context.ts
@@ -1,4 +1,3 @@
-import { userRepository } from '../../models';
 import { currencyHelper } from '../../utils/currencyHelper';
 
 export interface ResolvedContext {
@@ -15,17 +14,7 @@ export async function resolveScrapeContext(
   html?: string,
   currencyHint?: string
 ): Promise<ResolvedContext> {
-  let userLocale: string | undefined;
-  let userCurrency: string | undefined;
-
-  if (userId) {
-    const user = await userRepository.findById(userId);
-    if (user) {
-      userLocale = user.locale;
-      userCurrency = user.preferred_currency || user.currency;
-    }
-  }
-
-  const { locale, currency } = await currencyHelper.resolveLocaleAndCurrency(url, html, userLocale, userCurrency, currencyHint);
+  void userId;
+  const { locale, currency } = await currencyHelper.resolveLocaleAndCurrency(url, html, undefined, undefined, currencyHint);
   return { locale, currency };
 }

--- a/backend/src/services/scraper/extractors/price-extraction.ts
+++ b/backend/src/services/scraper/extractors/price-extraction.ts
@@ -45,9 +45,11 @@ export function extractJsonLdCandidates(
         if (isOffer) {
           const val = obj[jsonLdPriceKey] || obj.price || obj.lowPrice;
           if (val) {
-            let currency = obj.priceCurrency || currencyHint || 'USD';
+            // No fabricated fallback: an unresolvable currency stays '' so the
+            // candidate is routed through manual currency review downstream.
+            let currency = obj.priceCurrency || currencyHint || '';
             if (currency === "$") {
-              currency = currencyHint || 'USD';
+              currency = currencyHint || '';
             } else {
               currency = CURRENCY_MAP[currency] || currency;
             }
@@ -70,9 +72,9 @@ export function extractJsonLdCandidates(
           for (const spec of specs) {
             const specVal = spec[jsonLdPriceKey] || spec.price;
             if (specVal) {
-              let currency = spec.priceCurrency || obj.priceCurrency || currencyHint || 'USD';
+              let currency = spec.priceCurrency || obj.priceCurrency || currencyHint || '';
               if (currency === "$") {
-                currency = currencyHint || 'USD';
+                currency = currencyHint || '';
               } else {
                 currency = CURRENCY_MAP[currency] || currency;
               }

--- a/backend/src/services/scraper/orchestration/consensus.ts
+++ b/backend/src/services/scraper/orchestration/consensus.ts
@@ -58,6 +58,14 @@ export async function runConsensusPhase(
     if (arbResult.imageUrl && !result.imageUrl) result.imageUrl = arbResult.imageUrl;
   }
 
+  // A winning price without a resolved currency cannot be persisted, so flag
+  // it for manual confirmation on both the add and refresh paths.
+  if (result.price && !result.price.currency) {
+    result.needsReview = true;
+    result.reviewReason = result.reviewReason || 'missing_currency';
+    extractionSteps.push('Consensus | Review | Winning price has no resolved currency');
+  }
+
   // Out of Stock (OOS) price guardrails
   if (result.stockStatus === 'out_of_stock' || result.stockStatus === 'not_available') {
     if (result.price) {

--- a/backend/src/services/scraper/transport/headers.ts
+++ b/backend/src/services/scraper/transport/headers.ts
@@ -19,7 +19,7 @@ export async function getHeaders(userAgent?: string): Promise<Record<string, str
   const headers: Record<string, string> = {
     'User-Agent': ua || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-    'Accept-Language': 'en-AU,en;q=0.9',
+    'Accept-Language': 'en-US,en;q=0.9',
     'Sec-Ch-Ua': '"Not A(Brand";v="99", "Google Chrome";v="121", "Chromium";v="121"',
     'Sec-Ch-Ua-Mobile': '?0',
     'Sec-Ch-Ua-Platform': '"Windows"',

--- a/backend/src/types/scraper.ts
+++ b/backend/src/types/scraper.ts
@@ -29,7 +29,7 @@ export interface ScrapedProduct {
   html?: string;
 }
 
-export type ReviewReason = 'no_consensus' | 'ai_correction' | 'oos_guardrail' | 'manual_rescan' | 'first_scan';
+export type ReviewReason = 'no_consensus' | 'ai_correction' | 'oos_guardrail' | 'manual_rescan' | 'first_scan' | 'missing_currency';
 
 export interface ScrapedProductWithVoting extends ScrapedProduct {
   priceCandidates: PriceCandidate[];

--- a/backend/src/utils/i18n/currency/resolver.ts
+++ b/backend/src/utils/i18n/currency/resolver.ts
@@ -119,15 +119,15 @@ export class CurrencyResolver {
       urlObj = new URL(url);
     } catch (err) {
       logger.warn(`CurrencyResolver | Malformed URL provided: "${url}". Falling back to default locale and currency.`, 'Currency');
-      const fallbackLocale = (userLocale || 'en-AU').replace(/_/g, '-');
-      return { locale: fallbackLocale, currency: userCurrency || 'AUD' };
+      const fallbackLocale = (userLocale || 'en-US').replace(/_/g, '-');
+      return { locale: fallbackLocale, currency: userCurrency || '' };
     }
     const hostname = urlObj.hostname.toLowerCase();
     const path = urlObj.pathname.toLowerCase();
 
     // 0. Prioritize retailer config currency hint if provided
     if (currencyHint) {
-      const locale = await this.getLocaleFromCurrency(currencyHint) || userLocale || 'en-AU';
+      const locale = await this.getLocaleFromCurrency(currencyHint) || userLocale || 'en-US';
       return { locale: locale.replace(/_/g, '-'), currency: currencyHint };
     }
 
@@ -139,13 +139,13 @@ export class CurrencyResolver {
       return regex.test(hostname);
     });
     if (tldMatch) {
-      const locale = await this.getLocaleFromCurrency(tldMatch.currency) || userLocale || 'en-AU';
+      const locale = await this.getLocaleFromCurrency(tldMatch.currency) || userLocale || 'en-US';
       return { locale: locale.replace(/_/g, '-'), currency: tldMatch.currency };
     }
 
     const pathMatch = regionalMappings.find(m => m.match_type === 'path' && path.includes(m.pattern.toLowerCase()));
     if (pathMatch) {
-      const locale = await this.getLocaleFromCurrency(pathMatch.currency) || userLocale || 'en-AU';
+      const locale = await this.getLocaleFromCurrency(pathMatch.currency) || userLocale || 'en-US';
       return { locale: locale.replace(/_/g, '-'), currency: pathMatch.currency };
     }
 
@@ -180,10 +180,10 @@ export class CurrencyResolver {
     }
 
     // 3. Fallback to User Preferences
-    const finalLocale = (userLocale || 'en-AU').replace(/_/g, '-');
+    const finalLocale = (userLocale || 'en-US').replace(/_/g, '-');
     return {
       locale: finalLocale,
-      currency: userCurrency || 'AUD'
+      currency: userCurrency || ''
     };
   }
 }

--- a/backend/src/utils/scraping/price/normalizer.ts
+++ b/backend/src/utils/scraping/price/normalizer.ts
@@ -1,18 +1,18 @@
 /**
  * Normalizes a price string using locale-aware separation logic.
  */
-export function normalizePrice(priceStr: string, locale: string): number | null {
+export function normalizePrice(priceStr: string, locale?: string): number | null {
   if (!priceStr) return null;
 
   // Normalize locale: database often uses underscores (en_AU), JS requires hyphens (en-AU)
-  const cleanLocale = locale.replace('_', '-');
+  const cleanLocale = locale?.replace('_', '-');
 
   // Detect separators for the given locale
   try {
     // Intl accepts syntactically valid but unsupported locale tags by silently
     // resolving them to the host default. That would make parsing depend on the
     // operating system's ICU data, so use the locale-independent fallback instead.
-    if (Intl.NumberFormat.supportedLocalesOf([cleanLocale]).length === 0) {
+    if (!cleanLocale || Intl.NumberFormat.supportedLocalesOf([cleanLocale]).length === 0) {
       throw new RangeError(`Unsupported locale: ${cleanLocale}`);
     }
 

--- a/backend/src/utils/scraping/price/parser.ts
+++ b/backend/src/utils/scraping/price/parser.ts
@@ -5,7 +5,7 @@ import { currencyHelper } from '../../currencyHelper';
 /**
  * Parses a price string into a numeric value and currency code.
  */
-export function parsePrice(text: string, currencyHint?: string, localeHint: string = 'en-AU'): ParsedPrice | null {
+export function parsePrice(text: string, currencyHint?: string, localeHint?: string): ParsedPrice | null {
   if (!text) return null;
 
   const cleanText = text.trim().replace(/\s+/g, ' ');
@@ -41,15 +41,18 @@ export function parsePrice(text: string, currencyHint?: string, localeHint: stri
       if (priceStr) {
         const price = normalizePrice(priceStr, localeHint);
         if (price !== null && price > 0) {
-          let currency = 'USD';
+          let currency = currencyHint;
           if (currencySymbol) {
             const resolved = currencyHelper.getCurrencyFromSymbolSync(currencySymbol, localeHint);
-            currency = resolved || CURRENCY_MAP[currencySymbol.toUpperCase()] || currencySymbol.toUpperCase() || 'USD';
+            currency = resolved || CURRENCY_MAP[currencySymbol.toUpperCase()] || currencySymbol.toUpperCase();
           }
           if ((currencySymbol === '$' || !currencySymbol) && currencyHint) {
             currency = currencyHint;
           }
-          return { price, currency };
+          // Keep a numeric candidate even if its currency cannot be inferred.
+          // It must be reviewed before persistence, but dropping it here turns
+          // an otherwise recoverable scrape into a failed product discovery.
+          return { price, currency: currency || '' };
         }
       }
     }
@@ -59,7 +62,7 @@ export function parsePrice(text: string, currencyHint?: string, localeHint: stri
   if (numberMatch) {
     const price = normalizePrice(numberMatch[0], localeHint);
     if (price !== null && price > 0) {
-      return { price, currency: currencyHint || 'USD' };
+      return { price, currency: currencyHint || '' };
     }
   }
 

--- a/backend/src/utils/system/logging/printer.ts
+++ b/backend/src/utils/system/logging/printer.ts
@@ -59,15 +59,7 @@ export function print(level: LogLevel, msg: string, context?: string, details?: 
   // Strip common redundant prefixes
   cleanMsg = cleanMsg.replace(/^System [|:] /, '');
 
-  const ts = new Date().toLocaleString('en-AU', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false
-  }).replace(/,/, '');
+  const ts = new Date().toISOString();
   const ctx = context ? ' [' + context + ']' : '';
 
   // Prepare Console-safe version (Strip HTML tags for Docker visibility)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -30,7 +30,10 @@ Stores user profile information, authentication hashes, locale/currency settings
 * **Key Fields**:
  - `email` (unique) & `password_hash`
  - `is_admin`: Grants access to backend administrative endpoints.
- - `preferred_currency` & `locale` (defaults to `AUD` and `en-AU`).
+ - `currency` & `locale` are optional display preferences. A null locale uses
+   the browser format and a null currency leaves prices in the retailer's
+   original currency. `preferred_currency` is retained only for compatibility
+   and is no longer read by scraping.
  - **Notification Integrations**: Stores activation state, webhook tokens, and customizable templates for `telegram`, `discord`, `pushover`, `ntfy`, `gotify`, `webhook`, and `email`.
  - **AI Model Keys**: Encapsulates keys/models configuration for `anthropic`, `openai`, `gemini`, and `ollama`.
 

--- a/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
+++ b/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
@@ -335,7 +335,7 @@ export default function RetailerConfigEditor({
             onTest={handleTestConfig}
             isTesting={isTestingConfig}
             testResult={testResult}
-            userLocale={user?.locale}
+            userLocale={user?.locale ?? undefined}
             showToast={showToast}
           />
         </CollapsibleCard>

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -8,6 +8,7 @@ import PasswordInput from '../../../../components/PasswordInput';
 import SearchableSelect from '../../../../components/SearchableSelect';
 import { ToggleSwitch } from '../../components';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
+import { AUTOMATIC_CURRENCY_OPTION, AUTOMATIC_LOCALE_OPTION, LOCALE_OPTIONS } from '../../../settings/regionalOptions';
 
 interface UsersSectionProps {
   globalCurrencies: GlobalCurrency[];
@@ -24,8 +25,8 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   // Add User states
   const [newUserEmail, setNewUserEmail] = useState('');
   const [newUserPassword, setNewUserPassword] = useState('');
-  const [newUserCurrency, setNewUserCurrency] = useState('AUD');
-  const [newUserLocale, setNewUserLocale] = useState('en-AU');
+  const [newUserCurrency, setNewUserCurrency] = useState('');
+  const [newUserLocale, setNewUserLocale] = useState('');
   const [newUserIsAdmin, setNewUserIsAdmin] = useState(false);
 
   // Edit User states
@@ -48,7 +49,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   const handleAddUser = async () => {
     if (!newUserEmail || !newUserPassword) { showToast('Email and password required', 'error'); return; }
     try {
-      await UserAdminService.createUser(newUserEmail, newUserPassword, newUserIsAdmin, newUserCurrency, newUserLocale);
+      await UserAdminService.createUser(newUserEmail, newUserPassword, newUserIsAdmin, newUserCurrency || undefined, newUserLocale || undefined);
       showToast('User created', 'success');
       setIsAddingUser(false);
       setNewUserEmail(''); setNewUserPassword('');
@@ -61,7 +62,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
     if (editUserPassword && editUserPassword !== editUserConfirmPassword) { showToast('Passwords do not match', 'error'); return; }
     try {
       await UserAdminService.updateUser(editingUser.id, { 
-        name: editingUser.name, email: editingUser.email, currency: editingUser.currency, locale: editingUser.locale, 
+        name: editingUser.name, email: editingUser.email, currency: editingUser.currency || null, locale: editingUser.locale || null,
         is_admin: editingUser.is_admin, disabled: editingUser.disabled, password: editUserPassword || undefined 
       });
       showToast('User updated', 'success');
@@ -153,12 +154,13 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
             <div className="form-group">
               <SearchableSelect
                 label="Default Currency"
-                options={globalCurrencies.map(gc => ({
+                options={[AUTOMATIC_CURRENCY_OPTION, ...globalCurrencies.map(gc => ({
                   label: `${gc.iso} (${gc.symbol})`,
                   value: gc.iso,
                   subLabel: gc.currency_name
-                }))}
+                }))]}
                 value={newUserCurrency}
+                placeholder="Choose a currency"
                 onChange={(val) => {
                   setNewUserCurrency(val);
                   const match = globalCurrencies.find(gc => gc.iso === val);
@@ -169,12 +171,9 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
             <div className="form-group">
               <SearchableSelect
                 label="Default Locale"
-                options={globalCurrencies.map(gc => ({
-                  label: gc.locale,
-                  value: gc.locale,
-                  subLabel: `${gc.country_territory} (${gc.iso})`
-                }))}
+                options={[AUTOMATIC_LOCALE_OPTION, ...LOCALE_OPTIONS]}
                 value={newUserLocale}
+                placeholder="Choose a locale"
                 onChange={setNewUserLocale}
               />
             </div>
@@ -200,11 +199,11 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
             <div className="form-group">
               <SearchableSelect
                 label="Currency"
-                options={globalCurrencies.map(gc => ({
+                options={[AUTOMATIC_CURRENCY_OPTION, ...globalCurrencies.map(gc => ({
                   label: `${gc.iso} (${gc.symbol})`,
                   value: gc.iso,
                   subLabel: gc.currency_name
-                }))}
+                }))]}
                 value={editingUser.currency || ''}
                 onChange={(val) => {
                   setEditingUser(prev => prev ? { ...prev, currency: val } : null);
@@ -216,11 +215,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
             <div className="form-group">
               <SearchableSelect
                 label="Locale Format"
-                options={globalCurrencies.map(gc => ({
-                  label: gc.locale,
-                  value: gc.locale,
-                  subLabel: `${gc.country_territory} (${gc.iso})`
-                }))}
+                options={[AUTOMATIC_LOCALE_OPTION, ...LOCALE_OPTIONS]}
                 value={editingUser.locale || ''}
                 onChange={(val) => setEditingUser(prev => prev ? { ...prev, locale: val } : null)}
               />

--- a/frontend/src/features/auth/services/AuthService.ts
+++ b/frontend/src/features/auth/services/AuthService.ts
@@ -10,8 +10,8 @@ export interface AuthenticatedUser {
   id: number;
   email: string;
   name: string | null;
-  currency: string;
-  locale: string;
+  currency: string | null;
+  locale: string | null;
   is_admin: boolean;
   categories: string[];
 }

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
@@ -109,7 +109,7 @@ export default function NotificationHistory() {
             <NotificationTable 
               notifications={filteredNotifications} 
               loading={historyQuery.isLoading}
-              userLocale={user?.locale}
+              userLocale={user?.locale ?? undefined}
             />
 
             {totalPages > 1 && (

--- a/frontend/src/features/products/components/PriceChart/PriceChart.tsx
+++ b/frontend/src/features/products/components/PriceChart/PriceChart.tsx
@@ -11,6 +11,8 @@ import {
   Legend,
 } from 'recharts';
 import { PriceHistory } from '../../../../types/api';
+import { useAuth } from '../../../auth';
+import { formatPrice as formatPriceUtil, formatDateWithOptions } from '../../../../utils/format';
 
 const getThemeColors = () => {
   const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
@@ -42,6 +44,7 @@ export default function PriceChart({
   targetPrice,
   onRangeChange,
 }: PriceChartProps) {
+  const { user } = useAuth();
   const [selectedRange, setSelectedRange] = useState<number | undefined>(30);
   const [themeColors, setThemeColors] = useState(getThemeColors);
 
@@ -60,12 +63,6 @@ export default function PriceChart({
     setSelectedRange(days);
     onRangeChange?.(days);
   };
-
-  const formatter = new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: currency || 'USD',
-    minimumFractionDigits: 2
-  });
 
   // Group price history by timestamp (within a 5-second window)
   const groupedData: {
@@ -116,14 +113,12 @@ export default function PriceChart({
     ? standardPrices.reduce((sum, p) => sum + p, 0) / standardPrices.length
     : 0;
 
-  const formatDate = (timestamp: number) => {
-    const date = new Date(timestamp);
-    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  };
+  const formatDate = (timestamp: number) =>
+    formatDateWithOptions(timestamp, user?.locale, { month: 'short', day: 'numeric' });
 
   const formatPrice = (value: number) => {
     if (value === null || value === undefined || isNaN(value)) return 'N/A';
-    return formatter.format(value);
+    return formatPriceUtil(value, currency, user?.locale);
   };
 
   if (prices.length === 0) {
@@ -281,7 +276,7 @@ export default function PriceChart({
                 return [formatPrice(Number(numericValue ?? 0)), String(name ?? '')];
               }}
               labelFormatter={(label) =>
-                new Date(String(label)).toLocaleDateString(undefined, {
+                formatDateWithOptions(Number(label), user?.locale, {
                   weekday: 'short',
                   month: 'short',
                   day: 'numeric',

--- a/frontend/src/features/products/components/PriceChart/PriceChart.tsx
+++ b/frontend/src/features/products/components/PriceChart/PriceChart.tsx
@@ -61,7 +61,7 @@ export default function PriceChart({
     onRangeChange?.(days);
   };
 
-  const formatter = new Intl.NumberFormat('en-AU', {
+  const formatter = new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency: currency || 'USD',
     minimumFractionDigits: 2
@@ -118,7 +118,7 @@ export default function PriceChart({
 
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   };
 
   const formatPrice = (value: number) => {
@@ -281,7 +281,7 @@ export default function PriceChart({
                 return [formatPrice(Number(numericValue ?? 0)), String(name ?? '')];
               }}
               labelFormatter={(label) =>
-                new Date(String(label)).toLocaleDateString('en-US', {
+                new Date(String(label)).toLocaleDateString(undefined, {
                   weekday: 'short',
                   month: 'short',
                   day: 'numeric',

--- a/frontend/src/features/products/components/PriceHistoryList.tsx
+++ b/frontend/src/features/products/components/PriceHistoryList.tsx
@@ -15,7 +15,7 @@ interface PriceHistoryListProps {
 const PriceHistoryList: React.FC<PriceHistoryListProps> = ({ 
   history, 
   currency, 
-  locale = 'en-US' 
+  locale
 }) => {
   const [page, setPage] = useState(1);
   const [isExpanded, setIsExpanded] = useState(false);

--- a/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.tsx
+++ b/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.tsx
@@ -4,6 +4,8 @@ import { formatPrice } from '../../../../utils/format';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import './PriceSelectionModal.css';
 import Icon from '../../../../components/Icon';
+import { useQuery } from '@tanstack/react-query';
+import { currenciesQuery } from '../../../../api/queries';
 
 export interface PriceCandidate {
   price: number;
@@ -95,7 +97,8 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
   const [activeFilter, setActiveFilter] = useState<PriceTypeFilter>('all');
   const [showManualEntry, setShowManualEntry] = useState(false);
   const [manualPrice, setManualPrice] = useState('');
-  const [manualCurrency, setManualCurrency] = useState('AUD');
+  const [manualCurrency, setManualCurrency] = useState('');
+  const currenciesResult = useQuery(currenciesQuery());
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -152,8 +155,8 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
   const handleConfirm = async () => {
     if (showManualEntry) {
       const parsed = parseFloat(manualPrice);
-      if (isNaN(parsed) || parsed <= 0) {
-        setWarningMessage('Please enter a valid price greater than $0.00.');
+      if (isNaN(parsed) || parsed <= 0 || !manualCurrency) {
+        setWarningMessage('Please enter a valid price and select its currency.');
         return;
       }
       setIsSubmitting(true);
@@ -167,6 +170,14 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
 
     if (selectedIndex === null || selectedIndex < 0 || isSubmitting) return;
     const selected = filteredCandidates[selectedIndex];
+
+    if (!selected.currency) {
+      setManualPrice(String(selected.price));
+      setManualCurrency('');
+      setShowManualEntry(true);
+      setWarningMessage('Select the currency for this extracted price before tracking it.');
+      return;
+    }
 
     // Submission warnings for low confidence
     if (selected.confidence < 0.3 && !warningMessage) {
@@ -303,11 +314,10 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
                   value={manualCurrency}
                   onChange={(e) => setManualCurrency(e.target.value)}
                 >
-                  <option value="AUD">AUD</option>
-                  <option value="USD">USD</option>
-                  <option value="EUR">EUR</option>
-                  <option value="GBP">GBP</option>
-                  <option value="NZD">NZD</option>
+                  <option value="">Currency</option>
+                  {(currenciesResult.data || []).map((currency) => (
+                    <option key={currency.iso} value={currency.iso}>{currency.iso} — {currency.currency_name}</option>
+                  ))}
                 </select>
               </div>
               <button

--- a/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.tsx
+++ b/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.tsx
@@ -65,6 +65,7 @@ const METHOD_TIERS: Record<string, number> = {
 
 const REVIEW_REASON_COPY: Record<string, string> = {
   no_consensus: 'Our scrapers found multiple conflicting prices. Please confirm the correct price.',
+  missing_currency: 'We found a price but could not determine its currency. Please confirm the price and select its currency.',
   ai_correction: 'Our AI suggested a different price from the raw layout. Please review and confirm.',
   oos_guardrail: 'This item appears to be out of stock. Please confirm the last known price.',
   manual_rescan: 'You requested a manual re-scan. Please verify the current price.',
@@ -98,6 +99,9 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
   const [showManualEntry, setShowManualEntry] = useState(false);
   const [manualPrice, setManualPrice] = useState('');
   const [manualCurrency, setManualCurrency] = useState('');
+  // Candidate that seeded manual entry (currency-only completion): its
+  // method/selector must survive so the retailer config still learns from it.
+  const [manualSource, setManualSource] = useState<PriceCandidate | null>(null);
   const currenciesResult = useQuery(currenciesQuery());
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -161,7 +165,14 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
       }
       setIsSubmitting(true);
       try {
-        await onSelect(parsed, 'manual', manualCurrency, category || null);
+        // If manual entry only supplied the missing currency for an extracted
+        // candidate, keep that candidate's method and selector so the backend
+        // can still learn the retailer configuration.
+        if (manualSource && parsed === manualSource.price) {
+          await onSelect(parsed, manualSource.method, manualCurrency, category || null, manualSource.selector);
+        } else {
+          await onSelect(parsed, 'manual', manualCurrency, category || null);
+        }
       } finally {
         setIsSubmitting(false);
       }
@@ -174,6 +185,7 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
     if (!selected.currency) {
       setManualPrice(String(selected.price));
       setManualCurrency('');
+      setManualSource(selected);
       setShowManualEntry(true);
       setWarningMessage('Select the currency for this extracted price before tracking it.');
       return;
@@ -325,6 +337,7 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
                 style={{ textAlign: 'left', marginTop: '0.25rem' }}
                 onClick={() => {
                   setShowManualEntry(false);
+                  setManualSource(null);
                   setWarningMessage(null);
                 }}
               >
@@ -383,6 +396,7 @@ const PriceSelectionModal: React.FC<PriceSelectionModalProps> = ({
               )}
 
               <button className="manual-entry-link" onClick={() => {
+                setManualSource(null);
                 setShowManualEntry(true);
                 setWarningMessage(null);
               }}>

--- a/frontend/src/features/products/components/ProductCard/ProductCard.tsx
+++ b/frontend/src/features/products/components/ProductCard/ProductCard.tsx
@@ -122,6 +122,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
   const isMemberOnly = product.stock_status === 'member_only';
   const isNotAvailable = product.stock_status === 'not_available';
   const isPaused = product.checking_paused;
+  const conversionRequested = Boolean(user?.currency && product.currency && user.currency !== product.currency);
+  const conversionDetails = product.conversion_rate_date
+    ? `Converted using ${product.conversion_source || 'the reference exchange rate'} from ${product.conversion_rate_date}.`
+    : 'Converted using the latest available reference exchange rate.';
 
   return (
     <div className={`pb-card ${isPaused ? 'paused' : ''} ${isOutOfStock ? 'out-of-stock' : ''} ${isPreOrder ? 'pre-order' : ''} ${isMemberOnly ? 'member-only' : ''} ${isNotAvailable ? 'not-available' : ''}`}>
@@ -172,9 +176,14 @@ const ProductCard: React.FC<ProductCardProps> = ({
                     {formatPrice(product.original_price, product.currency, user?.locale)}
                   </span>
                 )}
-                {product.converted_price && product.converted_currency !== product.currency && (
-                  <span className="pb-card-price-converted" title="Converted Price">
+                {product.converted_price !== null && product.converted_currency !== product.currency && (
+                  <span className="pb-card-price-converted" title={conversionDetails} aria-label={conversionDetails}>
                     (~{formatPrice(product.converted_price, product.converted_currency, user?.locale)})
+                  </span>
+                )}
+                {conversionRequested && product.converted_price === null && (
+                  <span className="pb-card-price-converted" title="No exchange rate is available for this currency pair.">
+                    Conversion unavailable
                   </span>
                 )}
                 <span className="pb-card-meta">

--- a/frontend/src/features/products/components/ProductCard/ProductCard.tsx
+++ b/frontend/src/features/products/components/ProductCard/ProductCard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from '@tanstack/react-router';
 import { Product } from '../../../../types/api';
 import { useAuth } from '../../../auth';
-import { formatPrice, truncateUrl } from '../../../../utils/format';
+import { formatPrice, formatDate, truncateUrl } from '../../../../utils/format';
 import Sparkline from '../Sparkline';
 import ProductBadges from '../ProductBadges';
 import './ProductCard.css';
@@ -124,7 +124,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
   const isPaused = product.checking_paused;
   const conversionRequested = Boolean(user?.currency && product.currency && user.currency !== product.currency);
   const conversionDetails = product.conversion_rate_date
-    ? `Converted using ${product.conversion_source || 'the reference exchange rate'} from ${product.conversion_rate_date}.`
+    ? `Converted using ${product.conversion_source || 'the reference exchange rate'} from ${formatDate(product.conversion_rate_date, user?.locale)}.`
     : 'Converted using the latest available reference exchange rate.';
 
   return (

--- a/frontend/src/features/products/components/StockHistoryList.tsx
+++ b/frontend/src/features/products/components/StockHistoryList.tsx
@@ -12,7 +12,7 @@ interface StockHistoryListProps {
 
 const StockHistoryList: React.FC<StockHistoryListProps> = ({ 
   history, 
-  locale = 'en-US' 
+  locale
 }) => {
   const [page, setPage] = useState(1);
   const [isExpanded, setIsExpanded] = useState(false);

--- a/frontend/src/features/products/pages/dashboard/DashboardSummary.tsx
+++ b/frontend/src/features/products/pages/dashboard/DashboardSummary.tsx
@@ -5,6 +5,7 @@ import { Product } from '../../../../types/api';
 import { STOCK_COLORS } from '../../constants';
 import './DashboardSummary.css';
 import Icon from '../../../../components/Icon';
+import { formatPrice } from '../../../../utils/format';
 
 interface DashboardSummaryProps {
   summary: {
@@ -60,10 +61,7 @@ const DashboardSummary: React.FC<DashboardSummaryProps> = ({ summary }) => {
   // Format price helper
   const formatValue = (val: number | null, currency: string | null) => {
     if (val === null) return '-';
-    return new Intl.NumberFormat('en-AU', {
-      style: 'currency',
-      currency: currency || 'AUD'
-    }).format(val);
+    return formatPrice(val, currency, undefined, '-');
   };
 
   // Truncate name helper

--- a/frontend/src/features/products/pages/product-detail/ProductInfo.tsx
+++ b/frontend/src/features/products/pages/product-detail/ProductInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ProductBadges from '../../components/ProductBadges';
-import { formatPrice } from '../../../../utils/format';
+import { formatPrice, formatDate } from '../../../../utils/format';
 
 interface ProductImageProps {
   product: any;
@@ -81,7 +81,7 @@ export const ProductPriceStatus: React.FC<ProductPriceStatusProps> = ({
   const fallbackLabel = isPreOrder ? 'TBD' : 'Price unavailable';
   const conversionRequested = Boolean(user?.currency && product.currency && user.currency !== product.currency);
   const conversionDetails = product.conversion_rate_date
-    ? `Converted using ${product.conversion_source || 'the reference exchange rate'} from ${product.conversion_rate_date}.`
+    ? `Converted using ${product.conversion_source || 'the reference exchange rate'} from ${formatDate(product.conversion_rate_date, user?.locale)}.`
     : 'Converted using the latest available reference exchange rate.';
 
   return (

--- a/frontend/src/features/products/pages/product-detail/ProductInfo.tsx
+++ b/frontend/src/features/products/pages/product-detail/ProductInfo.tsx
@@ -79,6 +79,10 @@ export const ProductPriceStatus: React.FC<ProductPriceStatusProps> = ({
   const isOutOfStock = product.stock_status === 'out_of_stock' || product.stock_status === 'not_available';
   const isPreOrder = product.stock_status === 'pre_order';
   const fallbackLabel = isPreOrder ? 'TBD' : 'Price unavailable';
+  const conversionRequested = Boolean(user?.currency && product.currency && user.currency !== product.currency);
+  const conversionDetails = product.conversion_rate_date
+    ? `Converted using ${product.conversion_source || 'the reference exchange rate'} from ${product.conversion_rate_date}.`
+    : 'Converted using the latest available reference exchange rate.';
 
   return (
     <div className="product-detail-info-right">
@@ -105,9 +109,14 @@ export const ProductPriceStatus: React.FC<ProductPriceStatusProps> = ({
         ) : (
           <span>{formatPrice(product.current_price, product.currency, user?.locale, fallbackLabel)}</span>
         )}
-        {product.converted_price && product.converted_currency !== product.currency && (
-          <span style={{ fontSize: '1.25rem', color: 'var(--text-muted)', fontWeight: 600 }}>
+        {product.converted_price !== null && product.converted_currency !== product.currency && (
+          <span title={conversionDetails} aria-label={conversionDetails} style={{ fontSize: '1.25rem', color: 'var(--text-muted)', fontWeight: 600 }}>
             (~{formatPrice(product.converted_price, product.converted_currency, user?.locale)})
+          </span>
+        )}
+        {conversionRequested && product.converted_price === null && (
+          <span title="No exchange rate is available for this currency pair." style={{ fontSize: '1rem', color: 'var(--text-muted)', fontWeight: 600 }}>
+            Conversion unavailable
           </span>
         )}
       </div>

--- a/frontend/src/features/settings/pages/ProfileSection.tsx
+++ b/frontend/src/features/settings/pages/ProfileSection.tsx
@@ -30,9 +30,8 @@ export default function ProfileSection() {
     try {
       const res = await updateProfile.mutateAsync({
         name: profileName,
-        currency: profile?.currency || 'AUD',
-        locale: profile?.locale || 'en-AU',
-        preferred_currency: profile?.currency || 'AUD'
+        currency: profile?.currency ?? null,
+        locale: profile?.locale ?? null,
       });
       updateUser({ name: res.name, currency: res.currency, locale: res.locale });
       showToast('Profile updated', 'success');

--- a/frontend/src/features/settings/pages/RegionalSection.tsx
+++ b/frontend/src/features/settings/pages/RegionalSection.tsx
@@ -8,12 +8,13 @@ import SearchableSelect from '../../../components/SearchableSelect';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import { queryClient } from '../../../api/queryClient';
 import { currenciesQuery, profileQuery, queryKeys } from '../../../api/queries';
+import { AUTOMATIC_CURRENCY_OPTION, AUTOMATIC_LOCALE_OPTION, LOCALE_OPTIONS } from '../regionalOptions';
 
 export default function RegionalSection() {
   const { showToast } = useToast();
   const { updateUser } = useAuth();
-  const [profileCurrency, setProfileCurrency] = useState('AUD');
-  const [profileLocale, setProfileLocale] = useState('en-AU');
+  const [profileCurrency, setProfileCurrency] = useState('');
+  const [profileLocale, setProfileLocale] = useState('');
   const initializedProfileId = useRef<number | null>(null);
   const profileResult = useQuery(profileQuery());
   const currenciesResult = useQuery(currenciesQuery());
@@ -27,17 +28,16 @@ export default function RegionalSection() {
   useEffect(() => {
     if (!profile || initializedProfileId.current === profile.id) return;
     initializedProfileId.current = profile.id;
-    setProfileCurrency(profile.currency || 'AUD');
-    setProfileLocale(profile.locale || 'en-AU');
+    setProfileCurrency(profile.currency || '');
+    setProfileLocale(profile.locale || '');
   }, [profile]);
 
   const handleSaveRegional = async () => {
     try {
       const res = await updateProfile.mutateAsync({
         name: profile?.name || '', 
-        currency: profileCurrency, 
-        locale: profileLocale, 
-        preferred_currency: profileCurrency 
+        currency: profileCurrency || null,
+        locale: profileLocale || null,
       });
       updateUser({ name: res.name, currency: res.currency, locale: res.locale });
       showToast('Regional settings updated', 'success');
@@ -60,12 +60,13 @@ export default function RegionalSection() {
         <div className="form-group">
           <SearchableSelect
             label="Preferred Currency"
-            options={globalCurrencies.map(gc => ({
+            options={[AUTOMATIC_CURRENCY_OPTION, ...globalCurrencies.map(gc => ({
               label: `${gc.iso} (${gc.symbol})`,
               value: gc.iso,
               subLabel: gc.currency_name
-            }))}
+            }))]}
             value={profileCurrency}
+            placeholder="Choose a currency"
             onChange={(val) => {
               setProfileCurrency(val);
               const match = globalCurrencies.find(gc => gc.iso === val);
@@ -76,19 +77,16 @@ export default function RegionalSection() {
         <div className="form-group">
           <SearchableSelect
             label="Locale Format"
-            options={globalCurrencies.map(gc => ({
-              label: gc.locale,
-              value: gc.locale,
-              subLabel: `${gc.country_territory} (${gc.iso})`
-            }))}
+            options={[AUTOMATIC_LOCALE_OPTION, ...LOCALE_OPTIONS]}
             value={profileLocale}
+            placeholder="Choose a locale"
             onChange={setProfileLocale}
           />
         </div>
       </div>
 
       <div className="settings-actions">
-        <button className="btn btn-secondary" onClick={() => { setProfileCurrency(profile.currency || 'AUD'); setProfileLocale(profile.locale || 'en-AU'); }}>Cancel</button>
+        <button className="btn btn-secondary" onClick={() => { setProfileCurrency(profile.currency || ''); setProfileLocale(profile.locale || ''); }}>Cancel</button>
         <button className="btn btn-primary" onClick={handleSaveRegional} disabled={updateProfile.isPending}>
           {updateProfile.isPending ? 'Saving...' : 'Save Regional Settings'}
         </button>

--- a/frontend/src/features/settings/regionalOptions.test.ts
+++ b/frontend/src/features/settings/regionalOptions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { LOCALE_OPTIONS } from './regionalOptions';
+
+const EXISTING_DEFAULT_LOCALES = [
+  'de-CH', 'en-US', 'de-DE', 'en-GB', 'en-AU', 'en-CA', 'en-NZ', 'ja-JP',
+  'zh-CN', 'en-IN', 'pt-BR', 'es-MX', 'pl-PL', 'sv-SE', 'nb-NO', 'da-DK',
+  'cs-CZ', 'hu-HU', 'ro-RO', 'tr-TR', 'ru-RU', 'ko-KR', 'en-SG', 'zh-HK',
+  'en-ZA', 'he-IL', 'ar-AE', 'th-TH', 'ms-MY', 'en-PH', 'id-ID', 'vi-VN',
+  'es-CL', 'es-AR', 'es-CO', 'uk-UA',
+];
+
+const TARGETED_ADDITIONS = [
+  'is-IS', 'de-AT', 'fr-BE', 'nl-BE', 'fr-FR', 'it-IT', 'es-ES', 'nl-NL',
+  'en-IE', 'pt-PT', 'fi-FI', 'el-GR', 'sk-SK', 'sl-SI', 'et-EE', 'lv-LV',
+  'lt-LT', 'fr-LU', 'el-CY', 'mt-MT', 'fr-CA', 'fr-CH', 'it-CH',
+];
+
+describe('LOCALE_OPTIONS', () => {
+  it('contains every existing currency default and only the targeted additions', () => {
+    const localeCodes = LOCALE_OPTIONS.map(({ value }) => value);
+
+    expect(localeCodes).toHaveLength(EXISTING_DEFAULT_LOCALES.length + TARGETED_ADDITIONS.length);
+    expect(new Set(localeCodes).size).toBe(localeCodes.length);
+    expect(localeCodes).toEqual(expect.arrayContaining(EXISTING_DEFAULT_LOCALES));
+    expect(localeCodes).toEqual(expect.arrayContaining(TARGETED_ADDITIONS));
+  });
+
+  it('includes Icelandic formatting for the newly supported currency', () => {
+    expect(LOCALE_OPTIONS).toContainEqual({
+      label: 'Icelandic (Iceland)',
+      value: 'is-IS',
+      subLabel: 'is-IS',
+    });
+  });
+});

--- a/frontend/src/features/settings/regionalOptions.ts
+++ b/frontend/src/features/settings/regionalOptions.ts
@@ -1,0 +1,86 @@
+export interface LocaleOption {
+  label: string;
+  value: string;
+  subLabel: string;
+}
+
+export const AUTOMATIC_CURRENCY_OPTION = {
+  label: 'Automatic',
+  value: '',
+  subLabel: 'Show retailer prices without conversion',
+};
+
+export const AUTOMATIC_LOCALE_OPTION: LocaleOption = {
+  label: 'Automatic',
+  value: '',
+  subLabel: 'Use your browser format',
+};
+
+/**
+ * Display formats for the shopping markets PriceStalker already supports.
+ *
+ * This is intentionally a compact, frontend-only list rather than a general
+ * BCP 47 catalogue. It includes every existing currency default plus the
+ * country/language variants covered by the current regional domain mappings.
+ */
+export const LOCALE_OPTIONS: LocaleOption[] = [
+  { label: 'Arabic (United Arab Emirates)', value: 'ar-AE', subLabel: 'ar-AE' },
+  { label: 'Czech (Czechia)', value: 'cs-CZ', subLabel: 'cs-CZ' },
+  { label: 'Danish (Denmark)', value: 'da-DK', subLabel: 'da-DK' },
+  { label: 'German (Austria)', value: 'de-AT', subLabel: 'de-AT' },
+  { label: 'German (Switzerland)', value: 'de-CH', subLabel: 'de-CH' },
+  { label: 'German (Germany)', value: 'de-DE', subLabel: 'de-DE' },
+  { label: 'Greek (Cyprus)', value: 'el-CY', subLabel: 'el-CY' },
+  { label: 'Greek (Greece)', value: 'el-GR', subLabel: 'el-GR' },
+  { label: 'English (Australia)', value: 'en-AU', subLabel: 'en-AU' },
+  { label: 'English (Canada)', value: 'en-CA', subLabel: 'en-CA' },
+  { label: 'English (United Kingdom)', value: 'en-GB', subLabel: 'en-GB' },
+  { label: 'English (Ireland)', value: 'en-IE', subLabel: 'en-IE' },
+  { label: 'English (India)', value: 'en-IN', subLabel: 'en-IN' },
+  { label: 'English (New Zealand)', value: 'en-NZ', subLabel: 'en-NZ' },
+  { label: 'English (Philippines)', value: 'en-PH', subLabel: 'en-PH' },
+  { label: 'English (Singapore)', value: 'en-SG', subLabel: 'en-SG' },
+  { label: 'English (United States)', value: 'en-US', subLabel: 'en-US' },
+  { label: 'English (South Africa)', value: 'en-ZA', subLabel: 'en-ZA' },
+  { label: 'Spanish (Argentina)', value: 'es-AR', subLabel: 'es-AR' },
+  { label: 'Spanish (Chile)', value: 'es-CL', subLabel: 'es-CL' },
+  { label: 'Spanish (Colombia)', value: 'es-CO', subLabel: 'es-CO' },
+  { label: 'Spanish (Spain)', value: 'es-ES', subLabel: 'es-ES' },
+  { label: 'Spanish (Mexico)', value: 'es-MX', subLabel: 'es-MX' },
+  { label: 'Estonian (Estonia)', value: 'et-EE', subLabel: 'et-EE' },
+  { label: 'Finnish (Finland)', value: 'fi-FI', subLabel: 'fi-FI' },
+  { label: 'French (Belgium)', value: 'fr-BE', subLabel: 'fr-BE' },
+  { label: 'French (Canada)', value: 'fr-CA', subLabel: 'fr-CA' },
+  { label: 'French (Switzerland)', value: 'fr-CH', subLabel: 'fr-CH' },
+  { label: 'French (France)', value: 'fr-FR', subLabel: 'fr-FR' },
+  { label: 'French (Luxembourg)', value: 'fr-LU', subLabel: 'fr-LU' },
+  { label: 'Hebrew (Israel)', value: 'he-IL', subLabel: 'he-IL' },
+  { label: 'Hungarian (Hungary)', value: 'hu-HU', subLabel: 'hu-HU' },
+  { label: 'Indonesian (Indonesia)', value: 'id-ID', subLabel: 'id-ID' },
+  { label: 'Icelandic (Iceland)', value: 'is-IS', subLabel: 'is-IS' },
+  { label: 'Italian (Switzerland)', value: 'it-CH', subLabel: 'it-CH' },
+  { label: 'Italian (Italy)', value: 'it-IT', subLabel: 'it-IT' },
+  { label: 'Japanese (Japan)', value: 'ja-JP', subLabel: 'ja-JP' },
+  { label: 'Korean (South Korea)', value: 'ko-KR', subLabel: 'ko-KR' },
+  { label: 'Lithuanian (Lithuania)', value: 'lt-LT', subLabel: 'lt-LT' },
+  { label: 'Latvian (Latvia)', value: 'lv-LV', subLabel: 'lv-LV' },
+  { label: 'Maltese (Malta)', value: 'mt-MT', subLabel: 'mt-MT' },
+  { label: 'Malay (Malaysia)', value: 'ms-MY', subLabel: 'ms-MY' },
+  { label: 'Dutch (Belgium)', value: 'nl-BE', subLabel: 'nl-BE' },
+  { label: 'Dutch (Netherlands)', value: 'nl-NL', subLabel: 'nl-NL' },
+  { label: 'Norwegian Bokmål (Norway)', value: 'nb-NO', subLabel: 'nb-NO' },
+  { label: 'Polish (Poland)', value: 'pl-PL', subLabel: 'pl-PL' },
+  { label: 'Portuguese (Brazil)', value: 'pt-BR', subLabel: 'pt-BR' },
+  { label: 'Portuguese (Portugal)', value: 'pt-PT', subLabel: 'pt-PT' },
+  { label: 'Romanian (Romania)', value: 'ro-RO', subLabel: 'ro-RO' },
+  { label: 'Russian (Russia)', value: 'ru-RU', subLabel: 'ru-RU' },
+  { label: 'Slovak (Slovakia)', value: 'sk-SK', subLabel: 'sk-SK' },
+  { label: 'Slovenian (Slovenia)', value: 'sl-SI', subLabel: 'sl-SI' },
+  { label: 'Swedish (Sweden)', value: 'sv-SE', subLabel: 'sv-SE' },
+  { label: 'Thai (Thailand)', value: 'th-TH', subLabel: 'th-TH' },
+  { label: 'Turkish (Turkey)', value: 'tr-TR', subLabel: 'tr-TR' },
+  { label: 'Ukrainian (Ukraine)', value: 'uk-UA', subLabel: 'uk-UA' },
+  { label: 'Vietnamese (Vietnam)', value: 'vi-VN', subLabel: 'vi-VN' },
+  { label: 'Chinese (China)', value: 'zh-CN', subLabel: 'zh-CN' },
+  { label: 'Chinese (Hong Kong)', value: 'zh-HK', subLabel: 'zh-HK' },
+];

--- a/frontend/src/features/settings/services/ProfileService.ts
+++ b/frontend/src/features/settings/services/ProfileService.ts
@@ -4,7 +4,7 @@ import { UserProfile, NotificationSettings } from '../../../types/api';
 export const ProfileService = {
   getProfile: (options?: RequestOptions) => api.get<UserProfile>('/profile', options),
 
-  updateProfile: (data: { name?: string; currency?: string; locale?: string; preferred_currency?: string }) =>
+  updateProfile: (data: { name?: string; currency?: string | null; locale?: string | null }) =>
     api.put<UserProfile>('/profile', data),
 
   changePassword: (current: string, next: string) => 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -30,6 +30,8 @@ export interface Product {
   currency: string | null;
   converted_price: number | null;
   converted_currency: string | null;
+  conversion_rate_date?: string | null;
+  conversion_source?: string | null;
   ai_status: AIStatus;
   price_type?: 'standard' | 'member-price' | 'deal-price' | 'pre-order' | null;
   preferred_extraction_method?: string | null;
@@ -138,9 +140,9 @@ export interface UserProfile {
   id: number;
   email: string;
   name: string | null;
-  currency: string;
-  locale: string;
-  preferred_currency: string;
+  currency: string | null;
+  locale: string | null;
+  preferred_currency: string | null;
   is_admin: boolean;
   disabled: boolean;
   categories: string[];

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -67,7 +67,7 @@ export interface SearchResult {
   isSupported: boolean;
 }
 
-export type ReviewReason = 'no_consensus' | 'ai_correction' | 'oos_guardrail' | 'manual_rescan' | 'first_scan';
+export type ReviewReason = 'no_consensus' | 'ai_correction' | 'oos_guardrail' | 'manual_rescan' | 'first_scan' | 'missing_currency';
 
 export interface PriceReviewResponse {
   needsReview: true;

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -5,7 +5,7 @@
 export function formatPrice(
   price: number | string | null | undefined,
   currency: string | null = 'USD',
-  locale: string | null | undefined = 'en-AU',
+  locale?: string | null,
   fallback: string = 'N/A'
 ): string {
   if (price === null || price === undefined) return fallback;
@@ -64,7 +64,7 @@ export function formatRelativeDate(dateString: string | null): string {
  */
 export function formatDate(
   dateString: string | null | undefined,
-  locale: string | null | undefined = 'en-AU',
+  locale?: string | null,
   includeTime: boolean = false
 ): string {
   if (!dateString) return 'N/A';

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -12,11 +12,24 @@ export function formatPrice(
   const numPrice = typeof price === 'string' ? parseFloat(price) : price;
   if (isNaN(numPrice)) return fallback;
 
+  // An unknown currency ('' from the scraper's review flow, or null) must not
+  // masquerade as USD — show a plain localized number instead.
+  if (!currency) {
+    try {
+      return new Intl.NumberFormat(locale ?? undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(numPrice);
+    } catch {
+      return numPrice.toFixed(2);
+    }
+  }
+
   try {
     // Intl throws on an explicit null; undefined means "use the runtime default".
     const formatter = new Intl.NumberFormat(locale ?? undefined, {
       style: 'currency',
-      currency: currency || 'USD',
+      currency,
       currencyDisplay: 'narrowSymbol',
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
@@ -57,6 +70,24 @@ export function formatRelativeDate(dateString: string | null): string {
   if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`;
   
   return date.toLocaleDateString();
+}
+
+/**
+ * Localized date formatting with caller-supplied Intl options (e.g. compact
+ * chart axis labels). Normalises a null locale so Intl never throws on it.
+ */
+export function formatDateWithOptions(
+  value: string | number | Date,
+  locale: string | null | undefined,
+  options: Intl.DateTimeFormatOptions
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date.getTime())) return 'N/A';
+  try {
+    return date.toLocaleDateString(locale ?? undefined, options);
+  } catch {
+    return date.toLocaleDateString(undefined, options);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- add ISK plus the targeted locale formats needed by PriceStalker's existing shopping-market coverage
- make locale and display-currency preferences optional for new accounts, while preserving every existing user's settings
- move exchange-rate refreshes to Frankfurter v2 and show rate provenance or an unavailable-conversion state
- require manual confirmation when a numeric price has no reliable currency

## Rationale

PriceStalker is self-hosted and serves shoppers across multiple markets. A hard-coded locale or currency makes a new account look correct for one market while giving other users unfamiliar dates, decimal separators, grouping, and conversion behavior. The better default is therefore no imposed locale and no imposed display currency: the browser supplies the familiar locale format, and retailer prices remain in their original currency until the user explicitly chooses conversion. This is predictable, avoids silent conversion assumptions, and leaves existing users unchanged.

The locale catalog stays intentionally small. It retains the existing formats and adds only formats represented by the application's current supported currency and domain coverage, rather than presenting an unwieldy global locale catalog. ISK and `.is` complete the one remaining currency supported by the FX provider but absent from the picker.

Frankfurter v2 provides daily EUR-based reference rates without another dependency or token. Storing its date and source makes converted values explainable; when a rate is absent, the UI says so instead of silently hiding the failed conversion.

## Validation

- backend TypeScript build and 113 tests
- frontend typecheck, production build, and locale-options tests
- emoji lint and diff checks
- migration 008 applied twice against temporary PostgreSQL: defaults removed, metadata columns present, and rate cache cleared idempotently