### PR TITLE
fix(ui): keep native control colours on the app theme, not the OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The theme toggle icon is no longer invisible when the app is set to Light on a
+  device whose system theme is Dark. Choosing Light now pins the browser colour
+  scheme to light, so buttons, select popups, date pickers and autofill stop
+  rendering with dark system colours on the app's light surfaces.
 - Scraper debug previews no longer execute arbitrary scripts from fetched pages,
   preventing anti-bot scripts from triggering Chrome Private Network Access
   prompts; the API also acknowledges Private Network Access preflight requests.

--- a/frontend/src/features/auth/components/AuthForm.css
+++ b/frontend/src/features/auth/components/AuthForm.css
@@ -52,6 +52,7 @@
   top: 1rem;
   right: 1rem;
   background: var(--surface);
+  color: var(--text);
   border: 1px solid var(--border);
   border-radius: 0.5rem;
   padding: 0.5rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,6 +22,13 @@
   --chart-text: #94a3b8;
 }
 
+/* An explicit light choice must also pin the UA colour scheme. Without this,
+   :root's `light dark` resolves to dark on a dark OS, so native controls render
+   with dark UA colours (buttontext turns white) on the app's light surfaces. */
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
 /* Dark theme variables */
 :root[data-theme="dark"] {
   --primary: #818cf8;
@@ -83,6 +90,11 @@ a:hover {
 button {
   cursor: pointer;
   font-family: inherit;
+  /* Buttons do not inherit colour from their ancestors by default; the UA gives
+     them `buttontext`, which follows the OS scheme rather than the app theme.
+     Icon buttons stroke with `currentColor`, so without this they disappear
+     whenever the two disagree. Every .btn variant sets its own colour. */
+  color: inherit;
 }
 
 input, button, select, textarea {
@@ -119,7 +131,9 @@ input, button, select, textarea {
   background-color: var(--surface);
   color: var(--text);
   transition: border-color 0.2s, box-shadow 0.2s;
-  color-scheme: light dark;
+  /* Follow the resolved app theme, not the OS, so select popups, date pickers
+     and autofill backgrounds match the surface they sit on. */
+  color-scheme: inherit;
 }
 
 .form-group input:focus,

--- a/frontend/src/layouts/Layout.css
+++ b/frontend/src/layouts/Layout.css
@@ -117,6 +117,7 @@
 
 .theme-toggle {
   background: var(--background);
+  color: var(--text);
   border: 1px solid var(--border);
   border-radius: 0.5rem;
   padding: 0 0.75rem;


### PR DESCRIPTION
## Summary

The theme toggle's moon icon was invisible when the app was set to **Light** on a device whose **system** theme is Dark — which is why it read as mobile-related.

Three causes stacked up:

- `:root` declares `color-scheme: light dark` and only `[data-theme="dark"]` narrows it. An explicit Light choice therefore still resolved to **dark** on a dark OS, so the browser painted native controls with dark system colours.
- `button` inherits `font-family` but not `color`, so buttons took the UA's `buttontext` — white under that resolved dark scheme — while sitting on the app's light `--background`.
- `Icon` strokes with `currentColor`, so the moon rendered white on near-white.

## Changes

- `:root[data-theme="light"] { color-scheme: light; }` — an explicit light choice now pins the browser scheme, so select popups, date pickers, scrollbars and autofill stop rendering dark on light surfaces too.
- `button { color: inherit; }` — every `.btn` variant already sets its own colour, so this only affects buttons that set none, which is exactly the bug class.
- Explicit `color: var(--text)` on `.theme-toggle` and `.auth-theme-toggle`.
- Form controls now `color-scheme: inherit` rather than re-declaring `light dark`.

## Verification

Frontend build and typecheck, emoji lint, `git diff --check` — all pass.

Closes #105