### PR TITLE
fix(scraper): drop random fabricated referrers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retailer configs created or updated without AI auto-mapping now record the
   learned "Browser Scraper" flag when acquisition had to fall back to the
   browser scraper; previously only the AI auto-mapping path persisted it.
+- Scrapes no longer send a random fabricated referrer (search engines, social
+  sites) on discovery. The referrer is now the retailer config's value, then
+  the system default, then none — matching how a user refreshing an open tab
+  looks to the site.
 - Currency conversion now triangulates via the EUR reference base, so
   conversions between two non-EUR currencies keep working after the switch to
   EUR-based reference rates.

--- a/backend/src/services/scraper/acquisition/fallback.ts
+++ b/backend/src/services/scraper/acquisition/fallback.ts
@@ -4,8 +4,7 @@ import { settingsCache } from '../../../utils/cache';
 import { 
   detectBotChallenge, 
   fetchRemoteHtml, 
-  fetchBrowserHtml, 
-  getRandomReferrer
+  fetchBrowserHtml
 } from '../transport';
 
 export interface FallbackOptions {
@@ -39,8 +38,10 @@ export async function handleAcquisitionFallback(options: FallbackOptions): Promi
     try {
       const isDiscovery = !productId;
       const remoteOptions: any = { productId, isDiscovery };
+      // Referrer policy: system default or none — never a fabricated random
+      // one (issue #44).
       const defaultReferrer = await settingsCache.getDefaultReferrer();
-      remoteOptions.referrer = isDiscovery ? getRandomReferrer() : (defaultReferrer || undefined);
+      remoteOptions.referrer = defaultReferrer || undefined;
 
       html = await fetchRemoteHtml(url, rsUrl, remoteOptions);
       logger.info(`Scraper | Fallback | Remote success for ${domain}`, 'Scraper', { product_id: productId });
@@ -57,7 +58,7 @@ export async function handleAcquisitionFallback(options: FallbackOptions): Promi
   } else {
     try {
       logger.warn(`Scraper | Fallback | Local browser fallback for ${domain}`, 'Scraper', { product_id: productId });
-      html = await fetchBrowserHtml(url, undefined, undefined, undefined, productId, !productId);
+      html = await fetchBrowserHtml(url, undefined, undefined, undefined, productId);
       if (html) logger.info(`Scraper | Fallback | Local success for ${domain}`, 'Scraper', { product_id: productId });
       extractionSteps.push(html ? `Scraper | Fallback | Local Success` : `Scraper | Fallback | Local Failed`);
       

--- a/backend/src/services/scraper/acquisition/remote.ts
+++ b/backend/src/services/scraper/acquisition/remote.ts
@@ -2,7 +2,6 @@ import { logger } from '../../../utils/system/logger';
 import { settingsCache } from '../../../utils/cache';
 import { 
   fetchRemoteHtml, 
-  getRandomReferrer,
   PageNotAvailableError
 } from '../transport';
 import { RetailerConfig } from '../../../models';
@@ -46,10 +45,10 @@ export async function acquireRemoteHtml(options: RemoteAcquisitionOptions): Prom
       remoteOptions.proxyUrl = currentProxy;
     }
 
+    // Referrer policy: retailer config, then the system default, then none —
+    // never a fabricated random one (issue #44).
     if (domainConfig?.referrer) {
       remoteOptions.referrer = domainConfig.referrer;
-    } else if (isDiscovery) {
-      remoteOptions.referrer = getRandomReferrer();
     } else {
       const defaultReferrer = await settingsCache.getDefaultReferrer();
       if (defaultReferrer) remoteOptions.referrer = defaultReferrer;

--- a/backend/src/services/scraper/transport/browser.ts
+++ b/backend/src/services/scraper/transport/browser.ts
@@ -1,6 +1,5 @@
 import { logger } from '../../../utils/system/logger';
 import { settingsCache } from '../../../utils/cache';
-import { getRandomReferrer } from './headers';
 import { fetchRemoteHtml } from './remote';
 import { PageNotAvailableError } from './errors';
 
@@ -8,12 +7,11 @@ import { PageNotAvailableError } from './errors';
  * Orchestrates a browser-rendered fetch, offloading to the remote scraper.
  */
 export async function fetchBrowserHtml(
-  url: string, 
-  userAgent?: string, 
-  proxyServer?: string, 
-  referrer?: string, 
-  productId?: number, 
-  isDiscovery: boolean = false
+  url: string,
+  userAgent?: string,
+  proxyServer?: string,
+  referrer?: string,
+  productId?: number
 ): Promise<string> {
   const rsUrl = await settingsCache.getRemoteScraperUrl();
   if (!rsUrl) {
@@ -31,11 +29,11 @@ export async function fetchBrowserHtml(
       options.proxyUrl = proxyServer;
     }
     
-    // Identity & Stealth Logic
+    // Referrer policy: retailer config, then the system default, then none.
+    // A fabricated random referrer (search engines, social sites) looks less
+    // like a user refreshing an open tab and some sites reject it (issue #44).
     if (referrer) {
       options.referrer = referrer;
-    } else if (isDiscovery) {
-      options.referrer = getRandomReferrer();
     } else {
       const defaultReferrer = await settingsCache.getDefaultReferrer();
       if (defaultReferrer) options.referrer = defaultReferrer;

--- a/backend/src/services/scraper/transport/headers.ts
+++ b/backend/src/services/scraper/transport/headers.ts
@@ -1,19 +1,5 @@
 import { settingsCache } from '../../../utils/cache';
 
-export const STEALTH_REFERRERS = [
-  'https://www.google.com/',
-  'https://www.bing.com/',
-  'https://www.facebook.com/',
-  'https://www.instagram.com/',
-  'https://t.co/', // Twitter shortener
-  'https://www.reddit.com/',
-  'https://duckduckgo.com/'
-];
-
-export function getRandomReferrer(): string {
-  return STEALTH_REFERRERS[Math.floor(Math.random() * STEALTH_REFERRERS.length)];
-}
-
 export async function getHeaders(userAgent?: string): Promise<Record<string, string>> {
   const ua = userAgent || await settingsCache.getDefaultUserAgent();
   const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary

- remove the hard-coded random referrer list (google/bing/facebook/instagram/…) used on discovery scrapes
- resolve the referrer as retailer-config value → system default → none, at all three call sites (remote acquisition, browser transport, fallback)

## Validation

- backend build and tests

Closes #44