### PR TITLE
feat(products): poll the dashboard and detail page in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The products dashboard and product detail page now refresh in the background
+  while you are looking at them, so scraper results, price changes and status
+  updates appear without a manual reload. Polling stops automatically when the
+  tab is hidden, and your search, filters and category selection are untouched
+  by a background refresh.
 - Newly generated system API tokens now use a `ps_` prefix to make leaked
   PriceStalker tokens easier for secret-scanning tools to identify.
 - Password reset via email: a "Forgot password?" link on the login page sends

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -17,16 +17,27 @@ export const queryKeys = {
   notifications: { recent: (limit: number) => ['notifications', 'recent', limit] as const, history: (page: number, limit: number) => ['notifications', 'history', page, limit] as const },
 };
 
+/**
+ * How often the dashboard and product detail poll for scraper results while the
+ * user is looking at them. React Query leaves `refetchIntervalInBackground` at
+ * its default of false, so a hidden or unfocused tab stops polling on its own
+ * and we do not keep hitting the API for a window nobody is watching.
+ */
+const PRODUCT_POLL_INTERVAL = 15_000;
+const PRODUCT_DETAIL_POLL_INTERVAL = 30_000;
+
 export const productListQuery = () => queryOptions({
   queryKey: queryKeys.products.all,
   queryFn: ({ signal }) => ProductService.getAll({ signal }),
-  staleTime: 30_000,
+  staleTime: PRODUCT_POLL_INTERVAL,
+  refetchInterval: PRODUCT_POLL_INTERVAL,
 });
 
 export const productDetailQuery = (id: number) => queryOptions({
   queryKey: queryKeys.products.detail(id),
   queryFn: ({ signal }) => ProductService.getById(id, { signal }),
-  staleTime: 30_000,
+  staleTime: PRODUCT_DETAIL_POLL_INTERVAL,
+  refetchInterval: PRODUCT_DETAIL_POLL_INTERVAL,
 });
 
 export const discoveryStatusQuery = () => queryOptions({


### PR DESCRIPTION
## Summary

The dashboard only refetched on mount and on window refocus, so a scrape that finished while the user sat on the tab stayed invisible until they reloaded or switched away and back.

## Changes

- `refetchInterval` on `productListQuery` (15s) and `productDetailQuery` (30s).
- `staleTime` now matches each poll interval — leaving it longer than the interval had the two settings describing different refresh stories.

React Query v5 leaves `refetchIntervalInBackground` at its default of `false`, so a hidden or unfocused tab stops polling on its own. No manual visibility gating needed, and no hammering the API for a window nobody is watching.

Filters, search and category selection live in component state and `localStorage` (`useProductFilters`), so a background refetch updates rows in place without disturbing them.

## Verification

Frontend build and typecheck, 5 frontend tests, emoji lint, `git diff --check` — all pass.

Closes #87