### PR TITLE
fix(products): responsive layout of the price selection dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Price selection dialog layout on small screens: candidate rows now wrap
+  instead of colliding with the selection check, the manual-entry currency
+  dropdown is wide enough for full currency names, and the dialog uses the
+  viewport fully on phones.
 - The browser scraper no longer leaks Chromium profile directories in /tmp:
   profiles are pinned per session and removed when the browser closes,
   crashes, or the container stops, stale profiles are swept at startup, and

--- a/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.css
+++ b/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.css
@@ -113,6 +113,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.5rem;
+  /* Keep the confidence pill clear of the absolutely-positioned check icon. */
+  padding-right: 2.25rem;
   margin-bottom: 0.5rem;
 }
 
@@ -191,6 +195,8 @@
   align-items: flex-start;
   padding: 0.25rem 0.5rem;
   border-left: 3px solid var(--border);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .price-context-item.deal {
@@ -304,7 +310,12 @@
 
 .manual-entry-row {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+.manual-entry-row .manual-entry-input {
+  min-width: 140px;
 }
 
 .manual-entry-input {
@@ -322,7 +333,9 @@
   border: 1px solid var(--border);
   background: var(--surface);
   color: var(--text);
-  width: 80px;
+  flex: 1;
+  min-width: 160px;
+  max-width: 100%;
 }
 
 .warning-banner {
@@ -335,3 +348,26 @@
   color: #b45309;
 }
 
+
+@media (max-width: 480px) {
+  .price-modal-overlay {
+    padding: 0.5rem;
+  }
+
+  .price-modal {
+    max-height: 96vh;
+  }
+
+  .price-modal-header,
+  .price-modal-product,
+  .price-modal-body,
+  .price-modal-footer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .price-filter-tabs {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary

- candidate rows wrap on narrow widths and keep the confidence pill clear of the selection check icon
- manual-entry currency dropdown sized for full currency names (was a fixed 80px) and wraps on narrow screens
- price-context cells clamp overflow; small-screen media query uses the viewport fully

Addresses the concrete part of #54. The dialog's manual price currency list already reads from `global_currencies` in this codebase (not a static list). Whether manual price entry should exist at all is left open on the issue as a product decision.

## Validation

- frontend build, emoji lint

Part of #54