### PR TITLE
fix(scraper): resolve audit findings for O-6, O-7, A-15, and SYS-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retailer configurations that define only a JSON-LD price key are no longer
+  treated as empty shell configurations, so their saved extraction settings are
+  used instead of being discarded in favour of the generic selectors.
+- Exchange-rate refreshes now time out after 10 seconds instead of hanging
+  indefinitely when the Frankfurter API is unreachable.
+- Scraper HTTP retries are logged under the `Scraper` context rather than `AI`,
+  so the admin event log no longer files transport failures as AI failures.
+- Scrape request IDs now use a UUID instead of a timestamp plus a
+  three-digit random number, which could collide between concurrent scrapes.
 - The simplified scraper result now preserves the retailer name resolved during
   extraction, so callers can use it for store identification and configuration.
 - Retailer display names are no longer learned from a product's brand: the

--- a/backend/src/services/domain/system/CurrencyConversionService.ts
+++ b/backend/src/services/domain/system/CurrencyConversionService.ts
@@ -16,7 +16,8 @@ class CurrencyConversionService {
       logger.info(`Currency | Updating rates relative to ${base}...`, 'Currency');
       
       const response = await axios.get<Array<{ date: string; base: string; quote: string; rate: number }>>(this.API_URL, {
-        params: { base }
+        params: { base },
+        timeout: 10000
       });
 
       if (!Array.isArray(response.data) || response.data.length === 0) {

--- a/backend/src/services/scraper/acquisition/standard.ts
+++ b/backend/src/services/scraper/acquisition/standard.ts
@@ -41,7 +41,8 @@ export async function acquireStandardHtml(options: StandardAcquisitionOptions): 
     response = await withRetry(
       () => axios.get(url, { headers, timeout, httpsAgent }),
       { maxRetries: 1 },
-      'Axios'
+      'Axios',
+      'Scraper'
     );
     const latency = Date.now() - start;
     const status = response.status;
@@ -74,7 +75,8 @@ export async function acquireStandardHtml(options: StandardAcquisitionOptions): 
         response = await withRetry(
           () => axios.get(url, { headers, timeout, httpsAgent: undefined }),
           { maxRetries: 2 },
-          'Axios-Fallback'
+          'Axios-Fallback',
+          'Scraper'
         );
         const latency = Date.now() - fallbackStart;
         const status = response.status;

--- a/backend/src/services/scraper/orchestration/index.ts
+++ b/backend/src/services/scraper/orchestration/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { logger } from '../../../utils/system/logger';
 import { 
   ScrapedProduct, 
@@ -47,7 +48,7 @@ export async function scrapeProductWithVoting(
   overrideConfig?: Partial<RetailerConfig>,
   productId?: number
 ): Promise<ScrapedProductWithVoting> {
-  const requestId = `REQ-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const requestId = `REQ-${randomUUID()}`;
   const result: ScrapedProductWithVoting = { 
     name: null, 
     price: null, 
@@ -124,7 +125,8 @@ export async function scrapeProductWithVoting(
       (!domainConfig.member_price_selectors || domainConfig.member_price_selectors.length === 0) &&
       (!domainConfig.name_selectors || domainConfig.name_selectors.length === 0) &&
       (!domainConfig.image_selectors || domainConfig.image_selectors.length === 0) &&
-      (!domainConfig.stock_selectors || domainConfig.stock_selectors.length === 0);
+      (!domainConfig.stock_selectors || domainConfig.stock_selectors.length === 0) &&
+      !domainConfig.jsonld_price_key;
 
     const isDefinitivelyUnavailable = result.stockStatus === 'out_of_stock' || result.stockStatus === 'not_available';
     const priceExtracted = result.price !== null;

--- a/backend/src/services/scraper/transport/remote.ts
+++ b/backend/src/services/scraper/transport/remote.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import axios from 'axios';
 import { logger } from '../../../utils/system/logger';
 import { PageNotAvailableError } from './errors';
@@ -10,7 +11,7 @@ export async function fetchRemoteHtml(url: string, remoteScraperUrl: string, opt
   let retryCount = 0;
 
   // Generate a unique Request ID for traceability across services
-  const requestId = options.requestId || `REQ-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const requestId = options.requestId || `REQ-${randomUUID()}`;
   const productId = options.productId;
   const isDebug = options.debug || process.env.LOG_LEVEL === 'debug';
 

--- a/backend/src/utils/system/retry.ts
+++ b/backend/src/utils/system/retry.ts
@@ -38,7 +38,8 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 export async function withRetry<T>(
   operation: () => Promise<T>,
   options: RetryOptions = {},
-  context: string = 'Retry'
+  context: string = 'Retry',
+  category: string = 'AI'
 ): Promise<T> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
   let lastError: any;
@@ -67,10 +68,9 @@ export async function withRetry<T>(
       const errorMsg = error.response?.data?.error?.message || error.message || 'Unknown error';
       const status = error.response?.status ? ` (${error.response.status})` : '';
       
-      const logContext = context || 'Retry';
       logger.warn(
-        `${logContext} | Attempt ${attempt} failed${status}: ${errorMsg}. Retrying in ${currentDelay}ms...`,
-        logContext
+        `${category} | ${context} | Attempt ${attempt} failed${status}: ${errorMsg}. Retrying in ${currentDelay}ms...`,
+        category
       );
 
       await new Promise(resolve => setTimeout(resolve, currentDelay));

--- a/backend/src/utils/system/retry.ts
+++ b/backend/src/utils/system/retry.ts
@@ -67,9 +67,10 @@ export async function withRetry<T>(
       const errorMsg = error.response?.data?.error?.message || error.message || 'Unknown error';
       const status = error.response?.status ? ` (${error.response.status})` : '';
       
+      const logContext = context || 'Retry';
       logger.warn(
-        `AI | ${context} | Attempt ${attempt} failed${status}: ${errorMsg}. Retrying in ${currentDelay}ms...`,
-        'AI'
+        `${logContext} | Attempt ${attempt} failed${status}: ${errorMsg}. Retrying in ${currentDelay}ms...`,
+        logContext
       );
 
       await new Promise(resolve => setTimeout(resolve, currentDelay));

--- a/docs/audit/upstream_scraping_consensus_audit.md
+++ b/docs/audit/upstream_scraping_consensus_audit.md
@@ -38,8 +38,8 @@ The original audit registers aggregated bugs across scraping, voting, database t
 | **O-3** | High | Orchestration | `consensus.ts` | OOS drift only checks downward spikes. | Reopened — current code still checks only prices below 50% of the anchor. |
 | **O-4** | High | Orchestration | `maintenance.ts` | `configCache.invalidate()` with no domain key wipes entire cache. | Pending |
 | **O-5** | High | Orchestration | `maintenance.ts` | Wrong extraction step logged for status-restore vs engine-upgrade. | Pending |
-| **O-6** | Medium | Orchestration | `index.ts` | `requestId` has only 1,000 entropy values. | Fixed on `fix/audit-a15-o6-o7-sys15` |
-| **O-7** | Medium | Orchestration | `index.ts` | `isShellConfig` ignores `jsonld_price_key`. | Fixed on `fix/audit-a15-o6-o7-sys15` |
+| **O-6** | Medium | Orchestration | `index.ts` | `requestId` has only 1,000 entropy values. | Fixed |
+| **O-7** | Medium | Orchestration | `index.ts` | `isShellConfig` ignores `jsonld_price_key`. | Fixed |
 | **O-8** | Medium | Orchestration | `consensus.ts` | Arbitrated prices wrongly treated as uncorroborated in OOS guardrail. | Pending |
 | **O-9** | Medium | Orchestration | `index.ts` | `scrapeProduct()` silently drops `retailerName` from return value. | Fixed |
 | **O-10**| Medium | Orchestration | `arbitration.ts` | AI arbitration/verification errors swallowed. | Pending |
@@ -60,7 +60,7 @@ The original audit registers aggregated bugs across scraping, voting, database t
 | **A-12**| Medium | Transport | `remote.ts` | Empty remote HTML body silently treated as successful extraction. | Pending |
 | **A-13**| Medium | Transport | `detection.ts` | Case-sensitive WAF marker detection. | Pending |
 | **A-14**| Low | Transport | `detection.ts` | Akamai `Reference #18.` pattern too specific. | Pending |
-| **A-15**| Low | Acquisition | `standard.ts` | `withRetry` logs under `'AI'` category for HTTP scraper calls. | Fixed on `fix/audit-a15-o6-o7-sys15` |
+| **A-15**| Low | Acquisition | `standard.ts` | `withRetry` logs under `'AI'` category for HTTP scraper calls. | Fixed |
 | **E-1** | High | Extractor | `dom-denoiser.ts`| `denoiseHtmlForRegex` nested-quantifier regex ReDoS vulnerability. | Pending |
 | **E-2** | High | Extractor | `stock/schema.ts` | `walk()` recursion stack overflow risk (no depth guard). | Pending |
 | **E-3** | High | Extractor | `arbitration.ts` | AI arbitration passed `allCandidates` including member/original prices. | Confirmed pending — `standardCandidates` is created but AI receives `allCandidates`. |
@@ -108,6 +108,6 @@ The original audit registers aggregated bugs across scraping, voting, database t
 | **SYS-12**| Medium | System | `settings/system.ts` | Settings update loop has no transaction. | Pending |
 | **SYS-13**| Medium | System | `SettingsListenerService.ts` | Stale debounce closure not cancelled on reconnect. | Pending |
 | **SYS-14**| Medium | System | `settings/ai.ts` | API key mask detection based on `"..."` substring is fragile. | Pending |
-| **SYS-15**| Low | System | `CurrencyConversionService.ts` | No timeout on Frankfurter API call. | Fixed on `fix/audit-a15-o6-o7-sys15` |
+| **SYS-15**| Low | System | `CurrencyConversionService.ts` | No timeout on Frankfurter API call. | Fixed |
 | **SYS-16**| Low | System | `CurrencyConversionService.ts` | AUD→AUD self-rate never written to DB. | Pending |
 | **SYS-17**| Low | Routes | `admin/users.ts` | `PUT /:id` passes raw `req.body` to service. | Pending |

--- a/docs/audit/upstream_scraping_consensus_audit.md
+++ b/docs/audit/upstream_scraping_consensus_audit.md
@@ -38,8 +38,8 @@ The original audit registers aggregated bugs across scraping, voting, database t
 | **O-3** | High | Orchestration | `consensus.ts` | OOS drift only checks downward spikes. | Reopened — current code still checks only prices below 50% of the anchor. |
 | **O-4** | High | Orchestration | `maintenance.ts` | `configCache.invalidate()` with no domain key wipes entire cache. | Pending |
 | **O-5** | High | Orchestration | `maintenance.ts` | Wrong extraction step logged for status-restore vs engine-upgrade. | Pending |
-| **O-6** | Medium | Orchestration | `index.ts` | `requestId` has only 1,000 entropy values. | Pending |
-| **O-7** | Medium | Orchestration | `index.ts` | `isShellConfig` ignores `jsonld_price_key`. | Pending |
+| **O-6** | Medium | Orchestration | `index.ts` | `requestId` has only 1,000 entropy values. | Fixed on `fix/audit-a15-o6-o7-sys15` |
+| **O-7** | Medium | Orchestration | `index.ts` | `isShellConfig` ignores `jsonld_price_key`. | Fixed on `fix/audit-a15-o6-o7-sys15` |
 | **O-8** | Medium | Orchestration | `consensus.ts` | Arbitrated prices wrongly treated as uncorroborated in OOS guardrail. | Pending |
 | **O-9** | Medium | Orchestration | `index.ts` | `scrapeProduct()` silently drops `retailerName` from return value. | Fixed |
 | **O-10**| Medium | Orchestration | `arbitration.ts` | AI arbitration/verification errors swallowed. | Pending |
@@ -60,7 +60,7 @@ The original audit registers aggregated bugs across scraping, voting, database t
 | **A-12**| Medium | Transport | `remote.ts` | Empty remote HTML body silently treated as successful extraction. | Pending |
 | **A-13**| Medium | Transport | `detection.ts` | Case-sensitive WAF marker detection. | Pending |
 | **A-14**| Low | Transport | `detection.ts` | Akamai `Reference #18.` pattern too specific. | Pending |
-| **A-15**| Low | Acquisition | `standard.ts` | `withRetry` logs under `'AI'` category for HTTP scraper calls. | Pending |
+| **A-15**| Low | Acquisition | `standard.ts` | `withRetry` logs under `'AI'` category for HTTP scraper calls. | Fixed on `fix/audit-a15-o6-o7-sys15` |
 | **E-1** | High | Extractor | `dom-denoiser.ts`| `denoiseHtmlForRegex` nested-quantifier regex ReDoS vulnerability. | Pending |
 | **E-2** | High | Extractor | `stock/schema.ts` | `walk()` recursion stack overflow risk (no depth guard). | Pending |
 | **E-3** | High | Extractor | `arbitration.ts` | AI arbitration passed `allCandidates` including member/original prices. | Confirmed pending — `standardCandidates` is created but AI receives `allCandidates`. |
@@ -108,6 +108,6 @@ The original audit registers aggregated bugs across scraping, voting, database t
 | **SYS-12**| Medium | System | `settings/system.ts` | Settings update loop has no transaction. | Pending |
 | **SYS-13**| Medium | System | `SettingsListenerService.ts` | Stale debounce closure not cancelled on reconnect. | Pending |
 | **SYS-14**| Medium | System | `settings/ai.ts` | API key mask detection based on `"..."` substring is fragile. | Pending |
-| **SYS-15**| Low | System | `CurrencyConversionService.ts` | No timeout on Frankfurter API call. | Pending |
+| **SYS-15**| Low | System | `CurrencyConversionService.ts` | No timeout on Frankfurter API call. | Fixed on `fix/audit-a15-o6-o7-sys15` |
 | **SYS-16**| Low | System | `CurrencyConversionService.ts` | AUD→AUD self-rate never written to DB. | Pending |
 | **SYS-17**| Low | Routes | `admin/users.ts` | `PUT /:id` passes raw `req.body` to service. | Pending |


### PR DESCRIPTION
## Summary

- **O-6**: Upgraded the `requestId` generation from low-entropy random/timestamp strings to v4 `randomUUID` in [`orchestration/index.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/orchestration/index.ts) and [`transport/remote.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/transport/remote.ts).
- **O-7**: Fixed `isShellConfig` to properly check `!domainConfig.jsonld_price_key` in [`orchestration/index.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/orchestration/index.ts), preventing configurations utilizing only a JSON-LD price key from being treated as minimal shell configs.
- **A-15**: Changed retry warning messages in [`retry.ts`](file:///home/steven/projects/pricestalker/backend/src/utils/system/retry.ts) to log under their actual passed category context instead of hardcoding the `'AI'` tag.
- **SYS-15**: Implemented a 10-second timeout configuration for external Frankfurter rate updates in [`CurrencyConversionService.ts`](file:///home/steven/projects/pricestalker/backend/src/services/domain/system/CurrencyConversionService.ts).

## Validation

- Verified backend test suite: all 121 vitest test cases passed successfully.
- Verified request ID formatting: confirmed `REQ-[UUID]` outputs correctly (e.g., `REQ-33b1afcb-b5f0-4d1b-bd14-2e17f4b3102c`) inside the running backend container.
