### PR TITLE
fix: restore admin log context filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Admin System Event Log now populates the Context Filter from the API's
+  `contexts` response field and keeps pagination on the requested page.
 - Retailer configurations that define only a JSON-LD price key are no longer
   treated as empty shell configurations, so their saved extraction settings are
   used instead of being discarded in favour of the generic selectors.

--- a/frontend/src/features/admin/components/sections/LogsSection.tsx
+++ b/frontend/src/features/admin/components/sections/LogsSection.tsx
@@ -3,6 +3,7 @@ import { Link } from '@tanstack/react-router';
 import { AdminSystemService } from '../../services/AdminSystemService';
 import { useToast } from '../../../../context/ToastContext';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
+import type { SystemLog } from '../../../../types/api';
 
 interface LogsSectionProps {
   onSearchRetailer: (domain: string) => void;
@@ -10,7 +11,7 @@ interface LogsSectionProps {
 
 export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
   const { showToast } = useToast();
-  const [logs, setLogs] = useState<any[]>([]);
+  const [logs, setLogs] = useState<SystemLog[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [logPage, setLogPage] = useState(1);
   const [logPages, setLogPages] = useState(1);
@@ -38,9 +39,9 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
       });
       setLogs(res.logs);
       setTotalCount(res.total);
-      setLogPage(res.page);
+      setLogPage(page);
       setLogPages(res.pages);
-      setAvailableContexts(res.availableContexts || []);
+      setAvailableContexts(res.contexts);
     } catch {
       showToast('Failed to load logs', 'error');
     } finally {
@@ -210,7 +211,7 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
                                   <button 
                                     className="btn btn-secondary btn-sm" 
                                     style={{ fontSize: '0.65rem', height: '20px', padding: '0 0.5rem', display: 'flex', alignItems: 'center' }}
-                                    onClick={() => onSearchRetailer(log.details.retailer_domain)}
+                                    onClick={() => onSearchRetailer(log.details?.retailer_domain ?? '')}
                                   >
                                     Retailer
                                   </button>
@@ -225,7 +226,7 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
                               <div style={{ marginBottom: '1.5rem' }}>
                                 <div style={{ marginBottom: '0.75rem', fontWeight: 700, fontSize: '0.9rem' }}>Process Flow</div>
                                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                                  {(log.details.trace || log.details.steps).map((step: string, idx: number) => (
+                                  {(log.details?.trace ?? log.details?.steps ?? []).map((step: string, idx: number) => (
                                     <div key={idx} style={{ 
                                       padding: '0.5rem 0.75rem', 
                                       background: 'var(--background)', 

--- a/frontend/src/features/admin/services/AdminSystemService.ts
+++ b/frontend/src/features/admin/services/AdminSystemService.ts
@@ -2,7 +2,8 @@ import { api, type RequestOptions } from '../../../api/client';
 import { 
   SystemSettings, 
   SystemApiToken, 
-  CreateSystemApiTokenResponse 
+  CreateSystemApiTokenResponse,
+  SystemLogsResponse
 } from '../../../types/api';
 
 export const AdminSystemService = {
@@ -14,7 +15,7 @@ export const AdminSystemService = {
 
   // Logs
   getLogs: (params: { page?: number; limit?: number; level?: string; context?: string; search?: string }) => 
-    api.get<any>('/admin/logs', { params }),
+    api.get<SystemLogsResponse>('/admin/logs', { params }),
   deleteLogs: (ids: number[]) => api.delete('/admin/logs', { data: { ids } }),
   clearLogs: (level?: string, context?: string) => api.delete('/admin/logs/clear', { params: { level, context } }),
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -319,6 +319,36 @@ export interface CreateSystemApiTokenResponse {
   systemToken: SystemApiToken;
 }
 
+export interface SystemLogDetails {
+  tokens?: {
+    input: number;
+    output: number;
+  };
+  product_id?: number;
+  retailer_domain?: string;
+  trace?: string[];
+  steps?: string[];
+  error?: unknown;
+  stack?: string;
+  [key: string]: unknown;
+}
+
+export interface SystemLog {
+  id: number;
+  level: string;
+  context: string;
+  message: string;
+  details: SystemLogDetails | null;
+  created_at: string;
+}
+
+export interface SystemLogsResponse {
+  logs: SystemLog[];
+  total: number;
+  pages: number;
+  contexts: string[];
+}
+
 export interface TestRetailerConfigResult {
   success: boolean;
   name?: string | null;


### PR DESCRIPTION
## Summary

- Fix the Admin System Event Log Context Filter to consume the API response's `contexts` field.
- Keep pagination state on the requested page; the API returns `pages` but not `page`.
- Add typed frontend contracts for log entries and the logs response, removing the `any` response type.
- Update the changelog.

## Testing

- `pnpm --filter pricestalker-frontend test -- --run`
- `pnpm --filter pricestalker-frontend run build`
- `pnpm --filter pricestalker-backend test -- --run`
- `pnpm --filter pricestalker-backend run build`
- `pnpm run lint`
- `git diff --check`

The broader event-log JSON schema and UX redesign from the issue discussion is intentionally left for a separate follow-up.

Closes #78