### PR TITLE
feat: prefix generated API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Newly generated system API tokens now use a `ps_` prefix to make leaked
+  PriceStalker tokens easier for secret-scanning tools to identify.
 - Password reset via email: a "Forgot password?" link on the login page sends
   a single-use, one-hour reset link using the system SMTP settings
   (`SMTP_FALLBACK_*`). Admins can disable the feature under Admin -> System ->

--- a/backend/src/services/domain/token/index.ts
+++ b/backend/src/services/domain/token/index.ts
@@ -8,7 +8,7 @@ export class SystemApiTokenService {
    * Generates a new secure random token
    */
   private generateSecureToken(): string {
-    return crypto.randomBytes(32).toString('hex');
+    return `ps_${crypto.randomBytes(32).toString('hex')}`;
   }
 
   /**


### PR DESCRIPTION
## Summary

Prefix newly generated system API tokens with `ps_` so secret-scanning tools can identify leaked PriceStalker tokens more reliably.

Existing unprefixed tokens remain valid because verification still compares the supplied plaintext against their stored bcrypt hashes. The `ADMIN_API_TOKEN` environment variable is unchanged.

## Verification

- Backend TypeScript build passed
- Backend tests passed: 121 tests
- Lint passed
- `git diff --check` passed

Closes #84