### PR TITLE
fix(admin): stop password managers claiming API keys and admin user forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Browsers no longer offer to save API keys, provider tokens and webhook URLs as
+  passwords, and no longer offer to overwrite the administrator's own saved
+  login when creating or editing another user. These fields are now masked
+  without being real password inputs, so password-manager heuristics ignore
+  them. Sign-in and "change my own password" are unchanged and still work with
+  a password manager.
 - The admin System Event Log no longer blanks the whole admin page when the
   logs response omits its context list; the filter falls back to empty instead
   of throwing during render.

--- a/frontend/src/components/PasswordInput/PasswordInput.tsx
+++ b/frontend/src/components/PasswordInput/PasswordInput.tsx
@@ -1,11 +1,36 @@
-import { useState, InputHTMLAttributes } from 'react';
+import React, { useState, InputHTMLAttributes } from 'react';
 
 interface PasswordInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   allowReveal?: boolean;
+  /**
+   * Set for values that are not the signed-in user's own login credential --
+   * API keys, webhook URLs, provider tokens, and passwords an administrator
+   * sets for somebody else.
+   *
+   * Browsers apply password-manager heuristics to `type="password"` and largely
+   * ignore `autocomplete="off"` on it, which produces two bugs: they offer to
+   * save API keys as passwords, and on the admin user form they offer to update
+   * the *administrator's own* saved credential with another user's details.
+   * Masking a `type="text"` field with -webkit-text-security keeps the value
+   * hidden while staying invisible to those heuristics.
+   */
+  secret?: boolean;
 }
 
-export default function PasswordInput({ style, allowReveal = true, ...props }: PasswordInputProps) {
+// Firefox does not implement -webkit-text-security, so there we have to fall
+// back to a real password field and rely on the autocomplete and vendor
+// ignore attributes below.
+const supportsTextSecurity =
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('-webkit-text-security', 'disc');
+
+export default function PasswordInput({ style, allowReveal = true, secret = false, ...props }: PasswordInputProps) {
   const [visible, setVisible] = useState(false);
+
+  const revealed = visible && allowReveal;
+  const maskWithCss = secret && supportsTextSecurity;
+  const inputType = revealed || maskWithCss ? 'text' : 'password';
 
   return (
     <div style={{ position: 'relative' }}>
@@ -13,14 +38,19 @@ export default function PasswordInput({ style, allowReveal = true, ...props }: P
         autoComplete="off"
         data-1p-ignore="true"
         data-lpignore="true"
+        data-bwignore="true"
+        data-form-type={secret ? 'other' : undefined}
         spellCheck="false"
         {...props}
-        type={visible && allowReveal ? 'text' : 'password'}
+        type={inputType}
         style={{
           ...style,
           width: '100%',
           paddingRight: allowReveal ? '2.5rem' : '0.75rem',
           boxSizing: 'border-box',
+          ...(maskWithCss && !revealed
+            ? ({ WebkitTextSecurity: 'disc' } as React.CSSProperties)
+            : {}),
         }}
       />
       {allowReveal && (
@@ -43,13 +73,13 @@ export default function PasswordInput({ style, allowReveal = true, ...props }: P
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            color: visible ? 'var(--primary)' : 'var(--text-muted)',
+            color: revealed ? 'var(--primary)' : 'var(--text-muted)',
             zIndex: 10,
           }}
-          title={visible ? 'Hide' : 'Show'}
-          aria-label={visible ? 'Hide password' : 'Show password'}
+          title={revealed ? 'Hide' : 'Show'}
+          aria-label={revealed ? 'Hide value' : 'Show value'}
         >
-          {visible ? (
+          {revealed ? (
             // Eye-off icon (hidden)
             <svg
               width="20"

--- a/frontend/src/features/admin/components/sections/AIProviderConfig.tsx
+++ b/frontend/src/features/admin/components/sections/AIProviderConfig.tsx
@@ -141,7 +141,7 @@ export default function AIProviderConfig({
             <label htmlFor="gemini-api-key">Google Gemini API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="gemini-api-key"
                   name="gemini-api-key"
                   value={aiSettings?.gemini_api_key || ''} 
@@ -189,7 +189,7 @@ export default function AIProviderConfig({
             <label htmlFor="vertex-api-key">Vertex API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="vertex-api-key"
                   name="vertex-api-key"
                   value={aiSettings?.vertex_api_key || ''} 
@@ -223,7 +223,7 @@ export default function AIProviderConfig({
             <label htmlFor="openai-api-key">OpenAI API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="openai-api-key"
                   name="openai-api-key"
                   value={aiSettings?.openai_api_key || ''} 
@@ -249,7 +249,7 @@ export default function AIProviderConfig({
             <label htmlFor="anthropic-api-key">Anthropic API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="anthropic-api-key"
                   name="anthropic-api-key"
                   value={aiSettings?.anthropic_api_key || ''} 
@@ -275,7 +275,7 @@ export default function AIProviderConfig({
             <label htmlFor="deepseek-api-key">DeepSeek API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="deepseek-api-key"
                   name="deepseek-api-key"
                   value={aiSettings?.deepseek_api_key || ''} 
@@ -301,7 +301,7 @@ export default function AIProviderConfig({
             <label htmlFor="groq-api-key">Groq API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="groq-api-key"
                   name="groq-api-key"
                   value={aiSettings?.groq_api_key || ''} 
@@ -327,7 +327,7 @@ export default function AIProviderConfig({
             <label htmlFor="mistral-api-key">Mistral API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="mistral-api-key"
                   name="mistral-api-key"
                   value={aiSettings?.mistral_api_key || ''} 
@@ -353,7 +353,7 @@ export default function AIProviderConfig({
             <label htmlFor="openrouter-api-key">OpenRouter API Key</label>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput 
+                <PasswordInput secret
                   id="openrouter-api-key"
                   name="openrouter-api-key"
                   value={aiSettings?.openrouter_api_key || ''} 
@@ -387,7 +387,7 @@ export default function AIProviderConfig({
           </div>
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="openai-compatible-api-key">API Key (optional)</label>
-            <PasswordInput 
+            <PasswordInput secret
               id="openai-compatible-api-key"
               name="openai-compatible-api-key"
               value={aiSettings?.openai_compatible_api_key || ''} 

--- a/frontend/src/features/admin/components/sections/AuthSection.tsx
+++ b/frontend/src/features/admin/components/sections/AuthSection.tsx
@@ -276,7 +276,7 @@ export default function AuthSection() {
           ) : (
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <div style={{ flex: 1 }}>
-                <PasswordInput
+                <PasswordInput secret
                   value={clientSecret}
                   onChange={e => setClientSecret(e.target.value)}
                   placeholder={

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -148,7 +148,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
         <div className="settings-card" style={{ borderLeft: '4px solid var(--primary)' }}>
           <h3 className="settings-card-title">Create New User</h3>
           <div className="form-group"><label>Email Address</label><input type="email" value={newUserEmail} onChange={e => setNewUserEmail(e.target.value)} placeholder="user@example.com" autoComplete="off" /></div>
-          <div className="form-group"><label>Account Password</label><PasswordInput value={newUserPassword} onChange={e => setNewUserPassword(e.target.value)} autoComplete="new-password" /></div>
+          <div className="form-group"><label>Account Password</label><PasswordInput secret value={newUserPassword} onChange={e => setNewUserPassword(e.target.value)} autoComplete="new-password" /></div>
           
           <div className="form-grid">
             <div className="form-group">
@@ -222,8 +222,8 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
             </div>
           </div>
           <div className="form-grid" style={{ marginTop: '1rem' }}>
-            <div className="form-group"><label>New Password (Optional)</label><PasswordInput value={editUserPassword} onChange={e => setEditUserPassword(e.target.value)} autoComplete="new-password" /></div>
-            <div className="form-group"><label>Confirm New Password</label><PasswordInput value={editUserConfirmPassword} onChange={e => setEditUserConfirmPassword(e.target.value)} autoComplete="new-password" /></div>
+            <div className="form-group"><label>New Password (Optional)</label><PasswordInput secret value={editUserPassword} onChange={e => setEditUserPassword(e.target.value)} autoComplete="new-password" /></div>
+            <div className="form-group"><label>Confirm New Password</label><PasswordInput secret value={editUserConfirmPassword} onChange={e => setEditUserConfirmPassword(e.target.value)} autoComplete="new-password" /></div>
           </div>
           
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--background)', padding: '0.75rem', borderRadius: '0.5rem', marginTop: '1rem' }}>

--- a/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
+++ b/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
@@ -169,7 +169,7 @@ export default function NotificationChannelsSection() {
           <p style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '1.5rem' }}><strong>Tip:</strong> Start a conversation with your bot (<code>/start</code>) to authorize messages.</p>
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="telegram-bot-token">Bot Token</label>
-            <PasswordInput id="telegram-bot-token" name="telegram-bot-token" value={draftSettings.telegram_bot_token} onChange={e => handleUpdateField('telegram_bot_token', e.target.value)} placeholder="123456:ABC-DEF..." autoComplete="new-password" />
+            <PasswordInput secret id="telegram-bot-token" name="telegram-bot-token" value={draftSettings.telegram_bot_token} onChange={e => handleUpdateField('telegram_bot_token', e.target.value)} placeholder="123456:ABC-DEF..." autoComplete="new-password" />
           </form>
           <div className="form-group">
             <label>Chat ID</label>
@@ -194,7 +194,7 @@ export default function NotificationChannelsSection() {
         >
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="discord-webhook-url">Webhook URL</label>
-            <PasswordInput id="discord-webhook-url" name="discord-webhook-url" value={draftSettings.discord_webhook_url} onChange={e => handleUpdateField('discord_webhook_url', e.target.value)} placeholder="https://discord.com/api/webhooks/..." autoComplete="new-password" />
+            <PasswordInput secret id="discord-webhook-url" name="discord-webhook-url" value={draftSettings.discord_webhook_url} onChange={e => handleUpdateField('discord_webhook_url', e.target.value)} placeholder="https://discord.com/api/webhooks/..." autoComplete="new-password" />
           </form>
           <div className="form-group">
             <label>Message Template</label>
@@ -215,11 +215,11 @@ export default function NotificationChannelsSection() {
         >
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="pushover-user-key">User Key</label>
-            <PasswordInput id="pushover-user-key" name="pushover-user-key" value={draftSettings.pushover_user_key} onChange={e => handleUpdateField('pushover_user_key', e.target.value)} placeholder="u..." autoComplete="new-password" />
+            <PasswordInput secret id="pushover-user-key" name="pushover-user-key" value={draftSettings.pushover_user_key} onChange={e => handleUpdateField('pushover_user_key', e.target.value)} placeholder="u..." autoComplete="new-password" />
           </form>
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="pushover-app-token">App API Token</label>
-            <PasswordInput id="pushover-app-token" name="pushover-app-token" value={draftSettings.pushover_app_token} onChange={e => handleUpdateField('pushover_app_token', e.target.value)} placeholder="a..." autoComplete="new-password" />
+            <PasswordInput secret id="pushover-app-token" name="pushover-app-token" value={draftSettings.pushover_app_token} onChange={e => handleUpdateField('pushover_app_token', e.target.value)} placeholder="a..." autoComplete="new-password" />
           </form>
           <div className="form-group">
             <label>Message Template</label>
@@ -248,7 +248,7 @@ export default function NotificationChannelsSection() {
           </div>
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="ntfy-access-token">Access Token (Optional)</label>
-            <PasswordInput id="ntfy-access-token" name="ntfy-access-token" value={draftSettings.ntfy_password} onChange={e => handleUpdateField('ntfy_password', e.target.value)} placeholder="tk_..." autoComplete="new-password" />
+            <PasswordInput secret id="ntfy-access-token" name="ntfy-access-token" value={draftSettings.ntfy_password} onChange={e => handleUpdateField('ntfy_password', e.target.value)} placeholder="tk_..." autoComplete="new-password" />
           </form>
           <div className="form-group">
             <label>Message Template</label>
@@ -273,7 +273,7 @@ export default function NotificationChannelsSection() {
           </div>
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="gotify-app-token">App Token</label>
-            <PasswordInput id="gotify-app-token" name="gotify-app-token" value={draftSettings.gotify_app_token} onChange={e => handleUpdateField('gotify_app_token', e.target.value)} placeholder="A..." autoComplete="new-password" />
+            <PasswordInput secret id="gotify-app-token" name="gotify-app-token" value={draftSettings.gotify_app_token} onChange={e => handleUpdateField('gotify_app_token', e.target.value)} placeholder="A..." autoComplete="new-password" />
           </form>
           <div className="form-group">
             <label>Message Template</label>
@@ -320,7 +320,7 @@ export default function NotificationChannelsSection() {
         >
           <form onSubmit={(e) => e.preventDefault()} className="form-group">
             <label htmlFor="webhook-endpoint-url">Endpoint URL (POST)</label>
-            <PasswordInput id="webhook-endpoint-url" name="webhook-endpoint-url" value={draftSettings.webhook_url} onChange={e => handleUpdateField('webhook_url', e.target.value)} placeholder="https://api.example.com/alerts" autoComplete="new-password" />
+            <PasswordInput secret id="webhook-endpoint-url" name="webhook-endpoint-url" value={draftSettings.webhook_url} onChange={e => handleUpdateField('webhook_url', e.target.value)} placeholder="https://api.example.com/alerts" autoComplete="new-password" />
           </form>
           <span style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>Sends a standard JSON payload with product details.</span>
         </NotificationChannelCard>


### PR DESCRIPTION
## Summary

Every secret in the app rendered as `type="password"`, which browsers treat as a credential regardless of what `autocomplete` says. Two consequences, one of them serious:

1. **Autofill pollution.** "Save password for this site?" fires with a webhook URL or API key as the value, and the admin's own login gets autofilled into API key boxes.
2. **Credential overwrite.** On the admin user form an email field sits beside a password field, so submitting **Create Account** or **Update User** reads as a credential submission. Accepting the prompt can overwrite the *administrator's own* saved credential for the PriceStalker domain with another user's details.

## Approach

`PasswordInput` gains a `secret` mode that masks a `type="text"` field with `-webkit-text-security: disc` instead of using a real password field. Password managers do not apply their heuristics to text inputs, so both problems go away at the source. Firefox does not implement that property, so it falls back to `type="password"` behind a `CSS.supports` check, keeping the existing `autocomplete` and vendor-ignore attributes.

Applied to all 20 non-credential fields:

- AI provider API keys (9)
- Notification channel tokens and webhook URLs (7)
- Admin-set user passwords (3)
- OIDC client secret (1)

## Deliberately unchanged

Sign-in, password reset, and "change my own password" keep `type="password"`. There the password manager is doing its job and should keep working.

## Verification

Frontend build and typecheck, 5 frontend tests, emoji lint, `git diff --check` — all pass.

Closes #80