### PR TITLE
fix(deploy): pin the postgres task to the macmini node

### DIFF
--- a/deploy/swarm-stack.yml
+++ b/deploy/swarm-stack.yml
@@ -52,6 +52,12 @@ services:
     networks:
       - pricestalker-internal
     deploy:
+      # The data volume is node-local and lives on the macmini. Without this
+      # pin a redeploy can reschedule the task to another node, where it
+      # silently starts a fresh empty database on a new volume.
+      placement:
+        constraints:
+          - node.hostname == macmini
       restart_policy:
         condition: on-failure
 


### PR DESCRIPTION
The postgres data volume is node-local; without a placement constraint a redeploy can reschedule the task to another node and silently start a fresh empty database. This pins it to the macmini, matching where the data volume lives. Applied to production already — this records it in the repo.