### PR TITLE
fix(scraper): recognize robot interstitials and preserve known stock status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retailer robot-check interstitials (e.g. digitec's "Are you a robot?") are
+  now recognized as bot challenges instead of dead pages, a scrape that
+  cannot determine stock no longer overwrites a known stock status with
+  "unknown", and the browser scraper waits out auto-resolving challenge
+  pages before returning them.
 - A bot-protection wall served with a 404 status (e.g. Akamai "Access
   Denied") is no longer mistaken for a deleted product page: the response
   body is checked against the bot-challenge detector, and a product is only

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -129,6 +129,14 @@ export class ProductPersistenceService {
     product: Product,
     scrapedData: ScrapedProductWithVoting
   ) {
+    // 'unknown' means the scrape could not determine anything (blocked page,
+    // failed extraction) — it is not an observation, so never let it
+    // overwrite a real previously-known status.
+    if (scrapedData.stockStatus === 'unknown' && product.stock_status && product.stock_status !== 'unknown') {
+      logger.debug(`Product ${productId} | Stock | Scrape returned unknown; keeping '${product.stock_status}'`, 'Products', { product_id: productId });
+      return;
+    }
+
     if (scrapedData.stockStatus !== product.stock_status) {
       await productRepository.updateStockStatus(productId, scrapedData.stockStatus, scrapedData.aiStatus);
       await stockHistoryRepository.recordChange(productId, scrapedData.stockStatus);

--- a/backend/src/services/scraper/transport/detection.ts
+++ b/backend/src/services/scraper/transport/detection.ts
@@ -11,6 +11,13 @@ export function detectBotChallenge(html: string, $: CheerioAPI): string | null {
     return 'Akamai Access Denied';
   }
 
+  // Retailer-specific robot interstitials (e.g. digitec/galaxus "Are you a
+  // robot?"). These pages carry robots-noindex and no product data, so
+  // without this check they are misread as soft-404 dead pages.
+  if (title.includes('are you a robot') || title.includes('robot check') || title.includes('verify you are human') || title.includes('bot verification')) {
+    return 'Robot Check Interstitial';
+  }
+
   // Cloudflare
   if (title.includes('just a moment') || title.includes('cloudflare') || html.includes('cloudflare-static') || html.includes('cf-browser-verification')) {
     return 'Cloudflare Challenge';

--- a/scraper/src/services/ScraperService.ts
+++ b/scraper/src/services/ScraperService.ts
@@ -102,7 +102,20 @@ export class ScraperService {
       }
 
       if (abortSignal?.aborted) return null;
-      const html = await page.content();
+      let html = await page.content();
+
+      // Some challenge interstitials ("Are you a robot?", "Just a moment...")
+      // auto-resolve after their JS fingerprinting finishes. Give them a
+      // couple of chances before returning the wall page.
+      const challengePattern = /are you a robot|just a moment|access denied|verify you are human/i;
+      for (let attempt = 1; attempt <= 2 && challengePattern.test(html); attempt++) {
+        log(`Challenge interstitial detected, waiting for auto-resolve (${attempt}/2)...`, 'INFO', context);
+        await new Promise(resolve => setTimeout(resolve, 8000));
+        if (abortSignal?.aborted) return null;
+        await performHumanLikeActions(page, context);
+        html = await page.content();
+      }
+
       let screenshotBase64 = null;
 
       if (options.captureScreenshot) {


### PR DESCRIPTION
## Summary

Follow-up to #70, from live verification against digitec:

- `detectBotChallenge` now recognizes robot-check interstitial titles ("Are you a robot?" etc.), so they classify as challenges before the soft-404 checks can misread them as dead pages
- a scrape resolving stock as `unknown` no longer overwrites a real previously-known status
- the browser scraper waits out auto-resolving challenge interstitials (up to 2 re-reads, 8s apart) before returning the wall page

## Validation

- backend build + tests, scraper build
- verified against the live interstitial HTML returned by digitec through the production browser scraper