### PR TITLE
fix(admin): stop a missing log context list blanking the admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The admin System Event Log no longer blanks the whole admin page when the
+  logs response omits its context list; the filter falls back to empty instead
+  of throwing during render.
 - Dates and times across the app now follow the user's saved locale instead of
   always rendering US month/day/year. This covers the product detail page, price
   and stock history, the notification list and drawer, and the admin system log,

--- a/frontend/src/features/admin/components/sections/LogsSection.tsx
+++ b/frontend/src/features/admin/components/sections/LogsSection.tsx
@@ -40,11 +40,14 @@ export default function LogsSection({ onSearchRetailer }: LogsSectionProps) {
         level: logLevel, 
         context: logContext 
       });
-      setLogs(res.logs);
+      // The list and the filter options are rendered with .map(), so a response
+      // missing either array takes the whole admin page down through the
+      // ErrorBoundary rather than degrading to an empty table or filter.
+      setLogs(res.logs ?? []);
       setTotalCount(res.total);
       setLogPage(page);
       setLogPages(res.pages);
-      setAvailableContexts(res.contexts);
+      setAvailableContexts(res.contexts ?? []);
     } catch {
       showToast('Failed to load logs', 'error');
     } finally {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -343,10 +343,13 @@ export interface SystemLog {
 }
 
 export interface SystemLogsResponse {
-  logs: SystemLog[];
+  // The arrays are optional on purpose: the client must not assume a response
+  // shape it cannot enforce. Rendering code maps over them, so a missing field
+  // is a render crash rather than a missing filter.
+  logs?: SystemLog[];
   total: number;
   pages: number;
-  contexts: string[];
+  contexts?: string[];
 }
 
 export interface TestRetailerConfigResult {


### PR DESCRIPTION
## What was actually failing

Two `Publish Docker Images` runs on `main` failed after the #106 and #108 merges. The failing step was **Run frontend route acceptance tests**, and that job gates `publish-backend`, `publish-frontend` and `publish-scraper` — so no images reached GHCR.

It looked like a flake: the same spec passed on the very next push with the same code plus more, and it passed 3/3 locally. It is not a flake.

## Root cause

Playwright's saved error context showed the page had rendered the ErrorBoundary, not the admin screen:

```
heading "Couldn't display this page"
text: Cannot read properties of undefined (reading 'map')
```

#99 changed `LogsSection`:

```diff
-setAvailableContexts(res.availableContexts || []);
+setAvailableContexts(res.contexts);
```

The fallback went with it, and the component renders `availableContexts.map(...)`. The route spec mocks `/api/admin/logs` as `{ logs: [], total: 0, page: 1, pages: 1 }` — no `contexts` — so whenever the logs section won the race to render during the eight-route loop, the whole admin page was replaced by the ErrorBoundary and the `System Administration` heading never appeared.

Reproduced locally at roughly **1 run in 4**. I reviewed #99 and called this risk out before merging it, then judged it not worth blocking. That was the wrong call.

## Fix

- `res.logs ?? []` and `res.contexts ?? []` in `LogsSection`.
- `logs` and `contexts` are now optional on `SystemLogsResponse`. The client cannot enforce a response shape, and a missing filter list should degrade to an empty dropdown rather than take the page down.

## What I deliberately did not do

Add Playwright retries. That was my first instinct for an intermittent failure, and it would have buried a real render crash that any deployment returning a slightly different logs payload would hit in production.

## Verification

Full route acceptance suite, retries off:

- before: 1 failure in 4 runs
- after: **8/8 green**, and the suite is consistently faster (4.7s vs 6-11s)

Frontend build and typecheck, emoji lint, `git diff --check` — all pass.