### PR TITLE
fix(ui): render every date in the user's locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Dates and times across the app now follow the user's saved locale instead of
+  always rendering US month/day/year. This covers the product detail page, price
+  and stock history, the notification list and drawer, and the admin system log,
+  API token and authentication panels.
 - The theme toggle icon is no longer invisible when the app is set to Light on a
   device whose system theme is Dark. Choosing Light now pins the browser colour
   scheme to light, so buttons, select popups, date pickers and autofill stop

--- a/frontend/src/features/admin/components/sections/AuthSection.tsx
+++ b/frontend/src/features/admin/components/sections/AuthSection.tsx
@@ -12,6 +12,8 @@ import PasswordInput from '../../../../components/PasswordInput';
 import { CollapsibleCard, ToggleSwitch } from '../../components';
 import Icon from '../../../../components/Icon';
 import { ApiError, apiErrorMessage } from '../../../../api/error';
+import { useAuth } from '../../../auth';
+import { formatDate } from '../../../../utils/format';
 
 const toggleRow: React.CSSProperties = {
   display: 'flex',
@@ -31,6 +33,7 @@ const toggleRow: React.CSSProperties = {
  * is stored". Clearing it is therefore an explicit action, not an empty box.
  */
 export default function AuthSection() {
+  const { user } = useAuth();
   const { showToast } = useToast();
 
   const [config, setConfig] = useState<AuthConfigAdminView | null>(null);
@@ -349,7 +352,7 @@ export default function AuthSection() {
         </button>
         {config && (
           <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>
-            Last updated {new Date(config.updated_at).toLocaleString()}
+            Last updated {formatDate(config.updated_at, user?.locale, true)}
           </span>
         )}
       </div>

--- a/frontend/src/features/admin/components/sections/LogsSection.tsx
+++ b/frontend/src/features/admin/components/sections/LogsSection.tsx
@@ -4,12 +4,15 @@ import { AdminSystemService } from '../../services/AdminSystemService';
 import { useToast } from '../../../../context/ToastContext';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
 import type { SystemLog } from '../../../../types/api';
+import { useAuth } from '../../../auth';
+import { formatDateTime } from '../../../../utils/format';
 
 interface LogsSectionProps {
   onSearchRetailer: (domain: string) => void;
 }
 
 export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
+  const { user } = useAuth();
   const { showToast } = useToast();
   const [logs, setLogs] = useState<SystemLog[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -165,7 +168,7 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
                  <Fragment key={log.id}>
                    <tr style={{ fontSize: '0.8125rem', background: expandedLogId === log.id ? 'rgba(var(--primary-rgb), 0.05)' : 'none' }}>
                       <td className="log-select-cell"><input type="checkbox" checked={selectedLogIds.includes(log.id)} onChange={e => setSelectedLogIds(prev => e.target.checked ? [...prev, log.id] : prev.filter(id => id !== log.id))} /></td>
-                      <td style={{ color: 'var(--text-muted)' }} className="mobile-hide">{new Date(log.created_at).toLocaleString()}</td>
+                      <td style={{ color: 'var(--text-muted)' }} className="mobile-hide">{formatDateTime(log.created_at, user?.locale)}</td>
                       <td className="log-level-cell">
                         <span style={{ 
                           fontWeight: 700, fontSize: '0.65rem', padding: '0.125rem 0.4rem', borderRadius: '4px',
@@ -190,7 +193,7 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
                        <td colSpan={6} style={{ padding: '0 0 1.5rem 0', background: 'rgba(var(--primary-rgb), 0.05)' }}>
                          <div style={{ background: 'var(--surface)', padding: '1rem', borderRadius: '0.75rem', border: '1px solid var(--border)', fontSize: '0.8125rem', overflowX: 'auto', boxShadow: 'var(--shadow)' }}>
                             <div style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-                              <span style={{ fontWeight: 700, fontSize: '0.9rem' }}>Event Details <span style={{ fontWeight: 400, fontSize: '0.75rem', color: 'var(--text-muted)' }}>({new Date(log.created_at).toLocaleString()})</span></span>
+                              <span style={{ fontWeight: 700, fontSize: '0.9rem' }}>Event Details <span style={{ fontWeight: 400, fontSize: '0.75rem', color: 'var(--text-muted)' }}>({formatDateTime(log.created_at, user?.locale)})</span></span>
                               <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                                 {log.details?.tokens && (
                                   <>

--- a/frontend/src/features/admin/components/sections/SystemApiTokensSection.tsx
+++ b/frontend/src/features/admin/components/sections/SystemApiTokensSection.tsx
@@ -4,8 +4,11 @@ import { SystemApiToken } from '../../../../types/api';
 import { useToast } from '../../../../context/ToastContext';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
 import Icon from '../../../../components/Icon';
+import { useAuth } from '../../../auth';
+import { formatDate } from '../../../../utils/format';
 
 export default function SystemApiTokensSection() {
+  const { user } = useAuth();
   const { showToast } = useToast();
   const [tokens, setTokens] = useState<SystemApiToken[]>([]);
   const [isAddingToken, setIsAddingToken] = useState(false);
@@ -141,7 +144,7 @@ export default function SystemApiTokensSection() {
                           <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{token.description}</div>
                         )}
                         <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', marginTop: '0.25rem' }}>
-                          Created: {new Date(token.created_at).toLocaleDateString()}
+                          Created: {formatDate(token.created_at, user?.locale)}
                         </div>
                       </td>
                       <td className="mobile-hide">
@@ -156,7 +159,7 @@ export default function SystemApiTokensSection() {
                       </td>
                       <td>
                         <div style={{ fontSize: '0.875rem' }}>
-                          {token.last_used_at ? new Date(token.last_used_at).toLocaleString() : 'Never'}
+                          {token.last_used_at ? formatDate(token.last_used_at, user?.locale, true) : 'Never'}
                         </div>
                       </td>
                       <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>

--- a/frontend/src/features/debug/pages/DebugPage.tsx
+++ b/frontend/src/features/debug/pages/DebugPage.tsx
@@ -74,7 +74,7 @@ export default function Debug() {
         stock_selectors: state.tempStockSelectors,
         exclusion_selectors: state.tempExclusionSelectors,
         active: true,
-        description: `Saved from Debug Page on ${new Date().toLocaleDateString()}`
+        description: `Saved from Debug Page on ${new Date().toISOString().slice(0, 10)}`
       });
       showToast(`Retailer config for ${domain} updated successfully!`);
     } catch (err: any) {

--- a/frontend/src/features/notifications/components/ActivityLogTable.tsx
+++ b/frontend/src/features/notifications/components/ActivityLogTable.tsx
@@ -1,4 +1,6 @@
-import { formatDate, getNotificationIcon } from '../pages/utils';
+import { getNotificationIcon } from '../pages/utils';
+import { useAuth } from '../../auth';
+import { formatDate } from '../../../utils/format';
 import Icon from '../../../components/Icon';
 
 interface ActivityLogItem {
@@ -14,6 +16,8 @@ interface ActivityLogTableProps {
 }
 
 export default function ActivityLogTable({ activityLog }: ActivityLogTableProps) {
+  const { user } = useAuth();
+
   if (activityLog.length === 0) {
     return (
       <div className="notifications-empty">
@@ -69,7 +73,7 @@ export default function ActivityLogTable({ activityLog }: ActivityLogTableProps)
           </div>
 
           <div className="notification-date">
-            {formatDate(item.timestamp.toISOString())}
+            {formatDate(item.timestamp.toISOString(), user?.locale, true)}
           </div>
         </div>
       ))}

--- a/frontend/src/features/notifications/components/NotificationDrawer.tsx
+++ b/frontend/src/features/notifications/components/NotificationDrawer.tsx
@@ -91,7 +91,7 @@ const NotificationDrawer: React.FC = () => {
                     <div className="drawer-item-content">
                       <div className="drawer-item-title">{item.message}</div>
                       <div className="drawer-item-meta">
-                        <span>{formatRelativeDate(item.timestamp.toISOString())}</span>
+                        <span>{formatRelativeDate(item.timestamp.toISOString(), user?.locale)}</span>
                       </div>
                     </div>
                   </div>
@@ -124,7 +124,7 @@ const NotificationDrawer: React.FC = () => {
                       <div className="drawer-item-message">{n.message}</div>
                       <div className="drawer-item-meta">
                         {newPrice && <span className="drawer-item-price">{formatPrice(newPrice, currency, user?.locale)}</span>}
-                        <span>{formatRelativeDate(n.created_at)}</span>
+                        <span>{formatRelativeDate(n.created_at, user?.locale)}</span>
                       </div>
                     </div>
                   </div>

--- a/frontend/src/features/notifications/pages/NotificationTable.tsx
+++ b/frontend/src/features/notifications/pages/NotificationTable.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from '@tanstack/react-router';
 import { NotificationEntry } from '../../../types/api';
-import { formatPrice } from '../../../utils/format';
-import { formatDate, getNotificationIcon, getNotificationTypeLabel, getChannelIcon } from './utils';
+import { formatPrice, formatDate } from '../../../utils/format';
+import { getNotificationIcon, getNotificationTypeLabel, getChannelIcon } from './utils';
 import Icon from '../../../components/Icon';
 
 interface NotificationTableProps {
@@ -125,7 +125,7 @@ const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, lo
             </div>
 
             <div className="notification-date">
-              {formatDate(notification.created_at)}
+              {formatDate(notification.created_at, userLocale, true)}
             </div>
           </div>
         );

--- a/frontend/src/features/notifications/pages/utils.tsx
+++ b/frontend/src/features/notifications/pages/utils.tsx
@@ -1,17 +1,6 @@
 import React from 'react';
 import type { IconName } from '../../../components/Icon';
 
-export function formatDate(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
 export function getNotificationIcon(type: string): React.ReactNode {
   const strokeWidth = 2.5;
   const size = 18;

--- a/frontend/src/features/products/pages/product-detail/ProductMetadata.tsx
+++ b/frontend/src/features/products/pages/product-detail/ProductMetadata.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useAuth } from '../../../auth';
+import { formatDate } from '../../../../utils/format';
 
 interface ProductMetadataProps {
   product: any;
@@ -32,6 +34,8 @@ const ProductMetadata: React.FC<ProductMetadataProps> = ({
   isSaving,
   REFRESH_INTERVALS,
 }) => {
+  const { user } = useAuth();
+
   return (
     <div className="product-detail-meta">
       <div className="product-detail-meta-item">
@@ -98,7 +102,7 @@ const ProductMetadata: React.FC<ProductMetadataProps> = ({
       </div>
       <div className="product-detail-meta-item">
         <span className="product-detail-meta-label">Last Checked</span>
-        <span className="product-detail-meta-value">{product.last_checked ? new Date(product.last_checked).toLocaleString() : 'Never'}</span>
+        <span className="product-detail-meta-value">{product.last_checked ? formatDate(product.last_checked, user?.locale, true) : 'Never'}</span>
       </div>
       <div className="product-detail-meta-item">
         <span className="product-detail-meta-label">Check Interval</span>
@@ -115,7 +119,7 @@ const ProductMetadata: React.FC<ProductMetadataProps> = ({
       </div>
       <div className="product-detail-meta-item">
         <span className="product-detail-meta-label">Tracking Since</span>
-        <span className="product-detail-meta-value">{new Date(product.created_at).toLocaleDateString()}</span>
+        <span className="product-detail-meta-value">{formatDate(product.created_at, user?.locale)}</span>
       </div>
     </div>
   );

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -58,7 +58,7 @@ export function truncateUrl(url: string): string {
 /**
  * Format relative date/time
  */
-export function formatRelativeDate(dateString: string | null): string {
+export function formatRelativeDate(dateString: string | null, locale?: string | null): string {
   if (!dateString) return 'Never';
   const date = new Date(dateString);
   const now = new Date();
@@ -68,8 +68,38 @@ export function formatRelativeDate(dateString: string | null): string {
   if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`;
   if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`;
   if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`;
-  
-  return date.toLocaleDateString();
+
+  // Anything older falls back to an absolute date, which must respect the
+  // user's locale like every other date in the app.
+  return formatDate(dateString, locale);
+}
+
+/**
+ * Localized date and time down to the second, for log and audit timestamps
+ * where the exact moment matters. Normalises a null locale so Intl never throws.
+ */
+export function formatDateTime(
+  dateString: string | null | undefined,
+  locale?: string | null
+): string {
+  if (!dateString) return 'N/A';
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return 'N/A';
+
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  };
+
+  try {
+    return date.toLocaleString(locale ?? undefined, options);
+  } catch {
+    return date.toLocaleString(undefined, options);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Nine call sites formatted dates with a bare `new Date(...).toLocaleString()` or `.toLocaleDateString()`, ignoring the user's saved locale and falling back to the browser default — so a `de-CH` or `en-AU` profile still saw US month/day/year.

This is also a latent crash, not only a formatting bug: `users.locale` is nullable and `Intl` throws a `TypeError` on an explicit null, which blanks the page mid-render. That is exactly what CLAUDE.md rule 2 and `utils/format.ts` exist to prevent.

## Call sites fixed

| File | Sites |
|---|---|
| `product-detail/ProductMetadata.tsx` | Last Checked, Tracking Since |
| `admin/.../LogsSection.tsx` | log row, event detail header |
| `admin/.../SystemApiTokensSection.tsx` | Created, Last used |
| `admin/.../AuthSection.tsx` | Last updated |
| `notifications/NotificationTable.tsx` | timestamp |
| `notifications/ActivityLogTable.tsx` | timestamp |
| `notifications/NotificationDrawer.tsx` | relative timestamps |

Every one now routes through `utils/format.ts`, which is again the only module in the frontend that calls `Intl` or `toLocale*`.

## Along the way

- `formatRelativeDate` takes a locale for its absolute-date fallback.
- New `formatDateTime` for log timestamps, which need seconds.
- Removed the duplicate `formatDate` in `notifications/pages/utils.tsx` — identical to the shared one but without the null-locale guard.
- The debug page's saved retailer description records an ISO date instead of a locale-formatted one, since it is persisted data rather than display.

## Verification

Frontend build and typecheck, 5 frontend tests, emoji lint, `git diff --check` — all pass.

Closes #104