### PR TITLE
fix(scraper): persist learned browser-scraper flag without AI auto-mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value deletes the stored one instead of being silently ignored, and AI
   auto-mapping no longer overwrites learned selector metadata with an empty
   object.
+- Retailer configs created or updated without AI auto-mapping now record the
+  learned "Browser Scraper" flag when acquisition had to fall back to the
+  browser scraper; previously only the AI auto-mapping path persisted it.
 - Currency conversion now triangulates via the EUR reference base, so
   conversions between two non-EUR currencies keep working after the switch to
   EUR-based reference rates.

--- a/backend/src/services/domain/product/utils/auto-config.ts
+++ b/backend/src/services/domain/product/utils/auto-config.ts
@@ -179,7 +179,12 @@ export async function runAutoRetailerConfig(params: {
         original_price_selectors: sortAndCapSelectorArray(originalPriceSelectors),
         active: true,
         selector_metadata: metadata,
-        description: getRetailerDescription(existing, source === 'manual-add' ? 'scan' : (source === 'manual-confirm' ? 're-scan' : source))
+        description: getRetailerDescription(existing, source === 'manual-add' ? 'scan' : (source === 'manual-confirm' ? 're-scan' : source)),
+        // Acquisition learned that this domain needs the browser scraper
+        // (plain HTTP failed, remote fallback succeeded). Persist it here so
+        // the flag is set even without AI auto-mapping (issue #45). Only ever
+        // learned positively — absence means "leave the stored value alone".
+        ...(scrapedData?.learnedFlags?.use_browser_scraper ? { use_browser_scraper: true } : {})
       };
 
       await retailerRepository.upsert(finalUpsertData, client);

--- a/backend/src/services/scraper/orchestration/index.ts
+++ b/backend/src/services/scraper/orchestration/index.ts
@@ -86,6 +86,12 @@ export async function scrapeProductWithVoting(
     $ = acqResult.$;
     let challenge = acqResult.challengeReason;
 
+    // Surface acquisition-learned flags on the result so the retailer config
+    // is updated on save even when AI auto-mapping is disabled (issue #45).
+    if (acqResult.learnedFlags?.use_browser_scraper) {
+      result.learnedFlags = { use_browser_scraper: true };
+    }
+
     // --- Phase 2: Extraction ---
     const extResults = await runExtractionPhase({
       url,

--- a/backend/src/types/scraper.ts
+++ b/backend/src/types/scraper.ts
@@ -41,6 +41,9 @@ export interface ScrapedProductWithVoting extends ScrapedProduct {
   needsReview: boolean;
   selectedMethod?: string;
   reviewReason?: ReviewReason;
+  // Flags learned during acquisition (e.g. the page only rendered via the
+  // browser scraper), persisted to the retailer config on save.
+  learnedFlags?: { use_browser_scraper?: boolean };
 }
 
 export type ExtractionMethod = 'json-ld' | 'site-specific' | 'generic-css' | 'custom-css' | 'custom-regex' | 'ai' | 'generic' | 'deal-price' | 'member-price' | 'pre-order-price' | 'original-price';


### PR DESCRIPTION
## Summary

- carry acquisition-learned flags (`use_browser_scraper`) on the scrape result
- persist them in the retailer-config upsert that runs on every product save, so the flag is recorded even when AI auto-mapping is disabled
- the flag is only ever learned positively; absence leaves the stored value untouched

## Validation

- backend build and tests

Closes #45