### PR TITLE
fix(admin): guard Gemini config on a cached model list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sites) on discovery. The referrer is now the retailer config's value, then
   the system default, then none — matching how a user refreshing an open tab
   looks to the site.
+- The AI Engine admin page now explains when no Gemini model list is cached,
+  blocks Verify and saving until a model is selected, and the cached model
+  list refreshes automatically every day.
 - Currency conversion now triangulates via the EUR reference base, so
   conversions between two non-EUR currencies keep working after the switch to
   EUR-based reference rates.

--- a/backend/src/services/scheduler/index.ts
+++ b/backend/src/services/scheduler/index.ts
@@ -3,10 +3,12 @@ import { logger } from '../../utils/system/logger';
 import { checkPrices } from './tasks/PriceCheckTask';
 import { runCleanup } from './tasks/CleanupTask';
 import { updateExchangeRates, checkInitialExchangeRates } from './tasks/ExchangeRateTask';
+import { refreshAIModels } from './tasks/AIModelRefreshTask';
 
 export * from './tasks/PriceCheckTask';
 export * from './tasks/CleanupTask';
 export * from './tasks/ExchangeRateTask';
+export * from './tasks/AIModelRefreshTask';
 
 /**
  * Starts all scheduled background tasks.
@@ -27,10 +29,16 @@ export function startScheduler(): void {
     updateExchangeRates().catch((err) => logger.error('Scheduler | Exchange Rates | Unhandled error', 'Scheduler', err));
   });
 
-  // 4. Initial startup checks
+  // 4. Gemini model list refresh every day at 5 AM
+  cron.schedule('0 5 * * *', () => {
+    refreshAIModels().catch((err) => logger.error('Scheduler | AI Models | Unhandled error', 'Scheduler', err));
+  });
+
+  // 5. Initial startup checks
   checkInitialExchangeRates();
 
   logger.info('System | Scheduler | Started | Price check (1m)', 'Scheduler');
   logger.info('System | Scheduler | Started | Log cleanup (3am)', 'Scheduler');
   logger.info('System | Scheduler | Started | Exchange rates (4am)', 'Scheduler');
+  logger.info('System | Scheduler | Started | AI model refresh (5am)', 'Scheduler');
 }

--- a/backend/src/services/scheduler/tasks/AIModelRefreshTask.ts
+++ b/backend/src/services/scheduler/tasks/AIModelRefreshTask.ts
@@ -1,0 +1,24 @@
+import { logger } from '../../../utils/system/logger';
+import { settingsCache } from '../../../utils/cache';
+import { aiSettingsService } from '../../domain/system/settings/ai';
+
+/**
+ * Refreshes the cached Gemini model list daily so the admin UI's model
+ * dropdown and Verify action keep working without a manual sync (issue #46).
+ * Skipped when no Gemini API key is configured.
+ */
+export async function refreshAIModels(): Promise<void> {
+  try {
+    const settings = await settingsCache.getAISettings();
+    const apiKey = settings?.gemini_api_key;
+    if (!apiKey) {
+      logger.debug('Scheduler | AI Models | Skipped: no Gemini API key configured', 'Scheduler');
+      return;
+    }
+
+    const result = await aiSettingsService.refreshGeminiModels(apiKey);
+    logger.info(`Scheduler | AI Models | Refreshed ${result.models.length} Gemini models`, 'Scheduler');
+  } catch (error) {
+    logger.error('Scheduler | AI Models | Refresh failed', 'Scheduler', error);
+  }
+}

--- a/frontend/src/features/admin/components/sections/AIProviderConfig.tsx
+++ b/frontend/src/features/admin/components/sections/AIProviderConfig.tsx
@@ -2,6 +2,7 @@ import { AISettings } from '../../../../types/api';
 import { ToggleSwitch } from '../../components';
 import { AIService } from '../../services/AIService';
 import PasswordInput from '../../../../components/PasswordInput';
+import Icon from '../../../../components/Icon';
 import { useAsyncAction } from '../../../../hooks/useAsyncAction';
 import { useToast } from '../../../../context/ToastContext';
 
@@ -42,8 +43,15 @@ export default function AIProviderConfig({
   const handleTestProvider = (provider: string) => runTestProvider(async () => {
     let res: any;
     if (provider === 'gemini') {
-      if (!aiSettings?.gemini_api_key) return;
-      res = await AIService.testGemini(aiSettings.gemini_api_key, aiSettings.gemini_model || undefined);
+      if (!aiSettings?.gemini_api_key) {
+        showToast('Enter a Gemini API key before verifying.', 'error');
+        return;
+      }
+      if (!aiSettings.gemini_model) {
+        showToast('Verify needs a model: press Sync to load the model list, then select one.', 'error');
+        return;
+      }
+      res = await AIService.testGemini(aiSettings.gemini_api_key, aiSettings.gemini_model);
     } else if (provider === 'vertex') {
       if (!aiSettings?.vertex_api_key || !aiSettings?.vertex_project_id || !aiSettings?.vertex_location || !aiSettings?.vertex_model) return;
       res = await AIService.testVertex(aiSettings.vertex_api_key, aiSettings.vertex_project_id, aiSettings.vertex_location, aiSettings.vertex_model);
@@ -132,6 +140,12 @@ export default function AIProviderConfig({
               <button type="button" className="btn btn-secondary btn-sm" onClick={() => handleTestProvider('gemini')}>Verify</button>
             </div>
           </form>
+          {aiModels.length === 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.6rem 0.75rem', borderRadius: '0.5rem', background: 'var(--background)', border: '1px solid var(--warning, #f59e0b)', color: 'var(--text)', fontSize: '0.8rem' }}>
+              <Icon name="alertTriangle" /> No cached Gemini model list. Enter your API key and press
+              Sync to load the available models — model selection, Verify, and saving need it.
+            </div>
+          )}
           <div className="form-group">
             <label style={{ display: 'flex', justifyContent: 'space-between' }}>
               Primary Model

--- a/frontend/src/features/admin/components/sections/AISection.tsx
+++ b/frontend/src/features/admin/components/sections/AISection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { AIService } from '../../services/AIService';
 import { AISettings } from '../../../../types/api';
 import { useAsyncAction } from '../../../../hooks/useAsyncAction';
+import { useToast } from '../../../../context/ToastContext';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 import AIStatusBadge from '../../../../components/AIStatusBadge';
 import { CollapsibleCard } from '../../components';
@@ -13,6 +14,7 @@ export default function AISection() {
   const [aiSettings, setAiSettings] = useState<AISettings | null>(null);
   const [aiModels, setAiModels] = useState<any[]>([]);
   const { execute: runFetchAIData, isLoading } = useAsyncAction(true);
+  const { showToast } = useToast();
   const { execute: runSaveAISettings, isLoading: isSavingAI } = useAsyncAction();
   const [isRefreshingModels, setIsRefreshingModels] = useState(false);
 
@@ -38,6 +40,12 @@ export default function AISection() {
 
   const handleSaveAISettings = () => runSaveAISettings(async () => {
     if (!aiSettings) return;
+    // A Gemini configuration without a selected model cannot extract anything;
+    // require a model (synced from the API) before allowing the save.
+    if (aiSettings.ai_provider === 'gemini' && !aiSettings.gemini_model) {
+      showToast('Select a Gemini model before saving — press Sync next to the model dropdown to load the list.', 'error');
+      return;
+    }
     await AIService.updateAI(aiSettings);
   }, { onSuccessMessage: 'AI settings saved', onErrorFallback: 'Save failed' });
 


### PR DESCRIPTION
## Summary

- warn on the AI Engine page when no Gemini model list is cached and explain the Sync step
- Verify reports why it cannot run (missing key or model) instead of silently returning; saving a Gemini config without a selected model is blocked
- daily scheduler task (5 AM) keeps the cached Gemini model list fresh when an API key is configured

## Validation

- backend and frontend builds, backend tests, emoji lint

Closes #46