### PR TITLE
feat(auth): password reset via email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,10 +84,13 @@ JWT_SECRET=replace-with-a-long-random-string
 # unset unless you need it.
 # ADMIN_API_TOKEN=
 
-# SMTP fallback, used only to send database-health alerts when the app's own
-# notification channels cannot be reached.
+# System SMTP, used for database-health alerts and password-reset emails.
+# Password reset requires SMTP_FALLBACK_HOST to be set (and can additionally
+# be toggled off under Admin -> System -> Security & Access).
 # SMTP_FALLBACK_HOST=
 # SMTP_FALLBACK_PORT=587
+# SMTP_FALLBACK_USER=
+# SMTP_FALLBACK_PASS=
 # SMTP_FALLBACK_FROM=
 # ADMIN_ALERT_EMAIL=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Password reset via email: a "Forgot password?" link on the login page sends
+  a single-use, one-hour reset link using the system SMTP settings
+  (`SMTP_FALLBACK_*`). Admins can disable the feature under Admin -> System ->
+  Security & Access; it is hidden automatically when SMTP is not configured.
 - Theme can now be set to Auto (follow the operating system), Light, or Dark
   under Settings -> Regional -> Appearance; previously a single manual toggle
   permanently overrode the OS preference with no way back to automatic.

--- a/backend/src/migrations/010_password_reset_tokens.ts
+++ b/backend/src/migrations/010_password_reset_tokens.ts
@@ -1,0 +1,44 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Single-use, expiring password-reset tokens. Only a SHA-256 hash of the
+ * token is stored; the raw value exists solely inside the reset email.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS password_reset_tokens (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        token_hash VARCHAR(64) NOT NULL UNIQUE,
+        expires_at TIMESTAMPTZ NOT NULL,
+        used_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user
+        ON password_reset_tokens(user_id);
+    `);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('DROP TABLE IF EXISTS password_reset_tokens;');
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/backend/src/routes/auth/index.ts
+++ b/backend/src/routes/auth/index.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import { AuthRequest } from '../../middleware/auth';
 import { authService } from '../../services/domain/auth';
+import { passwordResetService } from '../../services/domain/auth/password-reset';
 import { logger } from '../../utils/system/logger';
 import { asyncHandler } from '../../utils/system/route-helpers';
 import oidcRoutes from './oidc';
@@ -29,5 +30,27 @@ router.post('/login', asyncHandler(async (req, res) => {
   const result = await authService.loginUser(email, password);
   res.json(result);
 }, 'Auth | Login', 'Auth', 'Failed to login'));
+
+// Password reset availability (admin toggle + configured system mailer)
+router.get('/password-reset-status', asyncHandler(async (_req, res) => {
+  const enabled = await passwordResetService.isEnabled();
+  res.json({ enabled });
+}, 'Auth | Reset Status', 'Auth', 'Failed to fetch password reset status'));
+
+// Request a password reset email. Always responds identically, so the
+// endpoint cannot be used to probe which emails have accounts.
+router.post('/forgot-password', asyncHandler(async (req, res) => {
+  const { email } = req.body;
+  const baseUrl = process.env.PUBLIC_URL || `${req.protocol}://${req.get('host')}`;
+  await passwordResetService.requestReset(email, baseUrl, req.ip || 'unknown');
+  res.json({ message: 'If that email belongs to an account, a reset link has been sent.' });
+}, 'Auth | Forgot Password', 'Auth', 'Failed to process password reset request'));
+
+// Consume a reset token and set the new password
+router.post('/reset-password', asyncHandler(async (req, res) => {
+  const { token, password } = req.body;
+  await passwordResetService.resetPassword(token, password);
+  res.json({ message: 'Password updated. You can now log in with your new password.' });
+}, 'Auth | Reset Password', 'Auth', 'Failed to reset password'));
 
 export default router;

--- a/backend/src/services/domain/auth/password-reset.ts
+++ b/backend/src/services/domain/auth/password-reset.ts
@@ -1,0 +1,136 @@
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import { userRepository } from '../../../models';
+import { systemService } from '../system';
+import { logger } from '../../../utils/system/logger';
+import { isSystemMailerConfigured, sendSystemEmail } from '../../../utils/system/mailer';
+import { passwordResetRepository } from './repositories/password-reset.repository';
+
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// Basic in-memory throttle so the endpoint cannot be used to spam mailboxes
+// or probe accounts at volume. Per-key (IP and email), 5 requests per hour.
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+const requestLog = new Map<string, number[]>();
+
+function isRateLimited(key: string): boolean {
+  const now = Date.now();
+  const entries = (requestLog.get(key) || []).filter(t => now - t < RATE_WINDOW_MS);
+  if (entries.length >= RATE_LIMIT) {
+    requestLog.set(key, entries);
+    return true;
+  }
+  entries.push(now);
+  requestLog.set(key, entries);
+  return false;
+}
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+export class PasswordResetService {
+  /**
+   * Reset is available when the admin toggle allows it AND the system mailer
+   * is configured — without SMTP the email could never be delivered.
+   */
+  async isEnabled(): Promise<boolean> {
+    const setting = await systemService.getSetting('password_reset_enabled');
+    return setting !== 'false' && isSystemMailerConfigured();
+  }
+
+  /**
+   * Issues a reset token and emails the link. Always resolves without
+   * revealing whether the email belongs to an account (no user enumeration).
+   */
+  async requestReset(email: string, baseUrl: string, clientIp: string): Promise<void> {
+    if (!(await this.isEnabled())) {
+      const err = new Error('Password reset is not available on this server');
+      (err as any).statusCode = 404;
+      throw err;
+    }
+
+    if (!email || typeof email !== 'string') {
+      const err = new Error('Email is required');
+      (err as any).statusCode = 400;
+      throw err;
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+    if (isRateLimited(`ip:${clientIp}`) || isRateLimited(`email:${normalizedEmail}`)) {
+      logger.warn(`Auth | Password Reset | Rate limited request for ${normalizedEmail}`, 'Auth');
+      return; // Indistinguishable from success, on purpose.
+    }
+
+    const user = await userRepository.findByEmail(normalizedEmail);
+    if (!user || user.disabled) {
+      logger.info('Auth | Password Reset | Requested for unknown or disabled account', 'Auth');
+      return;
+    }
+    if (!user.password_hash) {
+      // SSO-only account: there is no password to reset.
+      logger.info(`Auth | Password Reset | Requested for SSO-only account ID ${user.id}`, 'Auth');
+      return;
+    }
+
+    const token = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
+    await passwordResetRepository.create(user.id, hashToken(token), expiresAt);
+
+    const resetUrl = `${baseUrl.replace(/\/$/, '')}/reset-password?token=${token}`;
+    const result = await sendSystemEmail(
+      user.email,
+      'PriceStalker password reset',
+      `A password reset was requested for your PriceStalker account.\n\n` +
+      `Open this link to choose a new password (valid for 1 hour):\n\n` +
+      `${resetUrl}\n\n` +
+      `If you did not request this, you can ignore this email; your password is unchanged.`
+    );
+
+    if (result.success) {
+      logger.info(`Auth | Password Reset | Email sent for user ID ${user.id}`, 'Auth');
+    } else {
+      logger.error(`Auth | Password Reset | Email delivery failed for user ID ${user.id}: ${result.error}`, 'Auth');
+    }
+  }
+
+  /**
+   * Consumes a token and sets the new password.
+   */
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    if (!token || typeof token !== 'string') {
+      const err = new Error('Reset token is required');
+      (err as any).statusCode = 400;
+      throw err;
+    }
+    if (!newPassword || newPassword.length < 8) {
+      const err = new Error('Password must be at least 8 characters');
+      (err as any).statusCode = 400;
+      throw err;
+    }
+
+    const row = await passwordResetRepository.findValidByHash(hashToken(token));
+    if (!row) {
+      const err = new Error('This reset link is invalid or has expired. Request a new one.');
+      (err as any).statusCode = 400;
+      throw err;
+    }
+
+    const user = await userRepository.findById(row.user_id);
+    if (!user || user.disabled) {
+      const err = new Error('This reset link is invalid or has expired. Request a new one.');
+      (err as any).statusCode = 400;
+      throw err;
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, 12);
+    await userRepository.updatePassword(user.id, passwordHash);
+    await passwordResetRepository.markUsed(row.id);
+    await passwordResetRepository.deleteExpired();
+
+    logger.info(`Auth | Password Reset | Password changed for user ID ${user.id}`, 'Auth');
+  }
+}
+
+export const passwordResetService = new PasswordResetService();

--- a/backend/src/services/domain/auth/repositories/password-reset.repository.ts
+++ b/backend/src/services/domain/auth/repositories/password-reset.repository.ts
@@ -1,0 +1,48 @@
+import pool from '../../../../config/database';
+
+export interface PasswordResetToken {
+  id: number;
+  user_id: number;
+  token_hash: string;
+  expires_at: Date;
+  used_at: Date | null;
+  created_at: Date;
+}
+
+export const passwordResetRepository = {
+  create: async (userId: number, tokenHash: string, expiresAt: Date): Promise<void> => {
+    // One live token per user: a new request supersedes older unused ones.
+    await pool.query(
+      'DELETE FROM password_reset_tokens WHERE user_id = $1 AND used_at IS NULL',
+      [userId]
+    );
+    await pool.query(
+      `INSERT INTO password_reset_tokens (user_id, token_hash, expires_at)
+       VALUES ($1, $2, $3)`,
+      [userId, tokenHash, expiresAt]
+    );
+  },
+
+  findValidByHash: async (tokenHash: string): Promise<PasswordResetToken | null> => {
+    const result = await pool.query(
+      `SELECT * FROM password_reset_tokens
+       WHERE token_hash = $1 AND used_at IS NULL AND expires_at > CURRENT_TIMESTAMP`,
+      [tokenHash]
+    );
+    return result.rows[0] || null;
+  },
+
+  markUsed: async (id: number): Promise<void> => {
+    await pool.query(
+      'UPDATE password_reset_tokens SET used_at = CURRENT_TIMESTAMP WHERE id = $1',
+      [id]
+    );
+  },
+
+  deleteExpired: async (): Promise<number> => {
+    const result = await pool.query(
+      "DELETE FROM password_reset_tokens WHERE expires_at < CURRENT_TIMESTAMP - INTERVAL '1 day'"
+    );
+    return result.rowCount || 0;
+  },
+};

--- a/backend/src/services/domain/system/DatabaseHealthMonitor.ts
+++ b/backend/src/services/domain/system/DatabaseHealthMonitor.ts
@@ -1,6 +1,6 @@
 import pool from '../../../config/database';
 import { logger } from '../../../utils/system/logger';
-import nodemailer from 'nodemailer';
+import { isSystemMailerConfigured, sendSystemEmail } from '../../../utils/system/mailer';
 
 export type DBState = 'HEALTHY' | 'DEGRADED' | 'FAILED';
 
@@ -115,41 +115,19 @@ export class DatabaseHealthMonitor {
 
   async sendAlertEmail(subject: string, text: string) {
     const toEmail = this.cachedAdminEmail || process.env.ADMIN_ALERT_EMAIL || 'admin@localhost';
-    const smtpHost = process.env.SMTP_FALLBACK_HOST;
-    const smtpPort = parseInt(process.env.SMTP_FALLBACK_PORT || '587', 10);
-    const smtpUser = process.env.SMTP_FALLBACK_USER;
-    const smtpPass = process.env.SMTP_FALLBACK_PASS;
-    const emailFrom = process.env.SMTP_FALLBACK_FROM || 'pricestalker-monitor@localhost';
 
-    if (!smtpHost) {
+    if (!isSystemMailerConfigured()) {
       logger.error('DatabaseHealthMonitor | Cannot send alert email: SMTP_FALLBACK_HOST is not set in environment', 'Database');
       return { success: false, error: 'SMTP_FALLBACK_HOST is not set' };
     }
 
-    try {
-      const transporter = nodemailer.createTransport({
-        host: smtpHost,
-        port: smtpPort,
-        secure: smtpPort === 465,
-        auth: smtpUser && smtpPass ? { user: smtpUser, pass: smtpPass } : undefined,
-        tls: {
-          rejectUnauthorized: false,
-        }
-      });
-
-      await transporter.sendMail({
-        from: emailFrom,
-        to: toEmail,
-        subject,
-        text,
-      });
-
+    const result = await sendSystemEmail(toEmail, subject, text);
+    if (result.success) {
       logger.info(`DatabaseHealthMonitor | Outage alert email successfully sent to ${toEmail}`, 'Database');
       return { success: true, to: toEmail };
-    } catch (emailErr: any) {
-      logger.error('DatabaseHealthMonitor | Failed to deliver alert email', 'Database', emailErr);
-      return { success: false, error: emailErr.message };
     }
+    logger.error('DatabaseHealthMonitor | Failed to deliver alert email', 'Database', result.error);
+    return { success: false, error: result.error };
   }
 }
 

--- a/backend/src/services/domain/system/settings/system.ts
+++ b/backend/src/services/domain/system/settings/system.ts
@@ -14,7 +14,8 @@ export class SystemSettingsService {
   async updateSettings(updates: Record<string, any>, userId: number): Promise<Record<string, string>> {
     const updatedKeys: string[] = [];
     const validKeys = [
-      'registration_enabled', 
+      'registration_enabled',
+      'password_reset_enabled',
       'browser_timeout', 
       'browser_delay', 
       'scraper_proxy', 

--- a/backend/src/utils/system/mailer.ts
+++ b/backend/src/utils/system/mailer.ts
@@ -1,0 +1,45 @@
+import nodemailer from 'nodemailer';
+import { logger } from './logger';
+
+/**
+ * System email transport backed by the SMTP_FALLBACK_* environment settings
+ * (the same configuration the database health alerts use). Distinct from the
+ * per-user email notification channel, which is configured in the UI.
+ */
+export function isSystemMailerConfigured(): boolean {
+  return Boolean(process.env.SMTP_FALLBACK_HOST);
+}
+
+export async function sendSystemEmail(
+  to: string,
+  subject: string,
+  text: string
+): Promise<{ success: boolean; error?: string }> {
+  const smtpHost = process.env.SMTP_FALLBACK_HOST;
+  const smtpPort = parseInt(process.env.SMTP_FALLBACK_PORT || '587', 10);
+  const smtpUser = process.env.SMTP_FALLBACK_USER;
+  const smtpPass = process.env.SMTP_FALLBACK_PASS;
+  const emailFrom = process.env.SMTP_FALLBACK_FROM || 'pricestalker@localhost';
+
+  if (!smtpHost) {
+    return { success: false, error: 'SMTP_FALLBACK_HOST is not set' };
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: smtpHost,
+      port: smtpPort,
+      secure: smtpPort === 465,
+      auth: smtpUser && smtpPass ? { user: smtpUser, pass: smtpPass } : undefined,
+      tls: {
+        rejectUnauthorized: false,
+      }
+    });
+
+    await transporter.sendMail({ from: emailFrom, to, subject, text });
+    return { success: true };
+  } catch (error: any) {
+    logger.error(`Mailer | Failed to send "${subject}"`, 'System', error);
+    return { success: false, error: error.message };
+  }
+}

--- a/frontend/src/features/admin/components/sections/SystemSection.tsx
+++ b/frontend/src/features/admin/components/sections/SystemSection.tsx
@@ -62,6 +62,19 @@ export default function SystemSection() {
     }
   };
 
+  const handleTogglePasswordReset = async () => {
+    try {
+      const res = await AdminSystemService.updateSystemSettings({ 
+        password_reset_enabled: !(systemSettings?.password_reset_enabled === undefined || systemSettings?.password_reset_enabled === true || systemSettings?.password_reset_enabled === 'true') 
+      });
+      setSystemSettings(res);
+      queryClient.setQueryData(queryKeys.adminSystemSettings, res);
+      showToast('Password reset toggled', 'success');
+    } catch {
+      showToast('Update failed', 'error');
+    }
+  };
+
   const handleToggleDebugPage = async () => {
     try {
       const res = await AdminSystemService.updateSystemSettings({ 
@@ -180,6 +193,10 @@ export default function SystemSection() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem', background: 'var(--background)', padding: '0.75rem', borderRadius: '0.5rem' }}>
           <span style={{ fontWeight: 600, fontSize: '0.875rem' }}>Allow User Registration</span>
           <ToggleSwitch active={systemSettings?.registration_enabled === true || systemSettings?.registration_enabled === 'true'} onToggle={handleToggleRegistration} disabled={isSavingAdmin} />
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem', background: 'var(--background)', padding: '0.75rem', borderRadius: '0.5rem' }}>
+          <span style={{ fontWeight: 600, fontSize: '0.875rem' }}>Allow Password Reset via Email</span>
+          <ToggleSwitch active={systemSettings?.password_reset_enabled === undefined || systemSettings?.password_reset_enabled === true || systemSettings?.password_reset_enabled === 'true'} onToggle={handleTogglePasswordReset} disabled={isSavingAdmin} />
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem', background: 'var(--background)', padding: '0.75rem', borderRadius: '0.5rem' }}>
           <span style={{ fontWeight: 600, fontSize: '0.875rem' }}>Enable Admin Debug Page</span>

--- a/frontend/src/features/auth/components/AuthForm.tsx
+++ b/frontend/src/features/auth/components/AuthForm.tsx
@@ -19,6 +19,7 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode, onSubmit }) => {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [registrationEnabled, setRegistrationEnabled] = useState<boolean | null>(null);
+  const [passwordResetEnabled, setPasswordResetEnabled] = useState(false);
   const [ssoConfig, setSsoConfig] = useState<PublicAuthConfig | null>(null);
   const { theme, toggleTheme } = useTheme();
   const location = useRouterState({ select: (state) => state.location });
@@ -28,6 +29,11 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode, onSubmit }) => {
     AuthService.getRegistrationStatus()
       .then(res => setRegistrationEnabled(res.enabled))
       .catch(() => setRegistrationEnabled(true)); // Default to true on error
+
+    // Hidden unless the server confirms reset is available (toggle + SMTP).
+    AuthService.getPasswordResetStatus()
+      .then(res => setPasswordResetEnabled(res.enabled))
+      .catch(() => setPasswordResetEnabled(false));
 
     // 404s when SSO is disabled on the server; that is the normal
     // local-login-only case, not an error worth surfacing.
@@ -178,6 +184,11 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode, onSubmit }) => {
           </div>
         )}
 
+        {showLocalForm && mode === 'login' && passwordResetEnabled && (
+          <div className="auth-form-footer">
+            <Link to="/forgot-password">Forgot password?</Link>
+          </div>
+        )}
         {showLocalForm && mode === 'login' && registrationEnabled && (
           <div className="auth-form-footer">
             Don't have an account? <Link to="/register" search={{ redirect: new URLSearchParams(location.searchStr).get('redirect') || undefined }}>Sign up</Link>

--- a/frontend/src/features/auth/pages/ForgotPassword.tsx
+++ b/frontend/src/features/auth/pages/ForgotPassword.tsx
@@ -1,0 +1,78 @@
+import { useState, FormEvent } from 'react';
+import { Link } from '@tanstack/react-router';
+import { AuthService } from '../services/AuthService';
+import LoadingSpinner from '../../../components/LoadingSpinner';
+import { apiErrorMessage } from '../../../api/error';
+import '../components/AuthForm.css';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [sent, setSent] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+    try {
+      await AuthService.requestPasswordReset(email);
+      setSent(true);
+    } catch (err) {
+      setError(apiErrorMessage(err, 'Could not process the request'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-form-container">
+      <div className="auth-form-card">
+        <div className="auth-form-header">
+          <img src="/icon.svg" alt="PriceStalker" className="auth-form-logo" />
+          <h1 className="auth-form-title">Reset Password</h1>
+          <p className="auth-form-subtitle">
+            Enter your account email and we'll send you a reset link.
+          </p>
+        </div>
+
+        {error && <div className="alert alert-error">{error}</div>}
+
+        {sent ? (
+          <div className="alert alert-success">
+            If that email belongs to an account, a reset link is on its way.
+            The link is valid for 1 hour.
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="email">Email</label>
+              <input
+                type="email"
+                id="email"
+                className="form-control"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                required
+                autoComplete="email"
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              style={{ width: '100%', marginTop: '0.5rem' }}
+              disabled={isLoading}
+            >
+              {isLoading ? <LoadingSpinner size="1rem" /> : 'Send Reset Link'}
+            </button>
+          </form>
+        )}
+
+        <div className="auth-form-footer">
+          <Link to="/login">← Back to sign in</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/pages/ResetPassword.tsx
+++ b/frontend/src/features/auth/pages/ResetPassword.tsx
@@ -1,0 +1,104 @@
+import { useState, FormEvent } from 'react';
+import { Link, useRouterState } from '@tanstack/react-router';
+import { AuthService } from '../services/AuthService';
+import LoadingSpinner from '../../../components/LoadingSpinner';
+import { apiErrorMessage } from '../../../api/error';
+import '../components/AuthForm.css';
+
+export default function ResetPassword() {
+  const location = useRouterState({ select: (state) => state.location });
+  const token = new URLSearchParams(location.searchStr).get('token') || '';
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      await AuthService.resetPassword(token, password);
+      setDone(true);
+    } catch (err) {
+      setError(apiErrorMessage(err, 'Could not reset the password'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-form-container">
+      <div className="auth-form-card">
+        <div className="auth-form-header">
+          <img src="/icon.svg" alt="PriceStalker" className="auth-form-logo" />
+          <h1 className="auth-form-title">Choose a New Password</h1>
+        </div>
+
+        {error && <div className="alert alert-error">{error}</div>}
+
+        {!token ? (
+          <div className="alert alert-error">
+            This reset link is missing its token. Open the link from your email,
+            or request a new one.
+          </div>
+        ) : done ? (
+          <div className="alert alert-success">
+            Password updated. You can now sign in with your new password.
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="password">New Password</label>
+              <input
+                type="password"
+                id="password"
+                className="form-control"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                required
+                autoComplete="new-password"
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="confirmPassword">Confirm Password</label>
+              <input
+                type="password"
+                id="confirmPassword"
+                className="form-control"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="••••••••"
+                required
+                autoComplete="new-password"
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              style={{ width: '100%', marginTop: '0.5rem' }}
+              disabled={isLoading}
+            >
+              {isLoading ? <LoadingSpinner size="1rem" /> : 'Set New Password'}
+            </button>
+          </form>
+        )}
+
+        <div className="auth-form-footer">
+          <Link to="/login">← Back to sign in</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/pages/index.ts
+++ b/frontend/src/features/auth/pages/index.ts
@@ -1,3 +1,5 @@
 export { default as Login } from './Login';
 export { default as Register } from './Register';
 export { default as SsoComplete } from './SsoComplete';
+export { default as ForgotPassword } from './ForgotPassword';
+export { default as ResetPassword } from './ResetPassword';

--- a/frontend/src/features/auth/services/AuthService.ts
+++ b/frontend/src/features/auth/services/AuthService.ts
@@ -31,6 +31,15 @@ export const AuthService = {
   getRegistrationStatus: () =>
     api.get<{ enabled: boolean }>('/auth/registration-status'),
 
+  getPasswordResetStatus: () =>
+    api.get<{ enabled: boolean }>('/auth/password-reset-status'),
+
+  requestPasswordReset: (email: string) =>
+    api.post<{ message: string }>('/auth/forgot-password', { email }),
+
+  resetPassword: (token: string, password: string) =>
+    api.post<{ message: string }>('/auth/reset-password', { token, password }),
+
   /**
    * Public auth config, used by the login page to decide what to render.
    * 404s when SSO is disabled on the server; callers treat that as

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,2 @@
+import { ForgotPassword } from '../features/auth';
+export default ForgotPassword;

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,2 @@
+import { ResetPassword } from '../features/auth';
+export default ResetPassword;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,8 +13,10 @@ import { Route as PublicRouteRouteImport } from './routes/_public/route'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthSsoCompleteRouteImport } from './routes/auth/sso-complete'
+import { Route as PublicResetPasswordRouteImport } from './routes/_public/reset-password'
 import { Route as PublicRegisterRouteImport } from './routes/_public/register'
 import { Route as PublicLoginRouteImport } from './routes/_public/login'
+import { Route as PublicForgotPasswordRouteImport } from './routes/_public/forgot-password'
 import { Route as AuthenticatedNotificationsRouteImport } from './routes/_authenticated/notifications'
 import { Route as AuthenticatedInsightsRouteImport } from './routes/_authenticated/insights'
 import { Route as AuthenticatedSettingsRouteRouteImport } from './routes/_authenticated/settings/route'
@@ -62,6 +64,11 @@ const AuthSsoCompleteRoute = AuthSsoCompleteRouteImport.update({
   path: '/auth/sso-complete',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PublicResetPasswordRoute = PublicResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => PublicRouteRoute,
+} as any)
 const PublicRegisterRoute = PublicRegisterRouteImport.update({
   id: '/register',
   path: '/register',
@@ -70,6 +77,11 @@ const PublicRegisterRoute = PublicRegisterRouteImport.update({
 const PublicLoginRoute = PublicLoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => PublicRouteRoute,
+} as any)
+const PublicForgotPasswordRoute = PublicForgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
   getParentRoute: () => PublicRouteRoute,
 } as any)
 const AuthenticatedNotificationsRoute =
@@ -240,8 +252,10 @@ export interface FileRoutesByFullPath {
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/insights': typeof AuthenticatedInsightsRoute
   '/notifications': typeof AuthenticatedNotificationsRoute
+  '/forgot-password': typeof PublicForgotPasswordRoute
   '/login': typeof PublicLoginRoute
   '/register': typeof PublicRegisterRoute
+  '/reset-password': typeof PublicResetPasswordRoute
   '/auth/sso-complete': typeof AuthSsoCompleteRoute
   '/products/$productId': typeof AuthenticatedProductsProductIdRouteRouteWithChildren
   '/admin/ai': typeof AuthenticatedAdminAiRoute
@@ -271,8 +285,10 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/insights': typeof AuthenticatedInsightsRoute
   '/notifications': typeof AuthenticatedNotificationsRoute
+  '/forgot-password': typeof PublicForgotPasswordRoute
   '/login': typeof PublicLoginRoute
   '/register': typeof PublicRegisterRoute
+  '/reset-password': typeof PublicResetPasswordRoute
   '/auth/sso-complete': typeof AuthSsoCompleteRoute
   '/admin/ai': typeof AuthenticatedAdminAiRoute
   '/admin/auth': typeof AuthenticatedAdminAuthRoute
@@ -307,8 +323,10 @@ export interface FileRoutesById {
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/_authenticated/insights': typeof AuthenticatedInsightsRoute
   '/_authenticated/notifications': typeof AuthenticatedNotificationsRoute
+  '/_public/forgot-password': typeof PublicForgotPasswordRoute
   '/_public/login': typeof PublicLoginRoute
   '/_public/register': typeof PublicRegisterRoute
+  '/_public/reset-password': typeof PublicResetPasswordRoute
   '/auth/sso-complete': typeof AuthSsoCompleteRoute
   '/_authenticated/products/$productId': typeof AuthenticatedProductsProductIdRouteRouteWithChildren
   '/_authenticated/admin/ai': typeof AuthenticatedAdminAiRoute
@@ -343,8 +361,10 @@ export interface FileRouteTypes {
     | '/settings'
     | '/insights'
     | '/notifications'
+    | '/forgot-password'
     | '/login'
     | '/register'
+    | '/reset-password'
     | '/auth/sso-complete'
     | '/products/$productId'
     | '/admin/ai'
@@ -374,8 +394,10 @@ export interface FileRouteTypes {
     | '/'
     | '/insights'
     | '/notifications'
+    | '/forgot-password'
     | '/login'
     | '/register'
+    | '/reset-password'
     | '/auth/sso-complete'
     | '/admin/ai'
     | '/admin/auth'
@@ -409,8 +431,10 @@ export interface FileRouteTypes {
     | '/_authenticated/settings'
     | '/_authenticated/insights'
     | '/_authenticated/notifications'
+    | '/_public/forgot-password'
     | '/_public/login'
     | '/_public/register'
+    | '/_public/reset-password'
     | '/auth/sso-complete'
     | '/_authenticated/products/$productId'
     | '/_authenticated/admin/ai'
@@ -474,6 +498,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthSsoCompleteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_public/reset-password': {
+      id: '/_public/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof PublicResetPasswordRouteImport
+      parentRoute: typeof PublicRouteRoute
+    }
     '/_public/register': {
       id: '/_public/register'
       path: '/register'
@@ -486,6 +517,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof PublicLoginRouteImport
+      parentRoute: typeof PublicRouteRoute
+    }
+    '/_public/forgot-password': {
+      id: '/_public/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof PublicForgotPasswordRouteImport
       parentRoute: typeof PublicRouteRoute
     }
     '/_authenticated/notifications': {
@@ -808,13 +846,17 @@ const AuthenticatedRouteRouteWithChildren =
   AuthenticatedRouteRoute._addFileChildren(AuthenticatedRouteRouteChildren)
 
 interface PublicRouteRouteChildren {
+  PublicForgotPasswordRoute: typeof PublicForgotPasswordRoute
   PublicLoginRoute: typeof PublicLoginRoute
   PublicRegisterRoute: typeof PublicRegisterRoute
+  PublicResetPasswordRoute: typeof PublicResetPasswordRoute
 }
 
 const PublicRouteRouteChildren: PublicRouteRouteChildren = {
+  PublicForgotPasswordRoute: PublicForgotPasswordRoute,
   PublicLoginRoute: PublicLoginRoute,
   PublicRegisterRoute: PublicRegisterRoute,
+  PublicResetPasswordRoute: PublicResetPasswordRoute,
 }
 
 const PublicRouteRouteWithChildren = PublicRouteRoute._addFileChildren(

--- a/frontend/src/routes/_public/forgot-password.tsx
+++ b/frontend/src/routes/_public/forgot-password.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import ForgotPassword from '../../pages/ForgotPassword';
+
+export const Route = createFileRoute('/_public/forgot-password')({
+  component: ForgotPassword,
+});

--- a/frontend/src/routes/_public/reset-password.tsx
+++ b/frontend/src/routes/_public/reset-password.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+import ResetPassword from '../../pages/ResetPassword';
+
+export const Route = createFileRoute('/_public/reset-password')({
+  validateSearch: (search): { token?: string } => ({ token: typeof search.token === 'string' ? search.token : undefined }),
+  component: ResetPassword,
+});

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -225,6 +225,7 @@ export interface RetailerConfig {
 
 export interface SystemSettings {
   registration_enabled: boolean | string;
+  password_reset_enabled?: boolean | string;
   debug_page_enabled?: boolean | string;
   scheduler_disabled?: boolean | string;
   retailer_updates_disabled?: boolean | string;


### PR DESCRIPTION
## Summary

- single-use, one-hour reset tokens (SHA-256 hashes only) in a new `password_reset_tokens` table; a new request supersedes the previous unused token
- `POST /auth/forgot-password` responds identically whether or not the account exists (no enumeration), is rate-limited per IP and email, and silently skips disabled and SSO-only accounts
- emails use the existing `SMTP_FALLBACK_*` settings via a new shared system mailer, which the database health monitor now reuses
- admin toggle under Admin -> System -> Security & Access; the login page's Forgot password? link appears only when the toggle is on **and** SMTP is configured
- new public `/forgot-password` and `/reset-password` pages

## Validation

- backend/frontend builds, backend tests, emoji lint
- migration 010 applied against a real Postgres 17
- token flow behavior-tested against the migrated schema: valid reset, single-use, expiry, unknown token, short password, and supersession all verified

Closes #42