### PR TITLE
fix(scraper): repair selector settings, resolve image URLs, per-retailer JSON-LD preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Generic stock, AI price and AI image selector settings were stored as invalid
+  JSON by the baseline schema, so the scraper silently fell back to a smaller
+  built-in list instead of the seeded one. Stock detection in particular was
+  running on 5 generic selectors rather than 12. Existing installs are repaired
+  automatically on upgrade; a customised list is left untouched.
+- AI retailer auto-mapping is now shown the same breadth of image candidates
+  that normal extraction uses, so it stops learning over-specific image
+  selectors that then outrank the generic selector which would have worked.
 - The Admin System Event Log now honours the configured log level. Setting
   `LOG_LEVEL=error` previously still filled the table with INFO entries, and
   `DEBUG` messages could never be stored at all no matter how the level was set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Per-retailer "Prefer JSON-LD Images" override under Admin -> Retailers ->
+  Extraction Parameters. Retailers whose structured data points at a thumbnail
+  or a directory can now prefer CSS selectors while JSON-LD preference stays on
+  globally. Existing retailers inherit the global setting and are unchanged.
 - SQL query tracing: every statement, its duration and its parameter count are
   logged under the `Database` context, with a `WARN` for anything slower than
   `SLOW_QUERY_MS` (default 500ms) and the failing statement attached to query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Product images no longer break when a retailer expresses the image as a
+  relative or protocol-relative URL: candidates are now resolved against the
+  page they were scraped from. Placeholder and spacer images are recognised
+  under many more spellings, and an unusable candidate can no longer replace a
+  working stored image. Dynamic image endpoints, including ones ending in a
+  slash, are kept rather than discarded.
 - Generic stock, AI price and AI image selector settings were stored as invalid
   JSON by the baseline schema, so the scraper silently fell back to a smaller
   built-in list instead of the seeded one. Stock detection in particular was

--- a/backend/src/migrations/013_repair_selector_settings_json.ts
+++ b/backend/src/migrations/013_repair_selector_settings_json.ts
@@ -1,0 +1,302 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Repairs selector settings that 001_baseline stored as invalid JSON, and
+ * broadens the image evidence shown to AI auto-mapping.
+ *
+ * 001_baseline seeds system_settings with Postgres E'' escape strings. In an
+ * E'' string \" is an escape sequence meaning a bare quote, so the JSON
+ * escaping was stripped on the way in and any selector containing a quoted
+ * attribute was stored unparseable:
+ *
+ *   stored:   ["link[rel="preload"][as="image"]", ...]
+ *   intended: ["link[rel=\"preload\"][as=\"image\"]", ...]
+ *
+ * 006_seed_generic_selectors only writes rows whose value IS NULL, so it never
+ * repaired them, and SettingsCache.getArray silently swallows the parse error
+ * and falls back to its hardcoded default. The result was invisible:
+ *
+ *   generic_stock_selectors      12 seeded entries -> 5 hardcoded fallbacks
+ *   generic_ai_image_selectors    9 seeded entries -> 9 narrower fallbacks
+ *   generic_ai_price_selectors    9 seeded entries -> 9 hardcoded fallbacks
+ *
+ * Stock detection has therefore been running on the reduced generic set on every
+ * install, and AI auto-mapping was shown a narrower set of image candidates than
+ * extraction actually uses -- the cause of the over-specific learned image
+ * selectors in issue #101.
+ *
+ * Validity is checked in TypeScript rather than SQL: the IS JSON predicate needs
+ * Postgres 16, and a cast inside a WHERE is evaluated against rows the key
+ * filter has not excluded yet, which fails the whole statement on the first bad
+ * row. Values are written as bind parameters, which is what avoids the escaping
+ * problem that caused this in the first place.
+ *
+ * Only unparseable rows are rewritten. Anything an administrator has edited into
+ * valid JSON is left exactly as it is.
+ */
+
+const CANONICAL_ARRAYS: Record<string, string[]> = {
+  "generic_ai_image_selectors": [
+    "link[rel=\"preload\"][as=\"image\"]",
+    "[itemprop=\"image\"]",
+    "[property=\"og:image\"]",
+    "img#landingImage",
+    "img#main-image",
+    "img.main-image",
+    "img.hero-image",
+    "img[class*=\"product-image\" i]",
+    "img[class*=\"product__image\" i]",
+    "img[class*=\"product\" i]",
+    "img[class*=\"gallery\" i]",
+    "img[data-testid*=\"image\" i]",
+    "[data-automation-test-id*=\"image\" i]",
+    "[data-testid*=\"image\" i]",
+    ".product-image img",
+    ".main-image img",
+    "[data-zoom-image]"
+  ],
+  "generic_ai_price_selectors": [
+    "[class*=\"price\" i]",
+    "[class*=\"Price\" i]",
+    "[data-testid*=\"price\" i]",
+    "[data-automation*=\"price\" i]",
+    "[data-automation*=\"Price\" i]",
+    "[itemprop=\"price\"]",
+    "[data-price]",
+    "[data-price-amount]",
+    "[data-product-price]"
+  ],
+  "generic_deal_price_selectors": [
+    ".price-item--sale",
+    ".special-price .price",
+    ".sale-price",
+    ".deal-price"
+  ],
+  "generic_exclusion_selectors": [
+    ".site-wide-ad"
+  ],
+  "generic_image_selectors": [
+    "[itemprop=\"image\"]",
+    "[property=\"og:image\"]",
+    "link[rel=\"preload\"][as=\"image\"]",
+    "[data-automation-test-id*=\"image\" i]",
+    "[data-testid*=\"image\" i]",
+    ".product-image img",
+    ".main-image img",
+    "[data-zoom-image]",
+    "img[class*=\"product\"]",
+    ".productthumbnail::attr(src)"
+  ],
+  "generic_in_stock_phrases": [
+    "in stock",
+    "instock",
+    "add to cart",
+    "add to basket",
+    "add to bag",
+    "buy now",
+    "available now",
+    "add to trolley",
+    "clearance",
+    "on sale",
+    "special offer",
+    "limited stock",
+    "available",
+    "ready to ship",
+    "dispatched within",
+    "dispatched from"
+  ],
+  "generic_member_price_selectors": [
+    ".member-price",
+    ".perks-price",
+    ".club-price"
+  ],
+  "generic_name_selectors": [
+    "meta[property=\"og:title\"]::attr(content)",
+    "meta[name=\"twitter:title\"]::attr(content)",
+    "[itemprop=\"name\"]",
+    "[data-automation-test-id*=\"title\" i]",
+    "[data-automation-test-id*=\"name\" i]",
+    "[data-testid*=\"title\" i]",
+    "[data-testid*=\"name\" i]",
+    "h1[class*=\"product\"]",
+    "h1[class*=\"title\"]",
+    ".product-title",
+    "h1"
+  ],
+  "generic_original_price_selectors": [
+    ".rrp",
+    ".was-price",
+    ".price-item--regular",
+    ".old-price",
+    "[class*=\"original\" i]",
+    "[class*=\"rrp\" i]",
+    "[class*=\"was-price\" i]",
+    "[data-testid*=\"strikethrough-price\"]"
+  ],
+  "generic_out_of_stock_phrases": [
+    "out of stock",
+    "sold out",
+    "currently unavailable",
+    "not available",
+    "backorder",
+    "back-order",
+    "notify me when available",
+    "coming soon"
+  ],
+  "generic_pre_order_phrases": [
+    "pre-order",
+    "preorder",
+    "available starting",
+    "expected to ship",
+    "release date",
+    "pre-ordering"
+  ],
+  "generic_pre_order_price_selectors": [
+    "[class*=\"preorder-price\" i]",
+    "[class*=\"pre-order-price\" i]",
+    "[data-testid*=\"preorder-price\" i]",
+    "[data-testid*=\"pre-order-price\" i]",
+    "[id*=\"preorder-price\" i]"
+  ],
+  "generic_price_selectors": [
+    "meta[itemprop=\"lowPrice\"]::attr(content)",
+    "[itemprop=\"lowPrice\"]",
+    "[itemprop=\"price\"]",
+    "meta[property=\"product:price:amount\"]::attr(content)",
+    "meta[property=\"og:price:amount\"]::attr(content)",
+    "[data-price-type=\"finalPrice\"] .price",
+    "[data-price-amount]",
+    "[data-product-price]",
+    "[data-test=\"price\"]",
+    "[data-test=\"product-price\"]",
+    "[data-test=\"current-price\"]",
+    "[data-automation-test-id*=\"price\" i]",
+    "[data-testid*=\"price\" i]",
+    "[data-test-id*=\"price\" i]",
+    ".price-item--sale",
+    ".price-item--regular",
+    ".woocommerce-Price-amount.amount",
+    ".summary .price .amount",
+    "[data-price]",
+    "[data-price-amount]",
+    ".price-box .price",
+    ".special-price .price",
+    ".price",
+    ".product-price",
+    ".current-price",
+    ".sale-price",
+    ".final-price",
+    ".offer-price",
+    "#price",
+    "[class*=\"price\" i]"
+  ],
+  "generic_retailer_name_selectors": [
+    "meta[property=\"og:site_name\"]::attr(content)",
+    "meta[name=\"application-name\"]::attr(content)",
+    "[itemprop=\"brand\"] [itemprop=\"name\"]",
+    "[itemprop=\"brand\"]::attr(content)",
+    "a[class*=\"logo\" i]::attr(aria-label)",
+    "a[id*=\"logo\" i]::attr(aria-label)"
+  ],
+  "generic_stock_selectors": [
+    "[itemprop=\"availability\"]",
+    ".stock-status",
+    ".availability",
+    "[data-automation-test-id*=\"stock\" i]",
+    "[data-automation-test-id*=\"availability\" i]",
+    "[data-automation-test-id*=\"buy-box\" i]",
+    "[data-testid*=\"stock\" i]",
+    "[data-testid*=\"availability\" i]",
+    "[data-test-id*=\"stock\" i]",
+    "[data-test-id*=\"availability\" i]",
+    "[class*=\"stock-status\" i]",
+    "[class*=\"availability\" i]"
+  ]
+};
+
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const keys = Object.keys(CANONICAL_ARRAYS);
+    const { rows } = await client.query<{ key: string; value: string | null }>(
+      'SELECT key, value FROM system_settings WHERE key = ANY($1::text[])',
+      [keys]
+    );
+
+    const stored = new Map(rows.map((r) => [r.key, r.value]));
+
+    for (const key of keys) {
+      const canonical = JSON.stringify(CANONICAL_ARRAYS[key]);
+
+      if (!stored.has(key)) {
+        await client.query(
+          'INSERT INTO system_settings (key, value) VALUES ($1, $2::text) ON CONFLICT (key) DO NOTHING',
+          [key, canonical]
+        );
+        continue;
+      }
+
+      const value = stored.get(key);
+      let parsable = false;
+      if (value !== null && value !== undefined) {
+        try {
+          parsable = Array.isArray(JSON.parse(value));
+        } catch {
+          parsable = false;
+        }
+      }
+
+      if (!parsable) {
+        await client.query(
+          'UPDATE system_settings SET value = $1::text, updated_at = CURRENT_TIMESTAMP WHERE key = $2',
+          [canonical, key]
+        );
+      }
+    }
+
+    // #101: broaden the AI image evidence even where the row is already valid.
+    // Only replace the original narrow seed, so a tuned list is preserved.
+    const NARROW_AI_IMAGE = [
+      'link[rel="preload"][as="image"]',
+      'img#landingImage',
+      'img#main-image',
+      'img.main-image',
+      'img.hero-image',
+      'img[class*="product-image" i]',
+      'img[class*="product__image" i]',
+      'img[class*="gallery" i]',
+      'img[data-testid*="image" i]',
+    ];
+    const current = await client.query<{ value: string | null }>(
+      'SELECT value FROM system_settings WHERE key = $1',
+      ['generic_ai_image_selectors']
+    );
+    if (current.rows.length > 0 && current.rows[0].value) {
+      let parsed: unknown = null;
+      try {
+        parsed = JSON.parse(current.rows[0].value);
+      } catch {
+        parsed = null;
+      }
+      if (Array.isArray(parsed) && JSON.stringify(parsed) === JSON.stringify(NARROW_AI_IMAGE)) {
+        await client.query(
+          'UPDATE system_settings SET value = $1::text, updated_at = CURRENT_TIMESTAMP WHERE key = $2',
+          [JSON.stringify(CANONICAL_ARRAYS.generic_ai_image_selectors), 'generic_ai_image_selectors']
+        );
+      }
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async () => {
+  // Intentionally a no-op: restoring unparseable JSON serves nothing.
+};

--- a/backend/src/migrations/014_retailer_prefer_jsonld_image.ts
+++ b/backend/src/migrations/014_retailer_prefer_jsonld_image.ts
@@ -1,0 +1,33 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Per-retailer override for the JSON-LD image preference (issue #103).
+ *
+ * `prefer_jsonld_image` was a single system-wide setting, so a retailer whose
+ * structured data points at a directory, a thumbnail or an outright invalid
+ * asset could not be excluded without turning JSON-LD preference off for every
+ * retailer.
+ *
+ * The column is deliberately nullable, giving three states rather than two:
+ *
+ *   true   prefer JSON-LD images for this retailer
+ *   false  prefer the configured CSS/generic selectors for this retailer
+ *   NULL   inherit the global prefer_jsonld_image setting
+ *
+ * NULL is the default, so every existing retailer keeps behaving exactly as it
+ * does today and the global setting stays in charge until an administrator
+ * deliberately overrides one retailer.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  await pool.query(`
+    ALTER TABLE public.retailer_configs
+    ADD COLUMN IF NOT EXISTS prefer_jsonld_image boolean;
+  `);
+};
+
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  await pool.query(`
+    ALTER TABLE public.retailer_configs
+    DROP COLUMN IF EXISTS prefer_jsonld_image;
+  `);
+};

--- a/backend/src/models/types/retailer.ts
+++ b/backend/src/models/types/retailer.ts
@@ -24,6 +24,11 @@ export interface RetailerConfig {
   jsonld_image_key: string | null;
   jsonld_price_key: string | null;
   jsonld_name_key: string | null;
+  /**
+   * Tri-state override of the global prefer_jsonld_image setting:
+   * true prefer JSON-LD, false prefer CSS selectors, null inherit the global.
+   */
+  prefer_jsonld_image: boolean | null;
   user_agent: string | null;
   referrer: string | null;
   custom_selectors: any;

--- a/backend/src/services/domain/product/utils/metadata.ts
+++ b/backend/src/services/domain/product/utils/metadata.ts
@@ -1,3 +1,4 @@
+import { resolveImageUrl } from '../../../scraper/metadata/image-url';
 /**
  * Metadata validation and sanitization utilities for Products.
  */
@@ -32,15 +33,22 @@ export function sanitizeProductName(name: string | null | undefined): string | n
 
 /**
  * Validates and sanitizes a product image URL.
- * Returns null if the image is a placeholder.
+ * Returns null when the candidate should not replace what is already stored.
  */
 export function sanitizeProductImage(imageUrl: string | null | undefined, currentImageUrl: string | null): string | null {
   if (!imageUrl) return null;
-  if (imageUrl.includes('placeholder')) return null;
-  if (currentImageUrl === imageUrl) return null; // unchanged
+
+  // The scraper resolves candidates against the page before they get here, but
+  // this is also reached from paths that did not (imports, older rows, a
+  // hand-edited value), so re-check rather than trust the caller. A value that
+  // is still relative or still a placeholder must never replace a working URL.
+  const resolved = resolveImageUrl(imageUrl, null);
+  if (!resolved) return null;
+
+  if (currentImageUrl === resolved) return null; // unchanged
   // A differing scraped image replaces the stored one: retailers rotate CDN
   // asset URLs, and a stored URL that is never refreshed 404s forever once
   // the old asset disappears. Blocked/challenged scrapes extract no image,
   // so they cannot overwrite a good URL with junk.
-  return imageUrl;
+  return resolved;
 }

--- a/backend/src/services/domain/retailer/repositories/retailer-mutation.repository.ts
+++ b/backend/src/services/domain/retailer/repositories/retailer-mutation.repository.ts
@@ -42,6 +42,8 @@ export const retailerMutationRepository = {
     const executor = client || pool;
     const domain = config.domain?.toLowerCase();
     // $31..$52 — presence flags for PRESENCE_FIELDS, in that order.
+    // $53/$54 — prefer_jsonld_image value and its presence flag, appended so
+    // adding it did not renumber everything above.
     const presence = PRESENCE_FIELDS.map(field => config[field] !== undefined);
     const result = await executor.query(
       `INSERT INTO retailer_configs (
@@ -49,9 +51,9 @@ export const retailerMutationRepository = {
          name_selectors, price_selectors, deal_price_selectors, member_price_selectors, image_selectors, stock_selectors,
          in_stock_phrases, out_of_stock_phrases, pre_order_phrases, pre_order_price_selectors, user_agent, custom_selectors, active, description,
          retailer_name_selectors, jsonld_image_key, jsonld_price_key, jsonld_name_key, original_price_selectors, ai_selectors, exclusion_selectors,
-         selector_metadata
+         selector_metadata, prefer_jsonld_image
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $53)
        ON CONFLICT (domain) DO UPDATE SET
          name = CASE
            WHEN $30 = true THEN EXCLUDED.name
@@ -95,6 +97,7 @@ export const retailerMutationRepository = {
          jsonld_image_key = CASE WHEN $50 = true THEN EXCLUDED.jsonld_image_key ELSE retailer_configs.jsonld_image_key END,
          jsonld_price_key = CASE WHEN $51 = true THEN EXCLUDED.jsonld_price_key ELSE retailer_configs.jsonld_price_key END,
          jsonld_name_key = CASE WHEN $52 = true THEN EXCLUDED.jsonld_name_key ELSE retailer_configs.jsonld_name_key END,
+         prefer_jsonld_image = CASE WHEN $54 = true THEN EXCLUDED.prefer_jsonld_image ELSE retailer_configs.prefer_jsonld_image END,
          active = COALESCE(EXCLUDED.active, retailer_configs.active),
          updated_at = CURRENT_TIMESTAMP
        RETURNING *`,
@@ -129,7 +132,13 @@ export const retailerMutationRepository = {
         JSON.stringify(config.exclusion_selectors || []),
         JSON.stringify(config.selector_metadata || {}),
         config.forceNameRemoval ?? false,
-        ...presence
+        ...presence,
+        // $53/$54 are appended after the presence flags so the existing
+        // hand-numbered parameters keep their positions. A value of null here
+        // is meaningful -- it means "inherit the global setting" -- so it is
+        // passed through rather than collapsed with ||.
+        config.prefer_jsonld_image ?? null,
+        config.prefer_jsonld_image !== undefined,
       ]
     );
     return result.rows[0];

--- a/backend/src/services/scraper/metadata/image-url.ts
+++ b/backend/src/services/scraper/metadata/image-url.ts
@@ -1,0 +1,114 @@
+/**
+ * Image URL normalisation.
+ *
+ * A selector can match the right element and still yield an unusable URL. Pages
+ * routinely express image sources as:
+ *
+ *   /content/dam/example/image.jpg     relative to the site root
+ *   ../img/product.jpg                 relative to the current path
+ *   //cdn.example.com/image.jpg        protocol-relative
+ *   data:image/gif;base64,R0lGOD...    a 1x1 spacer standing in for a lazy image
+ *
+ * None of these were resolved against the page they came from, so they were
+ * stored and rendered as-is and the product showed a broken image.
+ */
+
+/**
+ * Fragments that identify a stand-in rather than a product image. Matched
+ * against the lowercased URL path.
+ *
+ * `placeholder` alone was the previous test, which missed every other spelling
+ * a CDN uses for the same thing.
+ */
+const PLACEHOLDER_MARKERS = [
+  'placeholder',
+  'no-image',
+  'noimage',
+  'no_image',
+  'image-not-available',
+  'notfound',
+  'not-found',
+  'default-product',
+  'dummy',
+  'blank.gif',
+  'blank.png',
+  'spacer.gif',
+  'spacer.png',
+  'transparent.gif',
+  'transparent.png',
+  'grey.gif',
+  'pixel.gif',
+  '1x1.',
+];
+
+/** Schemes that can never be fetched by a browser rendering the dashboard. */
+const UNUSABLE_SCHEMES = ['javascript:', 'about:', 'blob:', 'file:'];
+
+export function isPlaceholderImageUrl(url: string): boolean {
+  const lowered = url.toLowerCase();
+
+  // A data: URI is almost always the transparent spacer a lazy-loading script
+  // swaps out. Keep a genuinely large inline image, which is occasionally the
+  // real product shot on a small shop.
+  if (lowered.startsWith('data:')) return lowered.length < 1000;
+
+  let path = lowered;
+  try {
+    path = new URL(lowered).pathname;
+  } catch {
+    // Not absolute yet; match against the whole string.
+  }
+
+  return PLACEHOLDER_MARKERS.some((marker) => path.includes(marker));
+}
+
+/**
+ * Resolve a raw image value against the page it was scraped from.
+ *
+ * Returns null when the value cannot become something fetchable. A trailing
+ * slash is deliberately *not* a rejection: several CDNs serve images from a
+ * directory-style endpoint, and rejecting those threw away working images.
+ */
+export function resolveImageUrl(rawValue: string, pageUrl?: string | null): string | null {
+  const value = rawValue?.trim();
+  if (!value) return null;
+
+  if (UNUSABLE_SCHEMES.some((scheme) => value.toLowerCase().startsWith(scheme))) {
+    return null;
+  }
+
+  // Inline images are already self-contained; there is nothing to resolve.
+  if (value.toLowerCase().startsWith('data:')) {
+    return isPlaceholderImageUrl(value) ? null : value;
+  }
+
+  let resolved: URL;
+  try {
+    if (pageUrl) {
+      // Handles absolute, root-relative, path-relative and protocol-relative in
+      // one step: the URL constructor inherits scheme and host from the base.
+      resolved = new URL(value, pageUrl);
+    } else {
+      // Without a page to resolve against, only an absolute URL is usable. A
+      // protocol-relative one can still be rescued by assuming https.
+      resolved = value.startsWith('//') ? new URL(`https:${value}`) : new URL(value);
+    }
+  } catch {
+    return null;
+  }
+
+  if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null;
+  if (!resolved.hostname) return null;
+
+  // A page served over https resolving a protocol-relative URL correctly yields
+  // https. A page served over http would yield http for the same input, which a
+  // browser on an https dashboard then blocks as mixed content. Prefer https for
+  // the image regardless of how the page itself was fetched.
+  if (resolved.protocol === 'http:' && value.startsWith('//')) {
+    resolved.protocol = 'https:';
+  }
+
+  if (isPlaceholderImageUrl(resolved.href)) return null;
+
+  return resolved.href;
+}

--- a/backend/src/services/scraper/metadata/image.ts
+++ b/backend/src/services/scraper/metadata/image.ts
@@ -5,6 +5,7 @@ import { settingsCache } from '../../../utils/cache';
 import { extractMetaWithCandidates, findInJsonLd, evaluateMetadataSelectors } from './utils';
 import { parseSelector } from '../extractors/metadata';
 import { extractByRegex } from '../extractors/price-extraction';
+import { resolveImageUrl } from './image-url';
 
 export interface ImageDimensions {
   width: number;
@@ -134,16 +135,19 @@ export function evaluateImageSelectors(
   siteSelectors: string[],
   genericSelectors: string[],
   extractionSteps: string[],
-  html?: string
+  html?: string,
+  pageUrl?: string | null
 ): any[] {
   const candidates: any[] = [];
   const processedUrls = new Set<string>();
 
   const addCandidate = (url: string, method: string, selector: string, confidence: number) => {
-    const cleanUrl = url.trim();
-    if (!cleanUrl || processedUrls.has(cleanUrl)) return;
-    processedUrls.add(cleanUrl);
-    candidates.push({ value: cleanUrl, method, selector, confidence });
+    // Resolve here rather than at the end: a relative and an absolute form of
+    // the same image would otherwise both survive deduplication and compete.
+    const resolved = resolveImageUrl(url, pageUrl);
+    if (!resolved || processedUrls.has(resolved)) return;
+    processedUrls.add(resolved);
+    candidates.push({ value: resolved, method, selector, confidence });
   };
 
   const runSelectors = (selectors: string[], methodLabel: string, baseConfidence: number) => {
@@ -194,7 +198,8 @@ export async function extractProductImage(
   $: CheerioAPI,
   domainConfig: RetailerConfig | undefined,
   extractionSteps: string[],
-  result: ScrapedProductWithVoting
+  result: ScrapedProductWithVoting,
+  pageUrl?: string | null
 ): Promise<void> {
   const siteSelectors = domainConfig?.image_selectors || [];
   const genericSelectors = await settingsCache.getImageSelectors() || [];
@@ -203,7 +208,7 @@ export async function extractProductImage(
 
   extractionSteps.push(`Extract | Image | Prefer JSON-LD: ${preferJsonLd}`);
 
-  const candidates = evaluateImageSelectors($, siteSelectors, genericSelectors, extractionSteps, result.html || undefined);
+  const candidates = evaluateImageSelectors($, siteSelectors, genericSelectors, extractionSteps, result.html || undefined, pageUrl);
 
   result.imageCandidates.push(...candidates);
 
@@ -216,17 +221,24 @@ export async function extractProductImage(
     if (imgVal) {
       const imageUrl = Array.isArray(imgVal) ? imgVal[0] : imgVal;
       if (typeof imageUrl === 'string') {
-        result.imageCandidates?.push({ value: imageUrl.trim(), method: 'json-ld', confidence: 0.99 });
+        // JSON-LD is the worst offender for directory-style and relative values.
+        const resolved = resolveImageUrl(imageUrl, pageUrl);
+        if (resolved) {
+          result.imageCandidates?.push({ value: resolved, method: 'json-ld', confidence: 0.99 });
+        }
       }
     }
   });
 
-  const ogImg = $('meta[property="og:image"]').attr('content');
+  const ogImg = resolveImageUrl($('meta[property="og:image"]').attr('content') || '', pageUrl);
   if (ogImg) result.imageCandidates.push({ value: ogImg, method: 'og:image', confidence: 0.8 });
 
   $('link[rel="preload"][as="image"]').each((_, el) => {
     processImageElement(el, $, (url) => {
-      result.imageCandidates!.push({ value: url.trim(), method: 'link-preload', confidence: 0.85 });
+      const resolved = resolveImageUrl(url, pageUrl);
+      if (resolved) {
+        result.imageCandidates!.push({ value: resolved, method: 'link-preload', confidence: 0.85 });
+      }
     });
   });
 

--- a/backend/src/services/scraper/metadata/image.ts
+++ b/backend/src/services/scraper/metadata/image.ts
@@ -203,10 +203,17 @@ export async function extractProductImage(
 ): Promise<void> {
   const siteSelectors = domainConfig?.image_selectors || [];
   const genericSelectors = await settingsCache.getImageSelectors() || [];
-  const preferJsonLd = (await settingsCache.get('prefer_jsonld_image')) === 'true';
+  // Retailer override wins, then the global setting. Null on the retailer means
+  // inherit, which is why this is ?? and not ||: `false` is a real choice.
+  const globalPreferJsonLd = (await settingsCache.get('prefer_jsonld_image')) === 'true';
+  const retailerPreference = domainConfig?.prefer_jsonld_image;
+  const preferJsonLd = retailerPreference ?? globalPreferJsonLd;
   if (!result.imageCandidates) result.imageCandidates = [];
 
-  extractionSteps.push(`Extract | Image | Prefer JSON-LD: ${preferJsonLd}`);
+  const preferenceSource = retailerPreference === null || retailerPreference === undefined
+    ? `global (${globalPreferJsonLd})`
+    : `retailer override (${retailerPreference})`;
+  extractionSteps.push(`Extract | Image | Prefer JSON-LD: ${preferJsonLd} from ${preferenceSource}`);
 
   const candidates = evaluateImageSelectors($, siteSelectors, genericSelectors, extractionSteps, result.html || undefined, pageUrl);
 

--- a/backend/src/services/scraper/metadata/index.ts
+++ b/backend/src/services/scraper/metadata/index.ts
@@ -9,6 +9,7 @@ import { extractProductImage } from './image';
 export * from './stock';
 export * from './title';
 export * from './image';
+export * from './image-url';
 export * from './utils';
 
 /**
@@ -18,7 +19,8 @@ export async function extractMetadata(
   $: CheerioAPI,
   domainConfig: RetailerConfig | undefined,
   extractionSteps: string[],
-  result: ScrapedProductWithVoting
+  result: ScrapedProductWithVoting,
+  pageUrl?: string | null
 ): Promise<void> {
   // 1. Stock Status
   await extractProductStock($, domainConfig, extractionSteps, result);
@@ -27,5 +29,5 @@ export async function extractMetadata(
   await extractProductTitle($, domainConfig, extractionSteps, result);
 
   // 3. Image
-  await extractProductImage($, domainConfig, extractionSteps, result);
+  await extractProductImage($, domainConfig, extractionSteps, result, pageUrl);
 }

--- a/backend/src/services/scraper/orchestration/extraction.ts
+++ b/backend/src/services/scraper/orchestration/extraction.ts
@@ -56,7 +56,7 @@ export async function runExtractionPhase(
   }
 
   // 1. Metadata (Name, Image, Stock) first
-  await extractMetadata($, domainConfig || undefined, extractionSteps, result);
+  await extractMetadata($, domainConfig || undefined, extractionSteps, result, url);
 
   // 2. Extract Price Candidates
   extractionSteps.push(`HTML | Metadata | Length: ${html.length} chars`);

--- a/backend/src/utils/system/cache/SettingsCache.ts
+++ b/backend/src/utils/system/cache/SettingsCache.ts
@@ -29,16 +29,32 @@ const DEFAULT_CONFIG = {
     '[data-price-amount]',
     '[data-product-price]'
   ],
+  // These are the selectors used to gather *evidence* for AI auto-mapping. They
+  // must stay at least as broad as generic_image_selectors (seeded by
+  // 006_seed_generic_selectors), because the AI can only propose a selector for
+  // an element it was shown. When this list was the narrower of the two, pages
+  // whose image is matched by the broad `img[class*="product"]` were presented
+  // to the AI only through narrow patterns, so it learned an over-specific
+  // selector -- and site-specific selectors then outrank the generic one that
+  // would have worked.
   genericAIImageSelectors: [
     'link[rel="preload"][as="image"]',
+    '[itemprop="image"]',
+    '[property="og:image"]',
     'img#landingImage',
     'img#main-image',
     'img.main-image',
     'img.hero-image',
     'img[class*="product-image" i]',
     'img[class*="product__image" i]',
+    'img[class*="product" i]',
     'img[class*="gallery" i]',
-    'img[data-testid*="image" i]'
+    'img[data-testid*="image" i]',
+    '[data-automation-test-id*="image" i]',
+    '[data-testid*="image" i]',
+    '.product-image img',
+    '.main-image img',
+    '[data-zoom-image]'
   ],
   browserTimeout: 60000,
   browserDelay: 3000,
@@ -79,7 +95,15 @@ export class SystemSettingsCache {
       try {
         result = JSON.parse(this.settings[key]);
       } catch (e) {
-        // use default
+        // Falling back silently hid a real bug for a long time: 001_baseline
+        // stored several of these settings as unparseable JSON, so extraction
+        // quietly ran on the hardcoded defaults instead of the seeded set and
+        // nothing said so. Repaired by 013, but say it out loud if it recurs.
+        logger.warn(
+          `Settings | ${key} is not valid JSON; falling back to the built-in default. ` +
+            `Re-save it under Admin -> Extraction Rules to fix.`,
+          'System'
+        );
       }
     }
     this.parsedArrays.set(key, result);

--- a/backend/tests/unit/image-jsonld-preference.test.ts
+++ b/backend/tests/unit/image-jsonld-preference.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as cheerio from 'cheerio';
+
+/**
+ * The per-retailer JSON-LD image preference is a tri-state: true, false, and
+ * null meaning "inherit the global setting". `false` and `null` are easy to
+ * conflate — a `||` instead of a `??` silently turns an explicit "prefer CSS
+ * selectors" back into the global value.
+ */
+
+const settingsGet = vi.fn();
+
+vi.mock('../../src/utils/cache', () => ({
+  settingsCache: {
+    get: (key: string) => settingsGet(key),
+    getImageSelectors: async () => ['img[class*="product"]'],
+    getAISettings: async () => ({ jsonld_image_key: 'image' }),
+  },
+}));
+
+const PAGE = 'https://shop.example.com/p/1';
+
+const HTML = `
+  <html><body>
+    <script type="application/ld+json">
+      {"@type":"Product","name":"Widget","image":"https://cdn.example.com/from-jsonld.jpg"}
+    </script>
+    <img class="product-main" src="https://cdn.example.com/from-css.jpg">
+  </body></html>
+`;
+
+async function topCandidateMethod(retailerPreference: boolean | null | undefined, globalSetting: string) {
+  settingsGet.mockImplementation(async (key: string) =>
+    key === 'prefer_jsonld_image' ? globalSetting : null
+  );
+
+  const { extractProductImage } = await import('../../src/services/scraper/metadata/image');
+  const $ = cheerio.load(HTML);
+  const steps: string[] = [];
+  const result: any = { imageCandidates: [] };
+
+  const domainConfig: any =
+    retailerPreference === undefined
+      ? { image_selectors: ['img.product-main'] }
+      : { image_selectors: ['img.product-main'], prefer_jsonld_image: retailerPreference };
+
+  await extractProductImage($, domainConfig, steps, result, PAGE);
+
+  return { method: result.imageCandidates[0]?.method as string, steps };
+}
+
+describe('Per-retailer JSON-LD image preference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inherits the global setting when the retailer has no override', async () => {
+    expect((await topCandidateMethod(null, 'true')).method).toBe('json-ld');
+    expect((await topCandidateMethod(null, 'false')).method).not.toBe('json-ld');
+  });
+
+  it('inherits the global setting when the column is absent entirely', async () => {
+    // A retailer row written before the column existed.
+    expect((await topCandidateMethod(undefined, 'true')).method).toBe('json-ld');
+  });
+
+  it('lets a retailer opt out while the global setting stays on', async () => {
+    // The case the issue is about: JSON-LD stays preferred everywhere else, but
+    // this retailer's structured data points at something unusable.
+    const { method } = await topCandidateMethod(false, 'true');
+    expect(method).not.toBe('json-ld');
+  });
+
+  it('lets a retailer opt in while the global setting is off', async () => {
+    expect((await topCandidateMethod(true, 'false')).method).toBe('json-ld');
+  });
+
+  it('records which source decided the preference', async () => {
+    const override = await topCandidateMethod(false, 'true');
+    expect(override.steps.join('\n')).toContain('retailer override');
+
+    const inherited = await topCandidateMethod(null, 'true');
+    expect(inherited.steps.join('\n')).toContain('global');
+  });
+});

--- a/backend/tests/unit/image-url.test.ts
+++ b/backend/tests/unit/image-url.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { resolveImageUrl, isPlaceholderImageUrl } from '../../src/services/scraper/metadata/image-url';
+import { sanitizeProductImage } from '../../src/services/domain/product/utils/metadata';
+
+const PAGE = 'https://shop.example.com/catalog/widgets/blue-widget';
+
+describe('resolveImageUrl', () => {
+  describe('resolves against the page it was scraped from', () => {
+    it('resolves a root-relative path', () => {
+      expect(resolveImageUrl('/content/dam/example/image.jpg', PAGE)).toBe(
+        'https://shop.example.com/content/dam/example/image.jpg'
+      );
+    });
+
+    it('resolves a path-relative value against the current directory', () => {
+      expect(resolveImageUrl('../img/product.jpg', PAGE)).toBe(
+        'https://shop.example.com/catalog/img/product.jpg'
+      );
+    });
+
+    it('normalizes a protocol-relative URL', () => {
+      expect(resolveImageUrl('//cdn.example.com/image.jpg', PAGE)).toBe(
+        'https://cdn.example.com/image.jpg'
+      );
+    });
+
+    it('leaves an absolute URL alone', () => {
+      expect(resolveImageUrl('https://cdn.example.com/a.jpg', PAGE)).toBe(
+        'https://cdn.example.com/a.jpg'
+      );
+    });
+
+    it('upgrades a protocol-relative URL to https even from an http page', () => {
+      // The dashboard is usually served over https; an http image is blocked
+      // there as mixed content and shows as broken.
+      expect(resolveImageUrl('//cdn.example.com/a.jpg', 'http://shop.example.com/p')).toBe(
+        'https://cdn.example.com/a.jpg'
+      );
+    });
+  });
+
+  describe('accepts URLs that are valid but unusual', () => {
+    it('keeps a dynamic endpoint ending in a slash', () => {
+      // Several CDNs serve images from a directory-style endpoint. Rejecting
+      // these threw away working images.
+      expect(resolveImageUrl('https://cdn.example.com/img/12345/', PAGE)).toBe(
+        'https://cdn.example.com/img/12345/'
+      );
+    });
+
+    it('keeps a query-string image endpoint', () => {
+      expect(resolveImageUrl('/render?sku=99&w=800', PAGE)).toBe(
+        'https://shop.example.com/render?sku=99&w=800'
+      );
+    });
+
+    it('keeps a large inline image', () => {
+      const big = `data:image/png;base64,${'A'.repeat(2000)}`;
+      expect(resolveImageUrl(big, PAGE)).toBe(big);
+    });
+  });
+
+  describe('rejects what cannot be displayed', () => {
+    it('rejects an empty or whitespace value', () => {
+      expect(resolveImageUrl('', PAGE)).toBeNull();
+      expect(resolveImageUrl('   ', PAGE)).toBeNull();
+    });
+
+    it('rejects non-fetchable schemes', () => {
+      expect(resolveImageUrl('javascript:void(0)', PAGE)).toBeNull();
+      expect(resolveImageUrl('about:blank', PAGE)).toBeNull();
+      expect(resolveImageUrl('file:///etc/hosts', PAGE)).toBeNull();
+    });
+
+    it('rejects a tiny inline spacer', () => {
+      // The 1x1 transparent gif a lazy-loading script swaps out.
+      expect(
+        resolveImageUrl('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', PAGE)
+      ).toBeNull();
+    });
+
+    it('rejects placeholder assets under several spellings', () => {
+      for (const path of [
+        '/img/placeholder.jpg',
+        '/assets/no-image.png',
+        '/static/noimage.jpg',
+        '/i/image-not-available.webp',
+        '/img/spacer.gif',
+        '/img/1x1.png',
+        '/media/default-product.jpg',
+      ]) {
+        expect(resolveImageUrl(path, PAGE), path).toBeNull();
+      }
+    });
+
+    it('rejects a relative value when there is no page to resolve against', () => {
+      expect(resolveImageUrl('/content/dam/image.jpg', null)).toBeNull();
+    });
+
+    it('rejects an unparseable value', () => {
+      expect(resolveImageUrl('http://', PAGE)).toBeNull();
+    });
+  });
+
+  it('does not treat a product whose name contains a marker as a placeholder', () => {
+    // The marker check runs on the path, and only for known stand-in filenames.
+    expect(isPlaceholderImageUrl('https://cdn.example.com/products/widget.jpg')).toBe(false);
+  });
+});
+
+describe('sanitizeProductImage', () => {
+  it('refuses to overwrite a stored image with an unresolvable value', () => {
+    const stored = 'https://cdn.example.com/good.jpg';
+    expect(sanitizeProductImage('/still/relative.jpg', stored)).toBeNull();
+    expect(sanitizeProductImage('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', stored)).toBeNull();
+    expect(sanitizeProductImage('/img/placeholder.png', stored)).toBeNull();
+  });
+
+  it('still lets a genuinely new image replace a stale one', () => {
+    // Retailers rotate CDN asset URLs; a stored URL that never refreshes 404s
+    // forever once the old asset disappears.
+    expect(
+      sanitizeProductImage('https://cdn.example.com/new.jpg', 'https://cdn.example.com/old.jpg')
+    ).toBe('https://cdn.example.com/new.jpg');
+  });
+
+  it('reports no change when the image is unchanged', () => {
+    expect(
+      sanitizeProductImage('https://cdn.example.com/same.jpg', 'https://cdn.example.com/same.jpg')
+    ).toBeNull();
+  });
+});

--- a/docs/admin/selectors.md
+++ b/docs/admin/selectors.md
@@ -76,3 +76,27 @@ Every custom selector you define has a health score calculated by the database. 
 * **Score Formula**: `score = match_count - consecutive_failures * 2`
 * When a product is successfully scraped, the winning selector gets its `match_count` incremented, `consecutive_failures` reset to `0`, and is promoted to the top of the list (`index 0`).
 * Stale selectors that fail will gradually lose points and be evicted.
+
+## Prefer JSON-LD Images (per retailer)
+
+`Prefer JSON-LD Images` under **Admin -> Retailers -> [Retailer] -> Extraction
+Parameters** decides whether a JSON-LD image outranks the configured CSS and
+generic image selectors for that one retailer.
+
+| Setting | Behaviour |
+|---|---|
+| Use global setting | Follow the system-wide **Prefer JSON-LD Images** toggle (the default) |
+| Prefer JSON-LD images | Rank JSON-LD image candidates first for this retailer |
+| Prefer CSS selectors | Rank configured and generic image selectors first for this retailer |
+
+Resolution order is retailer override, then the global setting.
+
+Use the override for retailers whose structured data contains a thumbnail, a
+directory-style path such as `/content/dam/example/product/`, or an otherwise
+unusable image, while leaving JSON-LD preference on everywhere else. The scrape
+trace records which source decided it:
+
+```text
+Extract | Image | Prefer JSON-LD: false from retailer override (false)
+Extract | Image | Prefer JSON-LD: true from global (true)
+```

--- a/frontend/src/features/admin/components/sections/retailer-config/ExtractionParamsSection.tsx
+++ b/frontend/src/features/admin/components/sections/retailer-config/ExtractionParamsSection.tsx
@@ -1,4 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { RetailerConfig } from '../../../../../types/api';
+import { adminSystemSettingsQuery } from '../../../../../api/queries';
 import { UnifiedSelectorManager } from '../../index';
 import Icon from '../../../../../components/Icon';
 
@@ -47,6 +49,14 @@ export default function ExtractionParamsSection({
   customSelectorsJson,
   setCustomSelectorsJson
 }: ExtractionParamsSectionProps) {
+  // Name the value being inherited: "Use global setting" on its own leaves an
+  // admin guessing which behaviour that actually is.
+  const { data: systemSettings } = useQuery(adminSystemSettingsQuery());
+  const globalPrefersJsonLd =
+    systemSettings?.prefer_jsonld_image === true ||
+    systemSettings?.prefer_jsonld_image === 'true';
+  const globalPreferLabel = globalPrefersJsonLd ? 'JSON-LD images' : 'CSS selectors';
+
   return (
     <div className="extraction-params-section">
       <div className="form-grid">
@@ -88,6 +98,34 @@ export default function ExtractionParamsSection({
               value={draftConfig.jsonld_image_key || ''} 
               onChange={e => onUpdateConfig({ jsonld_image_key: e.target.value })} 
             />
+          </div>
+          <div className="form-group mt-2">
+            <label htmlFor="prefer-jsonld-image">Prefer JSON-LD Images</label>
+            <select
+              id="prefer-jsonld-image"
+              className="form-control"
+              value={
+                draftConfig.prefer_jsonld_image === true
+                  ? 'true'
+                  : draftConfig.prefer_jsonld_image === false
+                    ? 'false'
+                    : 'inherit'
+              }
+              onChange={e =>
+                onUpdateConfig({
+                  prefer_jsonld_image:
+                    e.target.value === 'inherit' ? null : e.target.value === 'true',
+                })
+              }
+            >
+              <option value="inherit">Use global setting ({globalPreferLabel})</option>
+              <option value="true">Prefer JSON-LD images</option>
+              <option value="false">Prefer CSS selectors</option>
+            </select>
+            <small style={{ color: 'var(--text-muted)' }}>
+              Override this for retailers whose structured data points at a
+              thumbnail, a directory, or an otherwise unusable image.
+            </small>
           </div>
         </div>
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -209,6 +209,8 @@ export interface RetailerConfig {
   pre_order_price_selectors: string[];
   exclusion_selectors: string[];
   jsonld_image_key: string | null;
+  /** true prefer JSON-LD, false prefer CSS selectors, null inherit the global setting. */
+  prefer_jsonld_image: boolean | null;
   jsonld_price_key: string | null;
   jsonld_name_key: string | null;
   user_agent: string | null;


### PR DESCRIPTION
Wave 3 of the backlog plan: the product image cluster. Closes #101, #102 and #103 as three commits.

Chasing #101 turned up a cause that is considerably wider than the image selectors, so please read that part first.

---

## 1. Selector settings were stored as invalid JSON (#101)

`001_baseline.ts` seeds `system_settings` using Postgres `E''` escape strings. In an `E''` string `\\"` is an escape sequence meaning a bare quote, so the JSON escaping is stripped on the way in and any selector containing a quoted attribute lands unparseable:

```
stored:   ["link[rel="preload"][as="image"]", ...]
intended: ["link[rel=\\"preload\\"][as=\\"image\\"]", ...]
```

`006_seed_generic_selectors` only writes rows whose value `IS NULL`, so it never repaired them, and `SettingsCache.getArray` caught the parse error and fell back to its hardcoded default **without a word**. Three settings were affected on every install:

| Setting | Seeded | Actually used |
|---|---|---|
| `generic_stock_selectors` | 12 entries | 5 hardcoded fallbacks |
| `generic_ai_image_selectors` | 9 entries | 9 narrower fallbacks |
| `generic_ai_price_selectors` | 9 entries | 9 hardcoded fallbacks |

So **generic stock detection has been running on under half its intended selectors** — it never saw any of the `data-testid`/`data-automation-test-id`/`data-test-id` stock and availability patterns. That is worth knowing independently of the image work, and may bear on the stock-status issues elsewhere in the backlog.

And it is #101 directly: the AI can only propose a selector for an element it was shown, so being shown a narrower set than extraction itself uses is exactly how it learned `img.product-image` where `img[class*="product"]` was correct — and site-specific selectors then outrank the generic one that would have worked.

**Fix:** migration 013 repairs any unparseable row from a canonical map, writing through **bind parameters** rather than string literals, which is what avoids the whole class of bug. Rows an administrator has edited into valid JSON are left alone. The AI image evidence list is broadened to match the extraction list, and only the original narrow seed is replaced so a tuned list survives. `getArray` now warns instead of falling back silently — this hid for a long time precisely because nothing said anything.

`001_baseline` is generated by `database/v2-migration/generate-baseline.py` and must not be hand-edited, so **the generator still emits the bad escaping for a fresh baseline** and 013 corrects the result afterwards. Worth fixing at the generator; I did not touch it here.

---

## 2. Image URLs were never resolved against the page (#102)

A selector could match the right element and still produce an unusable URL, because nothing resolved the extracted value against the page it came from. Relative paths, protocol-relative URLs and lazy-loading spacers were stored and rendered as-is, so the product showed a broken image at 100% confidence.

- Thread the scraped page URL into image extraction and resolve every candidate through it — selector matches, JSON-LD, `og:image` and preload links. JSON-LD is the worst offender for directory-style values.
- Resolve **before** deduplication, so a relative and an absolute form of the same image no longer both survive and compete for the top slot.
- Recognise placeholders under the spellings CDNs actually use. The previous test was a single `includes('placeholder')`, which missed `no-image`, `spacer.gif`, `1x1.`, `default-product` and the rest. A small `data:` URI is treated as the transparent spacer it almost always is; a large one is kept.
- Prefer https when upgrading a protocol-relative URL, since an http image is blocked as mixed content on an https dashboard.
- `sanitizeProductImage` re-resolves rather than trusting its caller, so an unusable value can never overwrite a working stored image.

A trailing slash is deliberately **not** a rejection — several CDNs serve images from a directory-style endpoint, and the issue explicitly calls that out as something to keep.

**Not done:** the optional HTTP `Content-Type` validation. That adds a network round trip to every scrape against hosts already fronted by bot protection, and a CDN that refuses HEAD would reject working images. The deterministic half above fixes the reported failures without that cost. Say the word and I will add it behind a setting.

---

## 3. Per-retailer JSON-LD image preference (#103)

Nullable `retailer_configs.prefer_jsonld_image`: `true` prefer JSON-LD, `false` prefer CSS selectors, `NULL` inherit the global. NULL is the default, so existing retailers are unchanged.

Resolution uses `??` rather than `||` — `false` is a real choice and `||` would silently turn "prefer CSS selectors" back into the global value. The scrape trace now records which source decided it.

The upsert numbers its parameters by hand, so the new value and presence flag are appended as `$53`/`$54` rather than inserted, leaving every existing position untouched.

The admin control names the value it inherits — "Use global setting (CSS selectors)" — because "Use global setting" alone leaves an admin guessing.

---

## Verification

I installed PostgreSQL 16 locally for this, since CLAUDE.md requires migrations to be tested against a real database and none was available.

- Full migration chain from an empty database, twice, for idempotency.
- 013: a corrupt value is repaired; a customised value is preserved; a missing row is seeded.
- 014: column applies and re-applies; the tri-state round-trips through the upsert across all six transitions, **including that an unrelated selector or key update does not clobber an override**.
- 23 new unit tests (backend total 142 -> 165).
- `tsc`, frontend build and typecheck, emoji lint, `git diff --check` — all pass.

Closes #101
Closes #102
Closes #103