### PR TITLE
fix(logging): apply the level hierarchy to database writes, add SQL tracing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ JWT_SECRET=replace-with-a-long-random-string
 # IMAGE_TAG=latest              # Use `beta` for the current v2 overhaul, or pin a version
 # TZ=UTC                        # affects log timestamps and scheduled tasks
 # LOG_LEVEL=info                # debug | info | warn | error
+# CONSOLE_LOG_LEVEL=info       # overrides LOG_LEVEL for container/stdout output
+# FILE_LOG_LEVEL=info          # overrides LOG_LEVEL for logs/backend.log
+# DB_LOG_LEVEL=info            # overrides LOG_LEVEL for the Admin System Event Log
 # BACKEND_MEM_LIMIT=1g
 # REDACT_API_KEYS=false         # Set to "true" to mask AI API keys in the Admin UI and disable the reveal (eye icon) button for added security
 

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,7 @@ JWT_SECRET=replace-with-a-long-random-string
 # CONSOLE_LOG_LEVEL=info       # overrides LOG_LEVEL for container/stdout output
 # FILE_LOG_LEVEL=info          # overrides LOG_LEVEL for logs/backend.log
 # DB_LOG_LEVEL=info            # overrides LOG_LEVEL for the Admin System Event Log
+# SLOW_QUERY_MS=500            # SQL slower than this is logged at WARN instead of DEBUG
 # BACKEND_MEM_LIMIT=1g
 # REDACT_API_KEYS=false         # Set to "true" to mask AI API keys in the Admin UI and disable the reveal (eye icon) button for added security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `DB_LOG_LEVEL` sets the log level for the Admin System Event Log
+  independently of the console and file logs, so the table can be kept quiet
+  while debugging on the console, or capture debug traces without flooding it.
 - The products dashboard and product detail page now refresh in the background
   while you are looking at them, so scraper results, price changes and status
   updates appear without a manual reload. Polling stops automatically when the
@@ -61,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Admin System Event Log now honours the configured log level. Setting
+  `LOG_LEVEL=error` previously still filled the table with INFO entries, and
+  `DEBUG` messages could never be stored at all no matter how the level was set.
 - Browsers no longer offer to save API keys, provider tokens and webhook URLs as
   passwords, and no longer offer to overwrite the administrator's own saved
   login when creating or editing another user. These fields are now masked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- SQL query tracing: every statement, its duration and its parameter count are
+  logged under the `Database` context, with a `WARN` for anything slower than
+  `SLOW_QUERY_MS` (default 500ms) and the failing statement attached to query
+  errors. Parameter values are never logged. Set `LOG_LEVEL=debug` to see
+  successful queries; slow-query and failure entries appear regardless.
 - `DB_LOG_LEVEL` sets the log level for the Admin System Event Log
   independently of the console and file logs, so the table can be kept quiet
   while debugging on the console, or capture debug traces without flooding it.

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,5 +1,6 @@
 import { Pool, types } from 'pg';
 import { loadEnvironment } from './environment';
+import { enableQueryTracing } from './queryTracing';
 
 loadEnvironment();
 
@@ -12,5 +13,10 @@ const pool = new Pool({
 
 // We remove the direct logger dependency here to avoid circular imports.
 // Error handling for the pool will be set up in the main application entry point.
+
+// Trace every statement (audit L-01). queryTracing imports the logger module
+// directly; that chain ends at `pg` and never reaches back here, so it does not
+// reintroduce the cycle the comment above is guarding against.
+enableQueryTracing(pool);
 
 export default pool;

--- a/backend/src/config/queryTracing.ts
+++ b/backend/src/config/queryTracing.ts
@@ -1,0 +1,147 @@
+import type { Pool, PoolClient } from 'pg';
+import { logger } from '../utils/system/logging/logger';
+
+/**
+ * Query tracing for the Postgres pool (logging audit L-01).
+ *
+ * Repository SQL was previously invisible: a failing query surfaced as a bare
+ * driver error with no statement, no timing, and no way to tell a slow query
+ * from a stuck one.
+ *
+ * This wraps the pool rather than introducing a `tracedQuery` helper, because
+ * thirty modules already import the pool directly and every one of them would
+ * otherwise have to be rewritten to get any coverage at all.
+ *
+ * The logger is imported directly rather than through the logging barrel: that
+ * chain ends at `pg` and never reaches back to `config/database`, so the
+ * circular-import warning on the pool module does not apply here.
+ *
+ * Parameter *values* are never logged. They routinely carry password hashes,
+ * reset tokens, API keys and email addresses, and the scrubber cannot reliably
+ * redact a bare positional array with no key names to match on. The parameter
+ * count is logged instead, which is what is actually useful when reading a
+ * failure.
+ */
+
+const DEFAULT_SLOW_QUERY_MS = 500;
+
+/** The logger's own insert, which must never be traced -- see below. */
+const LOG_INSERT_MARKER = 'INSERT INTO system_logs';
+
+function slowQueryThreshold(): number {
+  const configured = Number(process.env.SLOW_QUERY_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_SLOW_QUERY_MS;
+}
+
+/** Collapse a multi-line statement to one readable line and cap its length. */
+function summarize(sql: string): string {
+  const flattened = sql.replace(/\s+/g, ' ').trim();
+  return flattened.length > 500 ? `${flattened.slice(0, 500)}...` : flattened;
+}
+
+function describe(args: unknown[]): { sql: string; paramCount: number } | null {
+  const [first, second] = args;
+
+  if (typeof first === 'string') {
+    return { sql: summarize(first), paramCount: Array.isArray(second) ? second.length : 0 };
+  }
+
+  // The config-object form: pool.query({ text, values }).
+  if (first && typeof first === 'object' && 'text' in first) {
+    const config = first as { text: unknown; values?: unknown };
+    if (typeof config.text === 'string') {
+      return {
+        sql: summarize(config.text),
+        paramCount: Array.isArray(config.values) ? config.values.length : 0,
+      };
+    }
+  }
+
+  return null;
+}
+
+type Queryable = Pick<Pool | PoolClient, 'query'>;
+
+/** Replace `target.query` with a traced version, in place. */
+function instrumentQuery(target: Queryable, label: 'Pool' | 'Client'): void {
+  const original = target.query.bind(target) as (...args: unknown[]) => unknown;
+
+  (target as { query: unknown }).query = function tracedQuery(...args: unknown[]) {
+    const described = describe(args);
+
+    // The logger persists to system_logs through this same pool. Tracing that
+    // insert would make every database log line generate another one.
+    if (!described || described.sql.startsWith(LOG_INSERT_MARKER)) {
+      return original(...args);
+    }
+
+    const { sql, paramCount } = described;
+    const started = Date.now();
+
+    let result: unknown;
+    try {
+      result = original(...args);
+    } catch (err) {
+      logger.error(
+        `SQL | ${label} | Failed to dispatch | ${sql} | Params: ${paramCount}`,
+        'Database',
+        err
+      );
+      throw err;
+    }
+
+    if (!(result instanceof Promise)) return result;
+
+    return result.then(
+      (value) => {
+        const latency = Date.now() - started;
+        if (latency >= slowQueryThreshold()) {
+          logger.warn(
+            `SQL | ${label} | Slow query | ${latency}ms | ${sql} | Params: ${paramCount}`,
+            'Database'
+          );
+        } else {
+          logger.debug(
+            `SQL | ${label} | ${latency}ms | ${sql} | Params: ${paramCount}`,
+            'Database'
+          );
+        }
+        return value;
+      },
+      (err) => {
+        const latency = Date.now() - started;
+        logger.error(
+          `SQL | ${label} | Failed after ${latency}ms | ${sql} | Params: ${paramCount}`,
+          'Database',
+          err
+        );
+        throw err;
+      }
+    );
+  };
+}
+
+/**
+ * Trace every statement issued through the pool, including those on clients
+ * checked out for a transaction.
+ */
+export function enableQueryTracing(pool: Pool): void {
+  instrumentQuery(pool, 'Pool');
+
+  const originalConnect = pool.connect.bind(pool) as (...args: unknown[]) => unknown;
+
+  (pool as { connect: unknown }).connect = function tracedConnect(...args: unknown[]) {
+    const result = originalConnect(...args);
+    if (!(result instanceof Promise)) return result;
+
+    return result.then((client: PoolClient) => {
+      // A client is checked out and released repeatedly; only wrap it once.
+      const marked = client as PoolClient & { __psQueryTraced?: boolean };
+      if (!marked.__psQueryTraced) {
+        instrumentQuery(marked, 'Client');
+        marked.__psQueryTraced = true;
+      }
+      return client;
+    });
+  };
+}

--- a/backend/src/utils/system/logging/logger.ts
+++ b/backend/src/utils/system/logging/logger.ts
@@ -1,4 +1,4 @@
-import { print } from './printer';
+import { print, isLevelEnabled } from './printer';
 
 export const logger = {
   info: (msg: string, context?: string, details?: any) => print('INFO', msg, context, details),
@@ -32,7 +32,10 @@ export const logger = {
     }
   },
   debug: (msg: string, context?: string, details?: any) => {
-    if (process.env.DEBUG === 'true' || (process.env.LOG_LEVEL && process.env.LOG_LEVEL.toUpperCase() === 'DEBUG')) {
+    // This used to check the global LOG_LEVEL only, so setting
+    // CONSOLE_LOG_LEVEL=debug or DB_LOG_LEVEL=debug on its own produced no
+    // debug output at all. Ask the printer whether any sink wants it.
+    if (isLevelEnabled('DEBUG')) {
       print('DEBUG', msg, context, details);
     }
   },

--- a/backend/src/utils/system/logging/printer.ts
+++ b/backend/src/utils/system/logging/printer.ts
@@ -35,13 +35,51 @@ function getLogLevelValue(level: LogLevel | string): number {
   }
 }
 
+/**
+ * Each sink has its own threshold, falling back to the global LOG_LEVEL.
+ * These are read per call rather than cached so a level can be changed without
+ * a restart.
+ */
+function getSinkLevels() {
+  const global =
+    process.env.LOG_LEVEL || (process.env.DEBUG === 'true' ? 'DEBUG' : DEFAULT_LOG_LEVEL);
+  return {
+    console: process.env.CONSOLE_LOG_LEVEL || global,
+    file: process.env.FILE_LOG_LEVEL || global,
+    database: process.env.DB_LOG_LEVEL || global,
+  };
+}
+
+/**
+ * True when at least one sink would accept this level. Callers use it to skip
+ * building a message no sink will keep -- most usefully `logger.debug`, which
+ * would otherwise format and scrub text that is thrown away.
+ */
+export function isLevelEnabled(level: LogLevel): boolean {
+  const value = getLogLevelValue(level);
+  const levels = getSinkLevels();
+  return (
+    value >= getLogLevelValue(levels.console) ||
+    value >= getLogLevelValue(levels.file) ||
+    value >= getLogLevelValue(levels.database)
+  );
+}
+
+/**
+ * High-volume contexts. Below WARN they are operational chatter that would bloat
+ * system_logs without telling an administrator anything; at WARN and above they
+ * describe an actual problem and are always worth keeping.
+ */
+const NOISE_CONTEXTS = ['HTTP', 'Database', 'Scheduler'];
+
 export function print(level: LogLevel, msg: string, context?: string, details?: any) {
   msg = scrubSensitiveData(msg);
   if (context) context = scrubSensitiveData(context);
   if (details) details = scrubSensitiveData(details);
 
-  const currentConsoleLevel = process.env.CONSOLE_LOG_LEVEL || process.env.LOG_LEVEL || (process.env.DEBUG === 'true' ? 'DEBUG' : DEFAULT_LOG_LEVEL);
-  const currentFileLevel = process.env.FILE_LOG_LEVEL || process.env.LOG_LEVEL || (process.env.DEBUG === 'true' ? 'DEBUG' : DEFAULT_LOG_LEVEL);
+  const sinkLevels = getSinkLevels();
+  const currentConsoleLevel = sinkLevels.console;
+  const currentFileLevel = sinkLevels.file;
   
   // Clean up redundant context in message
   let cleanMsg = msg;
@@ -123,19 +161,14 @@ export function print(level: LogLevel, msg: string, context?: string, details?: 
     writeToLogFile(level, fileOutput);
   }
 
-  // --- DATABASE PERSISTENCE RULES ---
-  let shouldSaveToDb = false;
-  const noiseContexts = ['HTTP', 'Database', 'Scheduler'];
-
-  if (level === 'ERROR' || level === 'WARN') {
-    shouldSaveToDb = true;
-  } else if (level === 'INFO') {
-    // Only save INFO if it's not a noise context
-    shouldSaveToDb = !noiseContexts.includes(context || '');
-  } else if (level === 'DEBUG') {
-    // Only save DEBUG if it's the consolidated Voting trace
-    shouldSaveToDb = (context === 'Voting');
-  }
+  // 3. DATABASE PERSISTENCE
+  // Previously this ignored the configured level entirely: every INFO was
+  // written whatever LOG_LEVEL said, while DEBUG could never be written at all.
+  // The threshold now applies here like it does to the other two sinks.
+  const isProblem = level === 'WARN' || level === 'ERROR';
+  const shouldSaveToDb =
+    getLogLevelValue(level) >= getLogLevelValue(sinkLevels.database) &&
+    (isProblem || !NOISE_CONTEXTS.includes(context || ''));
 
   if (shouldSaveToDb) {
     saveToDb(level, cleanMsg, context, details).catch(() => {});

--- a/backend/tests/unit/log-levels.test.ts
+++ b/backend/tests/unit/log-levels.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * The level hierarchy is easy to break silently: nothing throws when a sink
+ * quietly starts swallowing or storing everything, and the symptom (an empty
+ * event log, or a bloated one) only shows up in production. These cases pin
+ * down which of the three sinks accepts which level.
+ */
+
+const LOG_ENV = ['LOG_LEVEL', 'CONSOLE_LOG_LEVEL', 'FILE_LOG_LEVEL', 'DB_LOG_LEVEL', 'DEBUG'] as const;
+
+const saveToDb = vi.fn();
+
+vi.mock('../../src/utils/system/logging/persistence', () => ({
+  saveToDb: (...args: unknown[]) => {
+    saveToDb(...args);
+    return Promise.resolve();
+  },
+  initLoggerPersistence: () => {},
+}));
+
+// The printer appends to real files; keep the suite off the disk.
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: { ...actual, existsSync: () => true, mkdirSync: () => undefined, appendFileSync: () => undefined },
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+    appendFileSync: () => undefined,
+  };
+});
+
+async function freshLogger() {
+  vi.resetModules();
+  return await import('../../src/utils/system/logging/logger');
+}
+
+/** Levels that reached the database for a given environment. */
+async function persistedLevels(env: Partial<Record<(typeof LOG_ENV)[number], string>>, context?: string) {
+  for (const key of LOG_ENV) delete process.env[key];
+  Object.assign(process.env, env);
+
+  saveToDb.mockClear();
+  const { logger } = await freshLogger();
+
+  logger.debug('debug message', context);
+  logger.info('info message', context);
+  logger.warn('warn message', context);
+  logger.error('error message', context);
+
+  return saveToDb.mock.calls.map((call) => call[0] as string);
+}
+
+describe('Log level hierarchy', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  describe('database persistence respects the configured threshold', () => {
+    it('stores INFO and above by default', async () => {
+      expect(await persistedLevels({})).toEqual(['INFO', 'WARN', 'ERROR']);
+    });
+
+    it('stores only ERROR when LOG_LEVEL is error', async () => {
+      // The bug this replaces: INFO was written unconditionally, so a user who
+      // set LOG_LEVEL=error still had their event log filled with INFO rows.
+      expect(await persistedLevels({ LOG_LEVEL: 'error' })).toEqual(['ERROR']);
+    });
+
+    it('stores WARN and above when LOG_LEVEL is warn', async () => {
+      expect(await persistedLevels({ LOG_LEVEL: 'warn' })).toEqual(['WARN', 'ERROR']);
+    });
+
+    it('stores DEBUG when the level allows it', async () => {
+      // Previously DEBUG could never reach the database at any setting.
+      expect(await persistedLevels({ LOG_LEVEL: 'debug' })).toEqual([
+        'DEBUG',
+        'INFO',
+        'WARN',
+        'ERROR',
+      ]);
+    });
+
+    it('accepts a lowercase level', async () => {
+      expect(await persistedLevels({ LOG_LEVEL: 'ERROR' })).toEqual(['ERROR']);
+    });
+  });
+
+  describe('DB_LOG_LEVEL overrides the global level for the database only', () => {
+    it('can keep the database quiet while the console stays verbose', async () => {
+      expect(await persistedLevels({ LOG_LEVEL: 'debug', DB_LOG_LEVEL: 'error' })).toEqual(['ERROR']);
+    });
+
+    it('can store debug traces without flooding the console', async () => {
+      expect(await persistedLevels({ LOG_LEVEL: 'warn', DB_LOG_LEVEL: 'debug' })).toEqual([
+        'DEBUG',
+        'INFO',
+        'WARN',
+        'ERROR',
+      ]);
+    });
+  });
+
+  describe('high-volume contexts', () => {
+    it('drops routine HTTP, Database and Scheduler chatter', async () => {
+      for (const context of ['HTTP', 'Database', 'Scheduler']) {
+        expect(await persistedLevels({ LOG_LEVEL: 'debug' }, context)).toEqual(['WARN', 'ERROR']);
+      }
+    });
+
+    it('still stores problems from those contexts', async () => {
+      // An HTTP 500 is exactly what an administrator opens the event log to find.
+      expect(await persistedLevels({ LOG_LEVEL: 'error' }, 'HTTP')).toEqual(['ERROR']);
+    });
+
+    it('stores every level for an ordinary context', async () => {
+      expect(await persistedLevels({ LOG_LEVEL: 'debug' }, 'Scraper')).toEqual([
+        'DEBUG',
+        'INFO',
+        'WARN',
+        'ERROR',
+      ]);
+    });
+  });
+
+  describe('isLevelEnabled', () => {
+    it('is true when any single sink asks for the level', async () => {
+      for (const key of LOG_ENV) delete process.env[key];
+      process.env.LOG_LEVEL = 'error';
+      process.env.CONSOLE_LOG_LEVEL = 'debug';
+
+      vi.resetModules();
+      const { isLevelEnabled } = await import('../../src/utils/system/logging/printer');
+
+      // The old guard checked the global level alone, so a console-only debug
+      // override produced no debug output anywhere.
+      expect(isLevelEnabled('DEBUG')).toBe(true);
+    });
+
+    it('is false when no sink asks for the level', async () => {
+      for (const key of LOG_ENV) delete process.env[key];
+      process.env.LOG_LEVEL = 'info';
+
+      vi.resetModules();
+      const { isLevelEnabled } = await import('../../src/utils/system/logging/printer');
+
+      expect(isLevelEnabled('DEBUG')).toBe(false);
+      expect(isLevelEnabled('INFO')).toBe(true);
+    });
+  });
+});

--- a/backend/tests/unit/query-tracing.test.ts
+++ b/backend/tests/unit/query-tracing.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { enableQueryTracing } from '../../src/config/queryTracing';
+import { logger } from '../../src/utils/system/logging/logger';
+
+/**
+ * Tracing wraps the pool that every repository already imports, so a mistake
+ * here breaks every query in the application rather than just the logging.
+ */
+
+function fakePool(behaviour: {
+  query?: (...args: unknown[]) => unknown;
+  client?: Record<string, unknown>;
+}) {
+  const client = behaviour.client ?? { query: vi.fn().mockResolvedValue({ rows: [] }) };
+  return {
+    query: behaviour.query ?? vi.fn().mockResolvedValue({ rows: [] }),
+    connect: vi.fn().mockResolvedValue(client),
+  } as unknown as Pool;
+}
+
+describe('Query tracing', () => {
+  let debug: ReturnType<typeof vi.spyOn>;
+  let warn: ReturnType<typeof vi.spyOn>;
+  let error: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debug = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    delete process.env.SLOW_QUERY_MS;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    delete process.env.SLOW_QUERY_MS;
+  });
+
+  it('passes the result through untouched', async () => {
+    const rows = [{ id: 1 }];
+    const pool = fakePool({ query: vi.fn().mockResolvedValue({ rows }) });
+    enableQueryTracing(pool);
+
+    const result = await pool.query('SELECT * FROM products WHERE id = $1', [1]);
+
+    expect(result.rows).toBe(rows);
+  });
+
+  it('logs the statement and the parameter count, never the values', async () => {
+    const pool = fakePool({});
+    enableQueryTracing(pool);
+
+    await pool.query('SELECT id FROM users WHERE email = $1 AND token = $2', [
+      'person@example.test',
+      'super-secret-reset-token',
+    ]);
+
+    expect(debug).toHaveBeenCalledTimes(1);
+    const [message, context] = debug.mock.calls[0];
+    expect(context).toBe('Database');
+    expect(message).toContain('SELECT id FROM users WHERE email = $1 AND token = $2');
+    expect(message).toContain('Params: 2');
+    // The whole point: positional values carry secrets and cannot be scrubbed
+    // by key name, so they must never reach a log line.
+    expect(message).not.toContain('super-secret-reset-token');
+    expect(message).not.toContain('person@example.test');
+  });
+
+  it('collapses a multi-line statement onto one line', async () => {
+    const pool = fakePool({});
+    enableQueryTracing(pool);
+
+    await pool.query('SELECT *\n  FROM   products\n  WHERE id = $1', [7]);
+
+    expect(debug.mock.calls[0][0]).toContain('SELECT * FROM products WHERE id = $1');
+  });
+
+  it('warns instead of debugging when a query is slow', async () => {
+    process.env.SLOW_QUERY_MS = '20';
+    const pool = fakePool({
+      query: vi.fn().mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ rows: [] }), 40))
+      ),
+    });
+    enableQueryTracing(pool);
+
+    await pool.query('SELECT pg_sleep(1)');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('Slow query');
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  it('logs a failing query and still rejects', async () => {
+    const boom = new Error('relation "missing" does not exist');
+    const pool = fakePool({ query: vi.fn().mockRejectedValue(boom) });
+    enableQueryTracing(pool);
+
+    await expect(pool.query('SELECT 1 FROM missing')).rejects.toThrow(boom);
+
+    expect(error).toHaveBeenCalledTimes(1);
+    const [message, context, err] = error.mock.calls[0];
+    expect(context).toBe('Database');
+    expect(message).toContain('SELECT 1 FROM missing');
+    expect(err).toBe(boom);
+  });
+
+  it('does not trace the logger\'s own insert', async () => {
+    const pool = fakePool({});
+    enableQueryTracing(pool);
+
+    // Tracing this would make every database log line generate another one.
+    await pool.query('INSERT INTO system_logs (level, context, message, details) VALUES ($1, $2, $3, $4)', [
+      'ERROR',
+      'Database',
+      'boom',
+      null,
+    ]);
+
+    expect(debug).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('traces queries issued on a checked-out transaction client', async () => {
+    const client = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const pool = fakePool({ client });
+    enableQueryTracing(pool);
+
+    const checkedOut = await pool.connect();
+    await checkedOut.query('UPDATE products SET name = $1 WHERE id = $2', ['x', 1]);
+
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(debug.mock.calls[0][0]).toContain('UPDATE products SET name = $1 WHERE id = $2');
+  });
+
+  it('wraps a pooled client only once across check-outs', async () => {
+    const client = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const pool = fakePool({ client });
+    enableQueryTracing(pool);
+
+    const first = await pool.connect();
+    const second = await pool.connect();
+    await second.query('SELECT 1');
+
+    // pg reuses client objects, so double-wrapping would log each statement
+    // once per check-out the client had ever had.
+    expect(first).toBe(second);
+    expect(debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports the config-object form of query', async () => {
+    const pool = fakePool({});
+    enableQueryTracing(pool);
+
+    await pool.query({ text: 'SELECT $1::int', values: [1] });
+
+    expect(debug.mock.calls[0][0]).toContain('SELECT $1::int');
+    expect(debug.mock.calls[0][0]).toContain('Params: 1');
+  });
+});

--- a/docs/audit/LOGGING.md
+++ b/docs/audit/LOGGING.md
@@ -55,7 +55,7 @@ We identified **five major monitoring and tracing gaps** that degrade debugging 
 | :--- | :--- | :--- | :--- | :--- |
 | **L-01** | Database Layer | **High** | No visibility into SQL queries, database latency, or parameter maps during transaction failures. | Introduce a wrapper around `pool.query` that logs executing queries, counts, and duration at `DEBUG` level. |
 | **L-02** | AI / LLM Integrations | **Medium** | Prompt structure, system parameters, and raw JSON returns are invisible; only token usage is logged. | Add `logger.debug` statements inside `providers/*.ts` printing the raw prompt request and response payloads. |
-| **L-03** | Configuration Filtering | **Low** | Global `LOG_LEVEL` limits are bypassed by database writes, causing disk bloat on errors even when debugging is off. | Modify the persistence write handler to enforce `LOG_LEVEL` thresholds before inserting into the Postgres database. |
+| **L-03** | Configuration Filtering | **Low** | Global `LOG_LEVEL` limits are bypassed by database writes, causing disk bloat on errors even when debugging is off. | **Fixed.** Database writes now honour `DB_LOG_LEVEL`, falling back to `LOG_LEVEL`, like the console and file sinks. |
 | **L-04** | Scraper Selectors | **Low** | Selector evaluation sequence (JSON-LD, custom-regex, generic parsing) lacks real-time streaming console logs. | Log each selector execution and matching candidate in real-time under `DEBUG` level. |
 | **L-05** | Auth token errors | **Low** | Verification checks for tokens don't log the reason for expiration or decryption failure. | Log token validation failures (e.g., token expired, signature mismatch) at `WARN` level. |
 

--- a/docs/audit/LOGGING.md
+++ b/docs/audit/LOGGING.md
@@ -53,7 +53,7 @@ We identified **five major monitoring and tracing gaps** that degrade debugging 
 
 | Gap ID | Area | Severity | Technical Impact | Actionable Mitigation |
 | :--- | :--- | :--- | :--- | :--- |
-| **L-01** | Database Layer | **High** | No visibility into SQL queries, database latency, or parameter maps during transaction failures. | Introduce a wrapper around `pool.query` that logs executing queries, counts, and duration at `DEBUG` level. |
+| **L-01** | Database Layer | **High** | No visibility into SQL queries, database latency, or parameter maps during transaction failures. | **Fixed.** Every pooled and transaction-client statement is traced under the `Database` context with its SQL, latency and parameter count; slow queries warn at `SLOW_QUERY_MS`. Parameter values are deliberately excluded. |
 | **L-02** | AI / LLM Integrations | **Medium** | Prompt structure, system parameters, and raw JSON returns are invisible; only token usage is logged. | Add `logger.debug` statements inside `providers/*.ts` printing the raw prompt request and response payloads. |
 | **L-03** | Configuration Filtering | **Low** | Global `LOG_LEVEL` limits are bypassed by database writes, causing disk bloat on errors even when debugging is off. | **Fixed.** Database writes now honour `DB_LOG_LEVEL`, falling back to `LOG_LEVEL`, like the console and file sinks. |
 | **L-04** | Scraper Selectors | **Low** | Selector evaluation sequence (JSON-LD, custom-regex, generic parsing) lacks real-time streaming console logs. | Log each selector execution and matching candidate in real-time under `DEBUG` level. |

--- a/docs/developer/LOGGING.md
+++ b/docs/developer/LOGGING.md
@@ -22,6 +22,7 @@ Logging behavior is controlled via environment variables in your `.env` file or 
 | `DEBUG` | `true`, `false` | `false` | Shortcut boolean. Setting to `true` overrides log levels to `DEBUG` and enables detailed HTTP request body logging. |
 | `CONSOLE_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for Console/Docker output. |
 | `FILE_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for Disk Log files. |
+| `DB_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for the `system_logs` table behind Admin -> System Event Log. Raise it to `warn` to keep the table small, or lower it to `debug` to capture traces without flooding the console. |
 | `LOG_DIR_PATH` | Any valid absolute/relative directory | `./logs` | Directory path where log files are written. |
 | `TZ` | e.g. `Australia/Perth`, `UTC` | `UTC` | Controls the timezone prefix format for both services. |
 
@@ -42,7 +43,18 @@ Logs are written to the directory specified by `LOG_DIR_PATH` (default: `./logs/
 * `error.log`: An error-only log capturing `WARN` and `ERROR` entries. Includes full stack traces when errors are thrown.
 
 ### C. Database (PostgreSQL)
-Persistent event logs stored in the `system_logs` table. These logs are queryable via the **Admin -> System Event Log** panel in the Web UI. They store:
+Persistent event logs stored in the `system_logs` table. These logs are queryable via the **Admin -> System Event Log** panel in the Web UI.
+
+Writes honour `DB_LOG_LEVEL` (falling back to `LOG_LEVEL`) exactly as the console
+and file sinks honour theirs. Two context rules apply on top of the threshold:
+
+* `HTTP`, `Database` and `Scheduler` are high-volume operational contexts. Below
+  `WARN` they are not persisted, because request and heartbeat chatter bloats the
+  table without telling an administrator anything.
+* At `WARN` and `ERROR` those contexts *are* persisted regardless, since a failed
+  request or a scheduler error is exactly what the event log is opened to find.
+
+They store:
 * Log Level & Timestamp
 * Source context (e.g. `Auth`, `Scraper`, `API`, `Database`)
 * Message content

--- a/docs/developer/LOGGING.md
+++ b/docs/developer/LOGGING.md
@@ -23,6 +23,7 @@ Logging behavior is controlled via environment variables in your `.env` file or 
 | `CONSOLE_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for Console/Docker output. |
 | `FILE_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for Disk Log files. |
 | `DB_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for the `system_logs` table behind Admin -> System Event Log. Raise it to `warn` to keep the table small, or lower it to `debug` to capture traces without flooding the console. |
+| `SLOW_QUERY_MS` | Any positive integer | `500` | A SQL statement taking at least this long is logged at `WARN` instead of `DEBUG`. |
 | `LOG_DIR_PATH` | Any valid absolute/relative directory | `./logs` | Directory path where log files are written. |
 | `TZ` | e.g. `Australia/Perth`, `UTC` | `UTC` | Controls the timezone prefix format for both services. |
 
@@ -117,3 +118,34 @@ Administrators can search, filter, and review logs under **Admin -> System Event
 * **Purge Logs**: Clear all logs matching current filters.
 * **Bulk Action**: Delete specific log rows.
 * **Auto-cleanup**: The database runs background routines that automatically prune logs older than 14 days to prevent storage growth.
+
+---
+
+## 6. SQL Query Tracing
+
+Every statement issued through the connection pool is traced under the
+`Database` context, including statements on a client checked out for a
+transaction. Each line carries the statement, how long it took, and how many
+bind parameters it had:
+
+```text
+DEBUG [Database]: SQL | Pool | 4ms | SELECT * FROM products WHERE user_id = $1 | Params: 1
+WARN  [Database]: SQL | Pool | Slow query | 812ms | SELECT ... | Params: 2
+ERROR [Database]: SQL | Client | Failed after 3ms | UPDATE ... | Params: 3
+```
+
+Levels follow the same thresholds as everything else:
+
+* `DEBUG` for a normal query. Set `LOG_LEVEL=debug` (or `CONSOLE_LOG_LEVEL=debug`)
+  to see them; at the default `info` they cost nothing.
+* `WARN` once a query reaches `SLOW_QUERY_MS`.
+* `ERROR` when a query fails, with the driver error attached.
+
+**Parameter values are never logged.** Bind parameters routinely carry password
+hashes, reset tokens, API keys and email addresses, and the scrubber matches on
+key names it cannot see in a bare positional array. The parameter count is
+recorded instead.
+
+Because `Database` is a high-volume context, `DEBUG` and `INFO` lines are printed
+and written to disk but not persisted to `system_logs`. Slow-query warnings and
+query failures are persisted, so they show up in **Admin -> System Event Log**.


### PR DESCRIPTION
Wave 2 of the backlog plan: fix the instruments before the engine. Closes #77 and lands phase 1 of #79.

---

## #77 — the level hierarchy did not reach the database

Console and file output each checked their configured threshold. The database sink used a hardcoded rule instead:

- `logger.info()` was unconditional and INFO was always persisted, so `LOG_LEVEL=error` still filled `system_logs` with INFO rows.
- DEBUG could **never** be persisted — except for a `context === 'Voting'` special case that nothing in the codebase emits. I grepped: the only occurrence of that string is the check itself. Dead since whatever produced it was removed.
- `logger.debug` gated on the global `LOG_LEVEL` alone, so setting `CONSOLE_LOG_LEVEL=debug` on its own produced no debug output anywhere.

### Changes

- New `DB_LOG_LEVEL`, falling back to `LOG_LEVEL`, alongside the existing `CONSOLE_LOG_LEVEL` and `FILE_LOG_LEVEL`. The database sink now checks a threshold like the other two.
- `logger.debug` asks the printer whether *any* sink wants the level.
- The high-volume context filter stays but is now explicit about intent: `HTTP`, `Database` and `Scheduler` are dropped below WARN as operational chatter, and kept at WARN and above because a failed request is exactly what the event log exists to surface. Previously an ERROR from those contexts was stored by accident of rule ordering.

### Tests

A matrix over level x sink x context. **10 of the 12 cases fail against the previous implementation** — I checked by stashing the source and re-running.

---

## #79 phase 1 — SQL query tracing (L-01)

A failing query surfaced as a bare driver error with no statement attached, and there was no way to tell a slow query from a stuck one.

I did **not** use the `tracedQuery` helper the audit sketched. Thirty modules already import the pool directly, so a helper only covers the call sites somebody remembers to convert. Instrumenting the pool covers all of them, and wrapping `pool.connect` covers statements inside a transaction — which is where the persistence bugs in #91 actually live.

```text
DEBUG [Database]: SQL | Pool | 4ms | SELECT * FROM products WHERE user_id = $1 | Params: 1
WARN  [Database]: SQL | Pool | Slow query | 812ms | SELECT ... | Params: 2
ERROR [Database]: SQL | Client | Failed after 3ms | UPDATE ... | Params: 3
```

### Parameter values are deliberately not logged

The audit's snippet logs `text` only and I kept that, for a specific reason: bind parameters carry password hashes, reset tokens, API keys and email addresses, and `scrubber.ts` matches on **key names** that do not exist in a bare positional array. It cannot redact them. Logging the count instead is both safe and what is actually useful when reading a failure. This is CLAUDE.md's "do not log credentials raw" rule.

### Two things that would otherwise bite

- The logger persists through this same pool, so tracing its own `INSERT INTO system_logs` would make every database log line generate another one. Explicitly skipped, with a test.
- pg reuses client objects across check-outs, so a client is wrapped once rather than once per `connect()`. Otherwise each statement would log once per check-out that client had ever had. Also tested.

### Verification

No Docker on this machine, so no full end-to-end against a live database. I did verify against a **real `pg.Pool`** rather than only mocks: a connection failure still rejects with the genuine driver `ECONNREFUSED` rather than a `TypeError` from the wrapper, and the emitted line carried the SQL with `Params: 1` and no values.

**Scope:** L-01 only. L-02 (AI prompt/response tracing), L-03 (covered by the #77 half), L-04 (selector progress) and L-05 (OIDC failure detail) remain open on #79, so that issue stays open.

---

## Docs

`docs/developer/LOGGING.md` gains `DB_LOG_LEVEL`, `SLOW_QUERY_MS`, a query-tracing section and the database persistence rules; `.env.example` gains all four level variables; `docs/audit/LOGGING.md` marks L-01 and L-03 fixed.

## Verification

`tsc`, 142 backend tests (up from 121), emoji lint, `git diff --check` — all pass.

Closes #77