### PR TITLE
fix(scraper): stop learning brand as retailer name; let images self-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retailer display names are no longer learned from a product's brand: the
+  seeded generic retailer-name selectors included two [itemprop="brand"]
+  selectors, which made shops without an og:site_name take the first scraped
+  product's brand as their name (digitec.ch showed as "Lian-Li").
+- Product images now self-heal: a scraped image URL that differs from the
+  stored one replaces it, so images survive retailers rotating their CDN
+  asset URLs (stored URLs previously went dead permanently).
 - Retailer robot-check interstitials (e.g. digitec's "Are you a robot?") are
   now recognized as bot challenges instead of dead pages, a scrape that
   cannot determine stock no longer overwrites a known stock status with

--- a/backend/src/migrations/012_remove_brand_retailer_selectors.ts
+++ b/backend/src/migrations/012_remove_brand_retailer_selectors.ts
@@ -1,0 +1,40 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * The seeded generic retailer-name selectors included two product-BRAND
+ * selectors ([itemprop="brand"]). On pages without an og:site_name they made
+ * the retailer "learn" the first scraped product's brand as the shop name
+ * (digitec.ch was displayed as "Lian-Li"). Remove them from the stored
+ * setting; retailer names come from site identity signals only.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`
+      UPDATE system_settings
+      SET value = COALESCE(
+            (SELECT jsonb_agg(elem)
+             FROM jsonb_array_elements_text(value::jsonb) AS elem
+             WHERE elem NOT LIKE '%itemprop="brand"%'),
+            '[]'::jsonb
+          )::text,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE key = 'generic_retailer_name_selectors'
+        AND EXISTS (
+          SELECT 1 FROM jsonb_array_elements_text(value::jsonb) AS elem
+          WHERE elem LIKE '%itemprop="brand"%'
+        );
+    `);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async () => {
+  // Intentionally a no-op: restoring known-bad selectors serves nothing.
+};

--- a/backend/src/services/domain/product/utils/metadata.ts
+++ b/backend/src/services/domain/product/utils/metadata.ts
@@ -37,6 +37,10 @@ export function sanitizeProductName(name: string | null | undefined): string | n
 export function sanitizeProductImage(imageUrl: string | null | undefined, currentImageUrl: string | null): string | null {
   if (!imageUrl) return null;
   if (imageUrl.includes('placeholder')) return null;
-  if (currentImageUrl && !currentImageUrl.includes('placeholder')) return null; // Only update if currently placeholder
+  if (currentImageUrl === imageUrl) return null; // unchanged
+  // A differing scraped image replaces the stored one: retailers rotate CDN
+  // asset URLs, and a stored URL that is never refreshed 404s forever once
+  // the old asset disappears. Blocked/challenged scrapes extract no image,
+  // so they cannot overwrite a good URL with junk.
   return imageUrl;
 }

--- a/backend/tests/unit/metadata-validation.test.ts
+++ b/backend/tests/unit/metadata-validation.test.ts
@@ -43,8 +43,12 @@ describe('Product Metadata Utilities', () => {
       expect(sanitizeProductImage('http://example.com/real.jpg', 'placeholder.png')).toBe('http://example.com/real.jpg');
     });
 
-    it('should return null if current image is already a real image', () => {
-      expect(sanitizeProductImage('http://example.com/new.jpg', 'http://example.com/old.jpg')).toBe(null);
+    it('should replace a differing stored image (retailers rotate CDN asset URLs)', () => {
+      expect(sanitizeProductImage('http://example.com/new.jpg', 'http://example.com/old.jpg')).toBe('http://example.com/new.jpg');
+    });
+
+    it('should return null when the scraped image is unchanged', () => {
+      expect(sanitizeProductImage('http://example.com/same.jpg', 'http://example.com/same.jpg')).toBe(null);
     });
   });
 });


### PR DESCRIPTION
## Summary

- migration 012 removes the two `[itemprop="brand"]` selectors from the seeded generic retailer-name selectors — they return the product's brand, and on pages without `og:site_name` the first scraped product's brand became the shop's display name (digitec.ch showed as "Lian-Li")
- `sanitizeProductImage` now replaces a stored image URL when the scraped one differs, so images survive retailers rotating CDN asset URLs; previously a stored URL was never updated and went permanently dead

## Validation

- backend build; tests updated for the new image semantics (114 passing)
- migration 012 verified against a real Postgres 17, including idempotent rerun