### PR TITLE
fix: preserve scraped retailer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The simplified scraper result now preserves the retailer name resolved during
+  extraction, so callers can use it for store identification and configuration.
 - Retailer display names are no longer learned from a product's brand: the
   seeded generic retailer-name selectors included two [itemprop="brand"]
   selectors, which made shops without an og:site_name take the first scraped

--- a/backend/src/services/scraper/orchestration/index.ts
+++ b/backend/src/services/scraper/orchestration/index.ts
@@ -23,6 +23,7 @@ export async function scrapeProduct(url: string, userId?: number): Promise<Scrap
   const res = await scrapeProductWithVoting(url, userId);
   return { 
     name: res.name, 
+    retailerName: res.retailerName,
     price: res.price, 
     memberPrice: res.memberPrice,
     originalPrice: res.originalPrice,


### PR DESCRIPTION
## Summary

Preserve `retailerName` in the simplified `scrapeProduct()` result so callers can use the retailer resolved during extraction.

The scraper type and full voting result already support this field; the simplified wrapper was dropping it.

## Verification

- Backend TypeScript build passed
- Backend tests passed: 121 tests
- `git diff --check` passed

Closes #69