### PR TITLE
fix(scraper): stop leaking Chromium profiles in /tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The browser scraper no longer leaks Chromium profile directories in /tmp:
+  profiles are pinned per session and removed when the browser closes,
+  crashes, or the container stops, stale profiles are swept at startup, and
+  the container's /tmp is backed by a capped tmpfs so nothing accumulates in
+  the writable layer.
 - Currency conversion now triangulates via the EUR reference base, so
   conversions between two non-EUR currencies keep working after the switch to
   EUR-based reference rates.

--- a/deploy/swarm-stack.yml
+++ b/deploy/swarm-stack.yml
@@ -122,6 +122,14 @@ services:
       pricestalker-internal:
         aliases:
           - remotescraper
+    # Chromium writes its per-session profiles to /tmp. Backing it with a
+    # capped tmpfs keeps leaked profiles out of the node's overlay storage and
+    # clears them on restart (issue #52).
+    volumes:
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          size: 1073741824
     deploy:
       restart_policy:
         condition: on-failure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,6 +108,14 @@ services:
       default:
         aliases:
           - remotescraper
+    # Chromium writes its per-session profiles to /tmp. Backing it with a
+    # capped tmpfs keeps leaked profiles out of the container's writable layer
+    # and clears them on restart (issue #52).
+    volumes:
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          size: 1073741824
 
 volumes:
   postgres_data:

--- a/scraper/src/core/SessionManager.ts
+++ b/scraper/src/core/SessionManager.ts
@@ -1,6 +1,9 @@
 import puppeteerExtra from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import AdblockerPlugin from 'puppeteer-extra-plugin-adblocker';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { log } from '../utils/logger.js';
 import type { Browser } from 'puppeteer';
 import type { BrowserSession, ScrapeOptions } from '../types.js';
@@ -26,18 +29,67 @@ export const IDLE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
 export const sessions: BrowserSession[] = [];
 
+// Chromium profiles live under a dedicated base directory so leaked ones can
+// be identified and swept. Without an explicit userDataDir Puppeteer creates
+// /tmp/puppeteer_dev_profile-* directories that are only removed on a clean
+// browser.close() — crashed browsers and container stops leaked them until
+// /tmp filled up (issue #52).
+export const PROFILE_BASE = path.join(os.tmpdir(), 'scraper-profiles');
+
+/**
+ * Deletes a session's Chromium profile directory. Safe to call repeatedly;
+ * failures are logged and left for the startup sweep.
+ */
+async function removeProfileDir(session: BrowserSession) {
+  const dir = session.userDataDir;
+  if (!dir) return;
+  session.userDataDir = null;
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch (error) {
+    log(`Failed to remove profile dir for ${session.id}: ${errorMessage(error)}`, 'WARN');
+  }
+}
+
+/**
+ * Removes profile directories that no live session owns: leftovers in
+ * PROFILE_BASE from a previous process, plus legacy puppeteer_dev_profile-*
+ * directories created before profiles were pinned to PROFILE_BASE.
+ */
+export async function cleanupStaleProfiles() {
+  const live = new Set(sessions.map(s => s.userDataDir).filter(Boolean));
+  for (const [base, prefix] of [[PROFILE_BASE, 'session_'], [os.tmpdir(), 'puppeteer_dev_profile-']] as const) {
+    let entries: string[] = [];
+    try {
+      entries = await fs.readdir(base);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(base, entry);
+      if (!entry.startsWith(prefix) || live.has(full)) continue;
+      try {
+        await fs.rm(full, { recursive: true, force: true });
+        log(`Removed stale browser profile ${full}`, 'INFO');
+      } catch (error) {
+        log(`Failed to remove stale profile ${full}: ${errorMessage(error)}`, 'WARN');
+      }
+    }
+  }
+}
+
 /**
  * Forcefully closes a browser session and removes it from the pool
  */
 export async function closeSession(session: BrowserSession) {
   const index = sessions.indexOf(session);
   if (index > -1) sessions.splice(index, 1);
-  
+
   if (session.idleTimer) {
     clearTimeout(session.idleTimer);
     session.idleTimer = null;
   }
-  
+
   try {
     log(`Closing browser session ${session.id} (Total Scrapes: ${session.totalScrapes})`, 'INFO');
     if (session.browser && session.browser.connected) {
@@ -46,6 +98,14 @@ export async function closeSession(session: BrowserSession) {
   } catch (error) {
     log(`Error closing browser ${session.id}: ${errorMessage(error)}`, 'ERROR');
   }
+  await removeProfileDir(session);
+}
+
+/**
+ * Closes every session (used on process shutdown so no profile survives).
+ */
+export async function shutdownAllSessions() {
+  await Promise.all([...sessions].map(session => closeSession(session)));
 }
 
 /**
@@ -76,6 +136,8 @@ export function startWatchdog() {
 export async function createNewSession(proxyUrl: string | null = null, userAgent: string | null = null): Promise<BrowserSession> {
   const id = `session_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
   
+  const userDataDir = path.join(PROFILE_BASE, id);
+
   const session: BrowserSession = {
     id,
     browser: null,
@@ -85,7 +147,8 @@ export async function createNewSession(proxyUrl: string | null = null, userAgent
     idleTimer: null,
     proxyUrl,
     userAgent,
-    lastActivity: Date.now()
+    lastActivity: Date.now(),
+    userDataDir
   };
 
   const args = [
@@ -106,18 +169,21 @@ export async function createNewSession(proxyUrl: string | null = null, userAgent
 
   log(`Launching new browser instance for ${id} (Proxy: ${proxyUrl || 'None'}, UA: ${userAgent ? 'Custom' : 'Default'})`, 'INFO');
   
-  session.launchPromise = puppeteer.launch({
+  session.launchPromise = fs.mkdir(userDataDir, { recursive: true }).then(() => puppeteer.launch({
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium',
     headless: 'new',
+    userDataDir,
     args
-  }).then((browser: Browser) => {
+  })).then((browser: Browser) => {
     session.browser = browser;
     session.launchPromise = null;
-    
+
     browser.on('disconnected', () => {
       log(`Browser session ${session.id} disconnected`, 'WARN');
       const idx = sessions.indexOf(session);
       if (idx > -1) sessions.splice(idx, 1);
+      // A crashed browser never reaches closeSession, so reap its profile here.
+      void removeProfileDir(session);
     });
 
     return browser;
@@ -125,6 +191,7 @@ export async function createNewSession(proxyUrl: string | null = null, userAgent
     log(`Failed to launch browser for ${id}: ${errorMessage(error)}`, 'ERROR');
     const idx = sessions.indexOf(session);
     if (idx > -1) sessions.splice(idx, 1);
+    void removeProfileDir(session);
     throw error;
   });
 

--- a/scraper/src/scraper.ts
+++ b/scraper/src/scraper.ts
@@ -1,7 +1,8 @@
 import express from 'express';
 import { log } from './utils/logger.js';
-import { startWatchdog } from './core/SessionManager.js';
+import { startWatchdog, cleanupStaleProfiles, shutdownAllSessions } from './core/SessionManager.js';
 import router from './api/routes.js';
+import { errorMessage } from './types.js';
 
 const app = express();
 app.use(express.json({ limit: '10mb' }));
@@ -11,8 +12,23 @@ const PORT = Number(process.env.PORT) || 5100;
 // Use modular routes
 app.use('/', router);
 
+// Reap browser profiles leaked by a previous run (crash, SIGKILL) before
+// launching anything new — see issue #52.
+cleanupStaleProfiles().catch((error: unknown) => {
+  log(`Startup profile sweep failed: ${errorMessage(error)}`, 'WARN');
+});
+
 // Start browser watchdog
 startWatchdog();
+
+// Close every browser (deleting its profile) before the container stops, so
+// profiles do not accumulate across restarts.
+for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+  process.on(signal, () => {
+    log(`Received ${signal}, closing browser sessions...`, 'INFO');
+    void shutdownAllSessions().finally(() => process.exit(0));
+  });
+}
 
 app.listen(PORT, '0.0.0.0', () => {
   log(`Scraper API listening at http://0.0.0.0:${PORT}`, 'INFO');

--- a/scraper/src/types.ts
+++ b/scraper/src/types.ts
@@ -33,6 +33,7 @@ export interface BrowserSession {
   proxyUrl: string | null;
   userAgent: string | null;
   lastActivity: number;
+  userDataDir: string | null;
 }
 
 export interface ScrapeResult {


### PR DESCRIPTION
## Summary

- pin each browser session's Chromium profile to `/tmp/scraper-profiles/<session-id>` and delete it when the session closes, the browser crashes, or the process receives SIGTERM/SIGINT
- sweep stale profiles (including legacy `puppeteer_dev_profile-*` directories) at startup
- back the container's `/tmp` with a capped tmpfs in compose and the swarm stack so leaked profiles never reach the writable layer

## Validation

- scraper workspace typecheck/build
- YAML validity of both stack files

Closes #52