### PR TITLE
fix(retailers): allow clearing selector lists and settings fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   crashes, or the container stops, stale profiles are swept at startup, and
   the container's /tmp is backed by a capped tmpfs so nothing accumulates in
   the writable layer.
+- Retailer selector lists and text fields (description, user agent, currency
+  hint, JSON-LD keys) can now be cleared from the admin UI: a submitted empty
+  value deletes the stored one instead of being silently ignored, and AI
+  auto-mapping no longer overwrites learned selector metadata with an empty
+  object.
 - Currency conversion now triangulates via the EUR reference base, so
   conversions between two non-EUR currencies keep working after the switch to
   EUR-based reference rates.

--- a/backend/src/services/ai/strategies/retailer-config.ts
+++ b/backend/src/services/ai/strategies/retailer-config.ts
@@ -106,22 +106,31 @@ export async function generateRetailerConfig(
       }
     }
 
-    const resultConfig: Partial<RetailerConfig> = {
-      name: data.retailer_name || null,
-      currency_hint: finalCurrency,
-      name_selectors: cleanAndValidateSelectors(data.name_selectors, url),
-      price_selectors: cleanAndValidateSelectors(data.price_selectors, url),
-      deal_price_selectors: cleanAndValidateSelectors(data.deal_price_selectors, url),
-      member_price_selectors: cleanAndValidateSelectors(data.member_price_selectors, url),
-      pre_order_price_selectors: cleanAndValidateSelectors(data.pre_order_price_selectors, url),
-      original_price_selectors: cleanAndValidateSelectors(data.original_price_selectors, url),
-      image_selectors: cleanAndValidateSelectors(data.image_selectors, url),
-      stock_selectors: cleanAndValidateSelectors(data.stock_selectors, url),
-      jsonld_name_key: data.jsonld_name_key || null,
-      jsonld_price_key: data.jsonld_price_key || null,
-      jsonld_image_key: data.jsonld_image_key || null,
-      active: true,
-    };
+    // Only include fields the AI actually produced values for. The upsert
+    // treats a present-but-empty field as an explicit clear (issue #32), so
+    // including empty lists here would wipe previously learned selectors.
+    const resultConfig: Partial<RetailerConfig> = { active: true };
+    if (data.retailer_name) resultConfig.name = data.retailer_name;
+    if (finalCurrency) resultConfig.currency_hint = finalCurrency;
+
+    const selectorFields = [
+      ['name_selectors', data.name_selectors],
+      ['price_selectors', data.price_selectors],
+      ['deal_price_selectors', data.deal_price_selectors],
+      ['member_price_selectors', data.member_price_selectors],
+      ['pre_order_price_selectors', data.pre_order_price_selectors],
+      ['original_price_selectors', data.original_price_selectors],
+      ['image_selectors', data.image_selectors],
+      ['stock_selectors', data.stock_selectors],
+    ] as const;
+    for (const [field, raw] of selectorFields) {
+      const cleaned = cleanAndValidateSelectors(raw, url);
+      if (cleaned.length > 0) resultConfig[field] = cleaned;
+    }
+
+    if (data.jsonld_name_key) resultConfig.jsonld_name_key = data.jsonld_name_key;
+    if (data.jsonld_price_key) resultConfig.jsonld_price_key = data.jsonld_price_key;
+    if (data.jsonld_image_key) resultConfig.jsonld_image_key = data.jsonld_image_key;
 
     // Quality gate: require at least one valid price selector or a JSON-LD price key
     const hasPriceSelector = resultConfig.price_selectors && resultConfig.price_selectors.length > 0;

--- a/backend/src/services/domain/retailer/repositories/retailer-mutation.repository.ts
+++ b/backend/src/services/domain/retailer/repositories/retailer-mutation.repository.ts
@@ -1,6 +1,37 @@
 import pool from '../../../../config/database';
 import { RetailerConfig } from '../../../../models/types';
 
+// Fields whose updates are gated on presence in the payload: a field that is
+// absent (undefined) keeps its stored value, while a field that is present
+// updates the row even when it is empty. This is what lets an admin CLEAR a
+// selector list or text field — the old empty-means-keep SQL made deletion
+// impossible (issue #32). Callers that must not clobber existing data (e.g.
+// AI auto-mapping) simply omit fields they have no values for.
+const PRESENCE_FIELDS = [
+  'name_selectors',
+  'retailer_name_selectors',
+  'price_selectors',
+  'deal_price_selectors',
+  'member_price_selectors',
+  'image_selectors',
+  'stock_selectors',
+  'in_stock_phrases',
+  'out_of_stock_phrases',
+  'pre_order_phrases',
+  'pre_order_price_selectors',
+  'original_price_selectors',
+  'exclusion_selectors',
+  'custom_selectors',
+  'selector_metadata',
+  'ai_selectors',
+  'user_agent',
+  'description',
+  'currency_hint',
+  'jsonld_image_key',
+  'jsonld_price_key',
+  'jsonld_name_key',
+] as const;
+
 export const retailerMutationRepository = {
   delete: async (id: number): Promise<boolean> => {
     const result = await pool.query('DELETE FROM retailer_configs WHERE id = $1', [id]);
@@ -10,9 +41,11 @@ export const retailerMutationRepository = {
   upsert: async (config: Partial<RetailerConfig> & { forceNameRemoval?: boolean }, client?: any): Promise<RetailerConfig> => {
     const executor = client || pool;
     const domain = config.domain?.toLowerCase();
+    // $31..$52 — presence flags for PRESENCE_FIELDS, in that order.
+    const presence = PRESENCE_FIELDS.map(field => config[field] !== undefined);
     const result = await executor.query(
       `INSERT INTO retailer_configs (
-         domain, name, status, status_history, use_proxy, use_browser_scraper, currency_hint, 
+         domain, name, status, status_history, use_proxy, use_browser_scraper, currency_hint,
          name_selectors, price_selectors, deal_price_selectors, member_price_selectors, image_selectors, stock_selectors,
          in_stock_phrases, out_of_stock_phrases, pre_order_phrases, pre_order_price_selectors, user_agent, custom_selectors, active, description,
          retailer_name_selectors, jsonld_image_key, jsonld_price_key, jsonld_name_key, original_price_selectors, ai_selectors, exclusion_selectors,
@@ -20,49 +53,49 @@ export const retailerMutationRepository = {
        )
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
        ON CONFLICT (domain) DO UPDATE SET
-         name = CASE 
-           WHEN $30 = true THEN EXCLUDED.name 
+         name = CASE
+           WHEN $30 = true THEN EXCLUDED.name
            WHEN retailer_configs.name = INITCAP(SPLIT_PART(retailer_configs.domain, '.', 1)) THEN COALESCE(NULLIF(EXCLUDED.name, ''), retailer_configs.name)
-           ELSE COALESCE(retailer_configs.name, NULLIF(EXCLUDED.name, '')) 
+           ELSE COALESCE(retailer_configs.name, NULLIF(EXCLUDED.name, ''))
          END,
-         status_history = CASE 
+         status_history = CASE
            WHEN EXCLUDED.status IS NOT NULL AND (retailer_configs.status IS NULL OR EXCLUDED.status != retailer_configs.status)
            THEN jsonb_path_query_array(
                   jsonb_insert(
-                    COALESCE(retailer_configs.status_history, '[]'::jsonb), 
-                    '{0}', 
+                    COALESCE(retailer_configs.status_history, '[]'::jsonb),
+                    '{0}',
                     jsonb_build_object('status', EXCLUDED.status, 'timestamp', CURRENT_TIMESTAMP)
                   ),
                   '$[0 to 9]'
                 )
-           ELSE retailer_configs.status_history 
+           ELSE retailer_configs.status_history
          END,
          status = COALESCE(EXCLUDED.status, retailer_configs.status),
          use_proxy = COALESCE(EXCLUDED.use_proxy, retailer_configs.use_proxy),
          use_browser_scraper = COALESCE(EXCLUDED.use_browser_scraper, retailer_configs.use_browser_scraper),
-         currency_hint = COALESCE(EXCLUDED.currency_hint, retailer_configs.currency_hint),
-         name_selectors = CASE WHEN EXCLUDED.name_selectors = '[]'::jsonb THEN retailer_configs.name_selectors ELSE EXCLUDED.name_selectors END,
-         retailer_name_selectors = CASE WHEN EXCLUDED.retailer_name_selectors = '[]'::jsonb THEN retailer_configs.retailer_name_selectors ELSE EXCLUDED.retailer_name_selectors END,
-         price_selectors = CASE WHEN EXCLUDED.price_selectors = '[]'::jsonb THEN retailer_configs.price_selectors ELSE EXCLUDED.price_selectors END,
-         deal_price_selectors = CASE WHEN EXCLUDED.deal_price_selectors = '[]'::jsonb THEN retailer_configs.deal_price_selectors ELSE EXCLUDED.deal_price_selectors END,
-         member_price_selectors = CASE WHEN EXCLUDED.member_price_selectors = '[]'::jsonb THEN retailer_configs.member_price_selectors ELSE EXCLUDED.member_price_selectors END,
-         image_selectors = CASE WHEN EXCLUDED.image_selectors = '[]'::jsonb THEN retailer_configs.image_selectors ELSE EXCLUDED.image_selectors END,
-         stock_selectors = CASE WHEN EXCLUDED.stock_selectors = '[]'::jsonb THEN retailer_configs.stock_selectors ELSE EXCLUDED.stock_selectors END,
-         in_stock_phrases = CASE WHEN EXCLUDED.in_stock_phrases = '[]'::jsonb THEN retailer_configs.in_stock_phrases ELSE EXCLUDED.in_stock_phrases END,
-         out_of_stock_phrases = CASE WHEN EXCLUDED.out_of_stock_phrases = '[]'::jsonb THEN retailer_configs.out_of_stock_phrases ELSE EXCLUDED.out_of_stock_phrases END,
-         pre_order_phrases = CASE WHEN EXCLUDED.pre_order_phrases = '[]'::jsonb THEN retailer_configs.pre_order_phrases ELSE EXCLUDED.pre_order_phrases END,
-         pre_order_price_selectors = CASE WHEN EXCLUDED.pre_order_price_selectors = '[]'::jsonb THEN retailer_configs.pre_order_price_selectors ELSE EXCLUDED.pre_order_price_selectors END,
-         user_agent = COALESCE(EXCLUDED.user_agent, retailer_configs.user_agent),
-         custom_selectors = CASE WHEN EXCLUDED.custom_selectors = '{}'::jsonb THEN retailer_configs.custom_selectors ELSE EXCLUDED.custom_selectors END,
+         name_selectors = CASE WHEN $31 = true THEN EXCLUDED.name_selectors ELSE retailer_configs.name_selectors END,
+         retailer_name_selectors = CASE WHEN $32 = true THEN EXCLUDED.retailer_name_selectors ELSE retailer_configs.retailer_name_selectors END,
+         price_selectors = CASE WHEN $33 = true THEN EXCLUDED.price_selectors ELSE retailer_configs.price_selectors END,
+         deal_price_selectors = CASE WHEN $34 = true THEN EXCLUDED.deal_price_selectors ELSE retailer_configs.deal_price_selectors END,
+         member_price_selectors = CASE WHEN $35 = true THEN EXCLUDED.member_price_selectors ELSE retailer_configs.member_price_selectors END,
+         image_selectors = CASE WHEN $36 = true THEN EXCLUDED.image_selectors ELSE retailer_configs.image_selectors END,
+         stock_selectors = CASE WHEN $37 = true THEN EXCLUDED.stock_selectors ELSE retailer_configs.stock_selectors END,
+         in_stock_phrases = CASE WHEN $38 = true THEN EXCLUDED.in_stock_phrases ELSE retailer_configs.in_stock_phrases END,
+         out_of_stock_phrases = CASE WHEN $39 = true THEN EXCLUDED.out_of_stock_phrases ELSE retailer_configs.out_of_stock_phrases END,
+         pre_order_phrases = CASE WHEN $40 = true THEN EXCLUDED.pre_order_phrases ELSE retailer_configs.pre_order_phrases END,
+         pre_order_price_selectors = CASE WHEN $41 = true THEN EXCLUDED.pre_order_price_selectors ELSE retailer_configs.pre_order_price_selectors END,
+         original_price_selectors = CASE WHEN $42 = true THEN EXCLUDED.original_price_selectors ELSE retailer_configs.original_price_selectors END,
+         exclusion_selectors = CASE WHEN $43 = true THEN EXCLUDED.exclusion_selectors ELSE retailer_configs.exclusion_selectors END,
+         custom_selectors = CASE WHEN $44 = true THEN EXCLUDED.custom_selectors ELSE retailer_configs.custom_selectors END,
+         selector_metadata = CASE WHEN $45 = true THEN EXCLUDED.selector_metadata ELSE retailer_configs.selector_metadata END,
+         ai_selectors = CASE WHEN $46 = true THEN EXCLUDED.ai_selectors ELSE retailer_configs.ai_selectors END,
+         user_agent = CASE WHEN $47 = true THEN EXCLUDED.user_agent ELSE retailer_configs.user_agent END,
+         description = CASE WHEN $48 = true THEN EXCLUDED.description ELSE retailer_configs.description END,
+         currency_hint = CASE WHEN $49 = true THEN EXCLUDED.currency_hint ELSE retailer_configs.currency_hint END,
+         jsonld_image_key = CASE WHEN $50 = true THEN EXCLUDED.jsonld_image_key ELSE retailer_configs.jsonld_image_key END,
+         jsonld_price_key = CASE WHEN $51 = true THEN EXCLUDED.jsonld_price_key ELSE retailer_configs.jsonld_price_key END,
+         jsonld_name_key = CASE WHEN $52 = true THEN EXCLUDED.jsonld_name_key ELSE retailer_configs.jsonld_name_key END,
          active = COALESCE(EXCLUDED.active, retailer_configs.active),
-         description = COALESCE(EXCLUDED.description, retailer_configs.description),
-         jsonld_image_key = COALESCE(EXCLUDED.jsonld_image_key, retailer_configs.jsonld_image_key),
-         jsonld_price_key = COALESCE(EXCLUDED.jsonld_price_key, retailer_configs.jsonld_price_key),
-         jsonld_name_key = COALESCE(EXCLUDED.jsonld_name_key, retailer_configs.jsonld_name_key),
-         original_price_selectors = CASE WHEN EXCLUDED.original_price_selectors = '[]'::jsonb THEN retailer_configs.original_price_selectors ELSE EXCLUDED.original_price_selectors END,
-         ai_selectors = COALESCE(EXCLUDED.ai_selectors, retailer_configs.ai_selectors),
-         exclusion_selectors = CASE WHEN EXCLUDED.exclusion_selectors = '[]'::jsonb THEN retailer_configs.exclusion_selectors ELSE EXCLUDED.exclusion_selectors END,
-         selector_metadata = COALESCE(EXCLUDED.selector_metadata, retailer_configs.selector_metadata),
          updated_at = CURRENT_TIMESTAMP
        RETURNING *`,
       [
@@ -95,7 +128,8 @@ export const retailerMutationRepository = {
         config.ai_selectors ? JSON.stringify(config.ai_selectors) : null,
         JSON.stringify(config.exclusion_selectors || []),
         JSON.stringify(config.selector_metadata || {}),
-        config.forceNameRemoval ?? false
+        config.forceNameRemoval ?? false,
+        ...presence
       ]
     );
     return result.rows[0];


### PR DESCRIPTION
## Summary

- gate retailer-config upsert updates on field presence: an absent field keeps its stored value, a present field updates the row even when empty — so admins can actually clear selector lists, description, user agent, currency hint, and JSON-LD keys
- AI auto-mapping now omits fields it produced no values for, so partial generated configs merge instead of clearing learned selectors
- fixes `selector_metadata` being overwritten with `{}` by any upsert that did not carry it

## Validation

- backend build and tests
- behavior-tested against a migrated Postgres 17: create, keep-on-absent, clear-on-empty, and metadata-preservation scenarios all verified

Closes #32