### PR TITLE
fix: prevent private network prompts in debug inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Scraper debug previews no longer execute arbitrary scripts from fetched pages,
+  preventing anti-bot scripts from triggering Chrome Private Network Access
+  prompts; the API also acknowledges Private Network Access preflight requests.
 - The Admin System Event Log now populates the Context Filter from the API's
   `contexts` response field and keeps pagination on the requested page.
 - Retailer configurations that define only a JSON-LD price key are no longer

--- a/backend/src/app/app.ts
+++ b/backend/src/app/app.ts
@@ -21,6 +21,12 @@ if (!fs.existsSync(debugDir)) {
 }
 
 // Middleware
+app.use((req, res, next) => {
+  if (req.headers['access-control-request-private-network'] === 'true') {
+    res.setHeader('Access-Control-Allow-Private-Network', 'true');
+  }
+  next();
+});
 app.use(cors());
 app.use(express.json({ limit: '50mb' }));
 app.use(requestLogger);

--- a/frontend/src/features/debug/pages/DebugPage.tsx
+++ b/frontend/src/features/debug/pages/DebugPage.tsx
@@ -194,6 +194,7 @@ export default function Debug() {
                         id="debug-iframe"
                         title="Rendered Source"
                         className="iframe-viewer"
+                        sandbox="allow-same-origin"
                         srcDoc={`
                           <style>
                             /* PriceStalker Debug Overrides: Prevent layout blowouts & Aggressive Flattening */

--- a/frontend/src/features/debug/pages/DebugPage.tsx
+++ b/frontend/src/features/debug/pages/DebugPage.tsx
@@ -194,7 +194,7 @@ export default function Debug() {
                         id="debug-iframe"
                         title="Rendered Source"
                         className="iframe-viewer"
-                        sandbox="allow-same-origin"
+                        sandbox=""
                         srcDoc={`
                           <style>
                             /* PriceStalker Debug Overrides: Prevent layout blowouts & Aggressive Flattening */


### PR DESCRIPTION
## Summary

Fixes Chrome Private Network Access prompts caused by scripts in the scraper debug preview.

- Sandbox the debug preview iframe so fetched page scripts cannot execute.
- Support Private Network Access preflight requests in the backend.
- Document the fix in the changelog.

## Verification

- Frontend build passed
- Backend TypeScript build passed
- Frontend tests passed
- Lint passed
- Runtime PNA preflight check passed

Closes #75