### PR TITLE
fix(scraper): RRP sanity guardrail and always-record manual confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Original Price (RRP) values below the resolved standard price (or absurdly
+  above it) are now discarded as stray selector matches instead of being
+  recorded, so the RRP history stops jumping to unrelated page numbers.
+- Confirming a price in the troubleshoot/re-scan flow now always records a
+  fresh price-history entry — including when the confirmed price is unchanged
+  — so stale products are repopulated by a manual confirmation.
 - Price selection dialog layout on small screens: candidate rows now wrap
   instead of colliding with the selection check, the manual-entry currency
   dropdown is wide enough for full currency names, and the dialog uses the

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -153,7 +153,10 @@ export class ProductPersistenceService {
       logger.warn(`Product ${productId} | Price | Skipped recording ${scrapedData.price.price}: no currency resolved (${source})`, 'Products', { product_id: productId });
     } else if (scrapedData.price?.currency) {
       const latestStandardPrice = await priceHistoryRepository.getLatest(productId, 'standard');
-      if (!latestStandardPrice || latestStandardPrice.price !== scrapedData.price.price) {
+      // A manual confirmation always records, even at an unchanged price: the
+      // user explicitly verified it, and the fresh row is what repopulates a
+      // stale product's history and anchor (issue #55).
+      if (source === 'manual-confirm' || !latestStandardPrice || latestStandardPrice.price !== scrapedData.price.price) {
         await priceHistoryRepository.create(
           productId,
           scrapedData.price.price,

--- a/backend/src/services/scraper/orchestration/consensus.ts
+++ b/backend/src/services/scraper/orchestration/consensus.ts
@@ -66,6 +66,20 @@ export async function runConsensusPhase(
     extractionSteps.push('Consensus | Review | Winning price has no resolved currency');
   }
 
+  // RRP sanity guardrail: original-price candidates come partly from generic
+  // strikethrough/"was"-style selectors, which can match unrelated numbers
+  // (financing text, bundle offers, related-product cards). A real RRP is
+  // never below the resolved standard price and not absurdly above it — drop
+  // anything else so it cannot pollute the original-price history (issue #55).
+  if (result.price?.price && result.originalPrice?.price) {
+    const standard = result.price.price;
+    const original = result.originalPrice.price;
+    if (original < standard || original > standard * 10) {
+      extractionSteps.push(`Consensus | Guardrail | Discarded implausible original price ${original} (standard ${standard})`);
+      result.originalPrice = null;
+    }
+  }
+
   // Out of Stock (OOS) price guardrails
   if (result.stockStatus === 'out_of_stock' || result.stockStatus === 'not_available') {
     if (result.price) {


### PR DESCRIPTION
## Summary

Code-level fixes for the reproducible parts of #55:

- consensus discards an "original price" below the resolved standard price or more than 10x above it — generic strikethrough/`was`-style selectors can match unrelated page numbers (financing text, bundle offers, related-product cards) and nothing sanity-checked them before recording
- confirming a price in troubleshoot/re-scan now always records a fresh history row, even when the confirmed price is unchanged, so stale products get repopulated (the re-scan flow already performs a full fetch -> extract -> display pass)

The remaining question in #55 — why the specific JB Hi-Fi RRP values fluctuated — needs the reporting instance's `retailer_configs` row and scrape traces; the guardrail neutralizes the failure mode either way.

## Validation

- backend build and tests

Part of #55