### PR TITLE
fix(scraper): treat wall-404s as challenges and debounce page-gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A bot-protection wall served with a 404 status (e.g. Akamai "Access
+  Denied") is no longer mistaken for a deleted product page: the response
+  body is checked against the bot-challenge detector, and a product is only
+  marked unavailable, paused, and notified after three consecutive page-gone
+  scrapes instead of one.
 - Original Price (RRP) values below the resolved standard price (or absurdly
   above it) are now discarded as stray selector matches instead of being
   recorded, so the RRP history stops jumping to unrelated page numbers.

--- a/backend/src/migrations/011_page_gone_streak.ts
+++ b/backend/src/migrations/011_page_gone_streak.ts
@@ -1,0 +1,38 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Counter of consecutive page-gone (404/410) scrape results per product.
+ * A product is only flagged not_available (paused + notified) after several
+ * consecutive hits, so a transient CDN/bot-wall 404 no longer pauses
+ * monitoring and spams notifications (2026-08-16 digitec incident).
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`
+      ALTER TABLE products
+      ADD COLUMN IF NOT EXISTS page_gone_streak INTEGER NOT NULL DEFAULT 0;
+    `);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('ALTER TABLE products DROP COLUMN IF EXISTS page_gone_streak;');
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/backend/src/models/types/product.ts
+++ b/backend/src/models/types/product.ts
@@ -10,6 +10,7 @@ export interface Product {
   last_checked: Date | null;
   next_check_at: Date | null;
   stock_status: StockStatus;
+  page_gone_streak?: number;
   price_drop_threshold: number | null;
   target_price: number | null;
   notify_back_in_stock: boolean;

--- a/backend/src/services/domain/product/ProductRefreshService.ts
+++ b/backend/src/services/domain/product/ProductRefreshService.ts
@@ -9,6 +9,10 @@ import { logger } from '../../../utils/system/logger';
 import { productNotificationService } from './notifications/index';
 import { productPersistenceService } from './ProductPersistenceService';
 
+// Consecutive page-gone (404/410) scrapes required before a product is
+// marked not_available, monitoring is paused, and the user is notified.
+const PAGE_GONE_THRESHOLD = 3;
+
 export class ProductRefreshService {
   /**
    * Refreshes a product by scraping its URL and updating its state.
@@ -37,6 +41,21 @@ export class ProductRefreshService {
       undefined,
       productId
     );
+
+    // 1.5 Debounce page-gone results: bot walls can serve 404 for a while,
+    // so a product is only flagged not_available (paused + notified) after
+    // several consecutive page-gone scrapes. Until then the previous status
+    // is kept and only the streak advances.
+    if (scrapedData.stockStatus === 'not_available' && product.stock_status !== 'not_available') {
+      const streak = (product.page_gone_streak || 0) + 1;
+      await productRepository.setPageGoneStreak(productId, streak);
+      if (streak < PAGE_GONE_THRESHOLD) {
+        logger.warn(`Product ${productId} | Status | Page gone (${streak}/${PAGE_GONE_THRESHOLD} consecutive). Keeping status '${product.stock_status}' until the streak completes.`, 'Products', { product_id: productId });
+        scrapedData.stockStatus = product.stock_status;
+      }
+    } else if (product.page_gone_streak) {
+      await productRepository.setPageGoneStreak(productId, 0);
+    }
 
     // 2. Persist results (DB State Sync)
     await productPersistenceService.saveScrapeResult(productId, userId, scrapedData, 'refresh');

--- a/backend/src/services/domain/product/repositories/product-config.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-config.repository.ts
@@ -3,6 +3,13 @@ import { StockStatus, AIStatus } from '../../../../models/types';
 import { calculateNextCheckSeconds } from '../../../../utils/system/scheduler-helpers';
 
 export const productConfigRepository = {
+  setPageGoneStreak: async (id: number, streak: number): Promise<void> => {
+    await pool.query(
+      'UPDATE products SET page_gone_streak = $2 WHERE id = $1',
+      [id, streak]
+    );
+  },
+
   updateLastChecked: async (id: number, refreshInterval: number): Promise<void> => {
     const nextCheckSeconds = calculateNextCheckSeconds(refreshInterval);
 

--- a/backend/src/services/scraper/acquisition/standard.ts
+++ b/backend/src/services/scraper/acquisition/standard.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosError } from 'axios';
+import { load } from 'cheerio';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { logger } from '../../../utils/system/logger';
 import { settingsCache } from '../../../utils/cache';
-import { 
-  getHeaders, 
+import {
+  getHeaders,
+  detectBotChallenge,
   PageNotAvailableError
 } from '../transport';
 import { RetailerConfig } from '../../../models';
@@ -114,6 +116,23 @@ function handleAxiosError(err: any, url: string, extractionSteps: string[], requ
   logger.debug(`Scraper | Axios | [${requestId || 'N/A'}] | Error Code: ${errCode}`, 'Scraper', { requestId });
   
   if (status === 404 || status === 410) {
+    // Bot walls (Akamai, Cloudflare, ...) sometimes serve their block page
+    // with a 404 status. Inspect the body before declaring the page gone —
+    // a blocked scrape must be treated as a challenge, not a deleted product.
+    const body = typeof err.response?.data === 'string' ? err.response.data : '';
+    if (body) {
+      try {
+        const challenge = detectBotChallenge(body, load(body));
+        if (challenge) {
+          extractionSteps.push(`Request | Challenge | ${challenge} served as HTTP ${status}`);
+          throw new BotChallengeError(`${challenge} (served as HTTP ${status})`);
+        }
+      } catch (detectErr) {
+        if (detectErr instanceof BotChallengeError) throw detectErr;
+        // A body we cannot parse is not evidence the page is gone or blocked;
+        // fall through to the plain 404 handling.
+      }
+    }
     throw new PageNotAvailableError(`Page not found (${status}): ${url}`);
   }
 

--- a/backend/src/services/scraper/transport/remote.ts
+++ b/backend/src/services/scraper/transport/remote.ts
@@ -66,9 +66,12 @@ export async function fetchRemoteHtml(url: string, remoteScraperUrl: string, opt
       const status = error.response?.status;
       const msg = error.response?.data?.error || error.message;
 
-      // SPECIFIC: 404/410 means the page is gone.
+      // The scraper service itself never responds 404/410 (it maps page
+      // failures to 500/503), so this status means the configured Remote
+      // Scraper URL endpoint does not exist — a configuration problem, never
+      // evidence that the product page is gone.
       if (status === 404 || status === 410) {
-        throw new PageNotAvailableError(`Page not found (${status}): ${url}`);
+        throw new Error(`Remote Scraper endpoint not found (${status}) — check the Remote Scraper URL setting`);
       }
 
       // Handle Rate Limiting (503) with Exponential Backoff


### PR DESCRIPTION
## Summary

- check 404/410 response bodies with the existing bot-challenge detector before declaring a page gone — Akamai served its Access Denied wall as HTTP 404 overnight and every digitec product got paused with a notification after a single failed check
- require 3 consecutive page-gone scrapes (new `page_gone_streak` column, migration 011) before marking not_available, pausing, and notifying; success resets the streak
- a 404 from the remote scraper service endpoint is a configuration error, not a dead product page

## Validation

- backend build and tests
- migration 011 applied against a real Postgres 17
- detector verified against the captured Akamai block body from production