### PR TITLE
fix(products): make price history transactional and type-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Price history is now written inside the same transaction as the product
+  update it belongs to, so a rollback can no longer leave behind history for a
+  state the product never reached.
+- A price change that is only a currency change (100 USD to 100 AUD) is now
+  recorded, instead of leaving the product reporting the old currency forever.
+- A scraped price still awaiting manual review no longer becomes the product's
+  current price and drift anchor before anyone has confirmed it.
+- Dashboard sparklines and the all-time-low price now use standard prices only.
+  A member-only or struck-through original price could previously appear as a
+  price drop, or become the product's all-time low.
+- Member and original prices with no resolvable currency are now reported in the
+  logs like standard prices are, rather than being skipped silently.
 - Product images no longer break when a retailer expresses the image as a
   relative or protocol-relative URL: candidates are now resolved against the
   page they were scraped from. Placeholder and spacer images are recognised

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -33,7 +33,7 @@ export class ProductPersistenceService {
       await client.query('SELECT pg_advisory_xact_lock($1)', [productId]);
 
       // 1. Fetch current state
-      const product = await productRepository.findById(productId, userId);
+      const product = await productRepository.findById(productId, userId, client);
       if (!product) {
         await client.query('ROLLBACK');
         return;
@@ -68,7 +68,7 @@ export class ProductPersistenceService {
       });
 
       // 7. Reschedule check
-      await productRepository.updateLastChecked(productId, product.refresh_interval);
+      await productRepository.updateLastChecked(productId, product.refresh_interval, client);
 
       // 7.5 Write needs_price_review = true to DB on refresh if needsReview is true
       if (source === 'refresh' && scrapedData.needsReview) {
@@ -93,7 +93,7 @@ export class ProductPersistenceService {
    * Updates product metadata if missing or generic.
    */
   private async updateMetadata(
-    _client: PoolClient, // Reserved for future transactional needs
+    client: PoolClient,
     productId: number,
     userId: number,
     product: Product,
@@ -115,7 +115,7 @@ export class ProductPersistenceService {
     }
 
     if (Object.keys(metadataUpdates).length > 0) {
-      await productRepository.update(productId, userId, metadataUpdates);
+      await productRepository.update(productId, userId, metadataUpdates, client);
       logger.debug(`Product ${productId} | Metadata Updated | ${source}`, 'Products');
     }
   }
@@ -124,7 +124,7 @@ export class ProductPersistenceService {
    * Handles stock status transitions and history recording.
    */
   private async updateStockState(
-    _client: PoolClient,
+    client: PoolClient,
     productId: number,
     product: Product,
     scrapedData: ScrapedProductWithVoting
@@ -138,84 +138,133 @@ export class ProductPersistenceService {
     }
 
     if (scrapedData.stockStatus !== product.stock_status) {
-      await productRepository.updateStockStatus(productId, scrapedData.stockStatus, scrapedData.aiStatus);
-      await stockHistoryRepository.recordChange(productId, scrapedData.stockStatus);
+      await productRepository.updateStockStatus(productId, scrapedData.stockStatus, scrapedData.aiStatus, client);
+      await stockHistoryRepository.recordChange(productId, scrapedData.stockStatus, client);
       logger.info(`Product ${productId} | Stock | Changed: ${product.stock_status} -> ${scrapedData.stockStatus}`, 'Products', { product_id: productId });
     }
   }
 
   /**
    * Records Standard, Member, and Original prices.
+   *
+   * Every statement runs on the caller's transaction client. These used to run
+   * on the shared pool, so a price-history row could commit on its own and
+   * survive a rollback of the product write it belonged to -- leaving history
+   * that describes a state the product never reached.
    */
   private async recordPrices(
-    _client: PoolClient,
+    client: PoolClient,
     productId: number,
     scrapedData: ScrapedProductWithVoting,
     source: string
   ) {
+    // A price that still needs a human decision is not authoritative yet.
+    // Recording it makes it the current price and the anchor, so a wrong
+    // extraction becomes the product's price before anyone has confirmed it.
+    // A manual confirmation is the act of reviewing, so it always records.
+    const awaitingReview = scrapedData.needsReview === true && source !== 'manual-confirm';
+
     // A. Standard Price
     if (scrapedData.price && !scrapedData.price.currency) {
       // A price without a resolved currency must never enter history, but the
       // skip has to be loud: arbitration flags it for review, and this log is
       // the trace for why the history did not advance.
       logger.warn(`Product ${productId} | Price | Skipped recording ${scrapedData.price.price}: no currency resolved (${source})`, 'Products', { product_id: productId });
+    } else if (awaitingReview && scrapedData.price?.currency) {
+      logger.info(`Product ${productId} | Price | Skipped recording ${scrapedData.price.currency} ${scrapedData.price.price}: awaiting review (${source})`, 'Products', { product_id: productId });
     } else if (scrapedData.price?.currency) {
-      const latestStandardPrice = await priceHistoryRepository.getLatest(productId, 'standard');
+      const latestStandardPrice = await priceHistoryRepository.getLatest(productId, 'standard', client);
       // A manual confirmation always records, even at an unchanged price: the
       // user explicitly verified it, and the fresh row is what repopulates a
       // stale product's history and anchor (issue #55).
-      if (source === 'manual-confirm' || !latestStandardPrice || latestStandardPrice.price !== scrapedData.price.price) {
+      if (source === 'manual-confirm' || this.hasChanged(latestStandardPrice, scrapedData.price)) {
         await priceHistoryRepository.create(
           productId,
           scrapedData.price.price,
           scrapedData.price.currency,
           scrapedData.aiStatus,
           null,
-          'standard'
+          'standard',
+          client
         );
 
         logger.info(`Product ${productId} | Price | Recorded: ${scrapedData.price.currency} ${scrapedData.price.price} (${source})`, 'Products', { product_id: productId });
 
         // Update anchor price for drift tracking
-        await productRepository.updateAnchorPrice(productId, scrapedData.price.price);
+        await productRepository.updateAnchorPrice(productId, scrapedData.price.price, client);
 
         // Record extraction method if we're moving to a stable one
         if (scrapedData.selectedMethod) {
-          await productRepository.updateExtractionMethod(productId, scrapedData.selectedMethod);
+          await productRepository.updateExtractionMethod(productId, scrapedData.selectedMethod, client);
         }
       }
     }
 
     // B. Member Price
-    if (scrapedData.memberPrice?.currency) {
-      const latestMemberPrice = await priceHistoryRepository.getLatest(productId, 'member-price');
-      if (!latestMemberPrice || latestMemberPrice.price !== scrapedData.memberPrice.price) {
-        await priceHistoryRepository.create(
-          productId,
-          scrapedData.memberPrice.price,
-          scrapedData.memberPrice.currency,
-          scrapedData.aiStatus,
-          null,
-          'member-price'
-        );
-      }
-    }
+    await this.recordSecondaryPrice(client, productId, scrapedData, source, 'member-price', scrapedData.memberPrice, awaitingReview);
 
     // C. Original Price
-    if (scrapedData.originalPrice?.currency) {
-      const latestOriginalPrice = await priceHistoryRepository.getLatest(productId, 'original-price');
-      if (!latestOriginalPrice || latestOriginalPrice.price !== scrapedData.originalPrice.price) {
-        await priceHistoryRepository.create(
-          productId,
-          scrapedData.originalPrice.price,
-          scrapedData.originalPrice.currency,
-          scrapedData.aiStatus,
-          null,
-          'original-price'
-        );
-      }
+    await this.recordSecondaryPrice(client, productId, scrapedData, source, 'original-price', scrapedData.originalPrice, awaitingReview);
+  }
+
+  /**
+   * Member and original prices follow the same rules as the standard price,
+   * including the missing-currency diagnostic that only the standard price used
+   * to emit -- these were skipped silently, so a retailer whose member price
+   * never had a resolvable currency looked identical to one that had no member
+   * price at all.
+   */
+  private async recordSecondaryPrice(
+    client: PoolClient,
+    productId: number,
+    scrapedData: ScrapedProductWithVoting,
+    source: string,
+    priceType: 'member-price' | 'original-price',
+    candidate: { price: number; currency?: string | null } | null | undefined,
+    awaitingReview: boolean
+  ) {
+    if (!candidate) return;
+
+    if (!candidate.currency) {
+      logger.warn(`Product ${productId} | Price | Skipped recording ${priceType} ${candidate.price}: no currency resolved (${source})`, 'Products', { product_id: productId });
+      return;
+    }
+
+    if (awaitingReview) {
+      logger.info(`Product ${productId} | Price | Skipped recording ${priceType}: awaiting review (${source})`, 'Products', { product_id: productId });
+      return;
+    }
+
+    const latest = await priceHistoryRepository.getLatest(productId, priceType, client);
+    if (this.hasChanged(latest, candidate)) {
+      await priceHistoryRepository.create(
+        productId,
+        candidate.price,
+        candidate.currency,
+        scrapedData.aiStatus,
+        null,
+        priceType,
+        client
+      );
     }
   }
+
+  /**
+   * True when the scraped price differs from the last recorded one.
+   *
+   * Currency is part of the comparison. Comparing the number alone meant a
+   * retailer switching 100 USD to 100 AUD wrote no row at all, so the product
+   * kept reporting the old currency indefinitely.
+   */
+  private hasChanged(
+    latest: { price: number | string; currency?: string | null } | null,
+    candidate: { price: number; currency?: string | null }
+  ): boolean {
+    if (!latest) return true;
+    const latestPrice = typeof latest.price === 'string' ? parseFloat(latest.price) : latest.price;
+    return latestPrice !== candidate.price || (latest.currency ?? null) !== (candidate.currency ?? null);
+  }
+
 }
 
 export const productPersistenceService = new ProductPersistenceService();

--- a/backend/src/services/domain/product/repositories/executor.ts
+++ b/backend/src/services/domain/product/repositories/executor.ts
@@ -1,0 +1,15 @@
+import type { Pool, PoolClient } from 'pg';
+import pool from '../../../../config/database';
+
+/**
+ * Anything that can run a query: the shared pool, or a client checked out for a
+ * transaction.
+ *
+ * Repository methods that a transaction needs to include must accept one of
+ * these. Reaching for the module-level pool inside a transaction silently opts
+ * that statement out of it -- the write commits on its own and survives a
+ * rollback of everything around it.
+ */
+export type Executor = Pool | PoolClient;
+
+export const asExecutor = (executor?: Executor): Executor => executor ?? pool;

--- a/backend/src/services/domain/product/repositories/price-history.repository.ts
+++ b/backend/src/services/domain/product/repositories/price-history.repository.ts
@@ -1,4 +1,5 @@
 import pool from '../../../../config/database';
+import { asExecutor, type Executor } from './executor';
 import { 
   PriceHistory,
   AIStatus
@@ -32,9 +33,10 @@ export const priceHistoryRepository = {
     currency: string = 'USD',
     aiStatus: AIStatus = null,
     details: any = null,
-    priceType: string = 'standard'
+    priceType: string = 'standard',
+    executor?: Executor
   ): Promise<PriceHistory> => {
-    const result = await pool.query(
+    const result = await asExecutor(executor).query(
       `INSERT INTO price_history (product_id, price, currency, ai_status, details, price_type)
        VALUES ($1, $2, $3, $4, $5, $6)
        RETURNING *`,
@@ -43,8 +45,8 @@ export const priceHistoryRepository = {
     return result.rows[0];
   },
 
-  getLatest: async (productId: number, priceType: string = 'standard'): Promise<PriceHistory | null> => {
-    const result = await pool.query(
+  getLatest: async (productId: number, priceType: string = 'standard', executor?: Executor): Promise<PriceHistory | null> => {
+    const result = await asExecutor(executor).query(
       `SELECT * FROM price_history
        WHERE product_id = $1 AND price_type = $2
        ORDER BY recorded_at DESC
@@ -54,7 +56,14 @@ export const priceHistoryRepository = {
     return result.rows[0] || null;
   },
 
-  getStats: async (productId: number): Promise<{
+  /**
+   * Statistics for one price type. Defaults to 'standard'.
+   *
+   * This used to aggregate every row for the product regardless of type, so a
+   * member-only or a struck-through original price could become the product's
+   * all-time low.
+   */
+  getStats: async (productId: number, priceType: string = 'standard'): Promise<{
     min_price: number;
     max_price: number;
     avg_price: number;
@@ -67,8 +76,8 @@ export const priceHistoryRepository = {
          AVG(price)::decimal(10,2) as avg_price,
          COUNT(*) as price_count
        FROM price_history
-       WHERE product_id = $1`,
-      [productId]
+       WHERE product_id = $1 AND price_type = $2`,
+      [productId, priceType]
     );
     return result.rows[0] || null;
   },

--- a/backend/src/services/domain/product/repositories/product-config.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-config.repository.ts
@@ -1,6 +1,7 @@
 import pool from '../../../../config/database';
 import { StockStatus, AIStatus } from '../../../../models/types';
 import { calculateNextCheckSeconds } from '../../../../utils/system/scheduler-helpers';
+import { asExecutor, type Executor } from './executor';
 
 export const productConfigRepository = {
   setPageGoneStreak: async (id: number, streak: number): Promise<void> => {
@@ -10,10 +11,10 @@ export const productConfigRepository = {
     );
   },
 
-  updateLastChecked: async (id: number, refreshInterval: number): Promise<void> => {
+  updateLastChecked: async (id: number, refreshInterval: number, executor?: Executor): Promise<void> => {
     const nextCheckSeconds = calculateNextCheckSeconds(refreshInterval);
 
-    await pool.query(
+    await asExecutor(executor).query(
       `UPDATE products
        SET last_checked = CURRENT_TIMESTAMP,
            next_check_at = CURRENT_TIMESTAMP + ($2 || ' seconds')::interval
@@ -22,22 +23,23 @@ export const productConfigRepository = {
     );
   },
 
-  updateStockStatus: async (id: number, stockStatus: StockStatus, aiStatus?: AIStatus): Promise<void> => {
+  updateStockStatus: async (id: number, stockStatus: StockStatus, aiStatus?: AIStatus, executor?: Executor): Promise<void> => {
+    const db = asExecutor(executor);
     if (aiStatus) {
-      await pool.query(
+      await db.query(
         'UPDATE products SET stock_status = $1, ai_status = $2 WHERE id = $3',
         [stockStatus, aiStatus, id]
       );
     } else {
-      await pool.query(
+      await db.query(
         'UPDATE products SET stock_status = $1 WHERE id = $2',
         [stockStatus, id]
       );
     }
   },
 
-  updateExtractionMethod: async (id: number, method: string): Promise<void> => {
-    await pool.query(
+  updateExtractionMethod: async (id: number, method: string, executor?: Executor): Promise<void> => {
+    await asExecutor(executor).query(
       'UPDATE products SET preferred_extraction_method = $1, needs_price_review = false WHERE id = $2',
       [method, id]
     );
@@ -51,8 +53,8 @@ export const productConfigRepository = {
     return result.rows[0]?.preferred_extraction_method || null;
   },
 
-  updateAnchorPrice: async (id: number, price: number): Promise<void> => {
-    await pool.query(
+  updateAnchorPrice: async (id: number, price: number, executor?: Executor): Promise<void> => {
+    await asExecutor(executor).query(
       'UPDATE products SET anchor_price = $1 WHERE id = $2',
       [price, id]
     );

--- a/backend/src/services/domain/product/repositories/product-core.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-core.repository.ts
@@ -1,4 +1,5 @@
 import pool from '../../../../config/database';
+import { asExecutor, type Executor } from './executor';
 import { 
   ProductWithLatestPrice, 
 } from '../../../../models/types';
@@ -51,8 +52,8 @@ export const productQueryCoreRepository = {
     return result.rows;
   },
 
-  findById: async (id: number, userId: number): Promise<ProductWithLatestPrice | null> => {
-    const result = await pool.query(
+  findById: async (id: number, userId: number, executor?: Executor): Promise<ProductWithLatestPrice | null> => {
+    const result = await asExecutor(executor).query(
       `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status,
               ph_m.price as member_price,
               ph_o.price as original_price,
@@ -62,7 +63,7 @@ export const productQueryCoreRepository = {
                 ELSE ph.price * er.rate
               END as converted_price,
               COALESCE(rc.name, rc.domain) as retailer_name,
-              (SELECT MIN(price) FROM price_history WHERE product_id = p.id) as min_price
+              (SELECT MIN(price) FROM price_history WHERE product_id = p.id AND price_type = 'standard') as min_price
        FROM products p
        JOIN users u ON u.id = p.user_id
        LEFT JOIN LATERAL (

--- a/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
@@ -74,9 +74,13 @@ export const productDashboardRepository = {
     // Get sparkline data for all products (last 7 days)
     const productIds = products.map((p: Product) => p.id);
     const sparklineResult = await pool.query(
+      // price_type must be filtered here. Without it a member-only or
+      // struck-through original price is plotted as though it were a change in
+      // the tracked price, and the sparkline shows drops that never happened.
       `SELECT product_id, price, recorded_at
        FROM price_history
        WHERE product_id = ANY($1)
+       AND price_type = 'standard'
        AND recorded_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
        ORDER BY product_id, recorded_at ASC`,
       [productIds]
@@ -84,9 +88,12 @@ export const productDashboardRepository = {
 
     // Get min prices for all products (all-time low)
     const minPriceResult = await pool.query(
+      // Same reason: a member price is not a price this user ever paid, so it
+      // must not become the product's all-time low.
       `SELECT product_id, MIN(price) as min_price
        FROM price_history
        WHERE product_id = ANY($1)
+       AND price_type = 'standard'
        GROUP BY product_id`,
       [productIds]
     );

--- a/backend/src/services/domain/product/repositories/stock-history.repository.ts
+++ b/backend/src/services/domain/product/repositories/stock-history.repository.ts
@@ -1,4 +1,5 @@
 import pool from '../../../../config/database';
+import { asExecutor, type Executor } from './executor';
 import { 
   StockStatus,
   StockStatusHistory,
@@ -56,8 +57,8 @@ export const stockHistoryRepository = {
   },
 
   // Get the most recent status for a product
-  getLatest: async (productId: number): Promise<StockStatusHistory | null> => {
-    const result = await pool.query(
+  getLatest: async (productId: number, executor?: Executor): Promise<StockStatusHistory | null> => {
+    const result = await asExecutor(executor).query(
       `SELECT * FROM stock_status_history
        WHERE product_id = $1
        ORDER BY changed_at DESC
@@ -68,16 +69,20 @@ export const stockHistoryRepository = {
   },
 
   // Record a status change (only if status actually changed)
-  recordChange: async (productId: number, status: StockStatus): Promise<StockStatusHistory | null> => {
-    // First check if this is actually a change
-    const latest = await stockHistoryRepository.getLatest(productId);
+  recordChange: async (productId: number, status: StockStatus, executor?: Executor): Promise<StockStatusHistory | null> => {
+    const db = asExecutor(executor);
+
+    // First check if this is actually a change. Reading through the same
+    // executor matters inside a transaction: the pool would not see rows this
+    // transaction has already written.
+    const latest = await stockHistoryRepository.getLatest(productId, db);
 
     // If status is the same as the last recorded status, don't create a new record
     if (latest && latest.status === status) {
       return null;
     }
 
-    const result = await pool.query(
+    const result = await db.query(
       `INSERT INTO stock_status_history (product_id, status)
        VALUES ($1, $2)
        RETURNING *`,

--- a/backend/tests/unit/price-persistence.test.ts
+++ b/backend/tests/unit/price-persistence.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * These rules decide what becomes a product's authoritative price. Getting one
+ * wrong does not throw -- it quietly writes a wrong number into history, or
+ * quietly writes nothing, and the symptom only shows up on a chart weeks later.
+ */
+
+const priceHistory = {
+  create: vi.fn().mockResolvedValue({}),
+  getLatest: vi.fn().mockResolvedValue(null),
+};
+const product = {
+  updateAnchorPrice: vi.fn().mockResolvedValue(undefined),
+  updateExtractionMethod: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../../src/models', () => ({
+  priceHistoryRepository: priceHistory,
+  productRepository: product,
+  stockHistoryRepository: { recordChange: vi.fn() },
+}));
+
+const warn = vi.fn();
+const info = vi.fn();
+vi.mock('../../src/utils/system/logger', () => ({
+  logger: {
+    warn: (...a: unknown[]) => warn(...a),
+    info: (...a: unknown[]) => info(...a),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const CLIENT = { query: vi.fn() } as never;
+
+async function record(scraped: Record<string, unknown>, source = 'refresh') {
+  const { ProductPersistenceService } = await import(
+    '../../src/services/domain/product/ProductPersistenceService'
+  );
+  const service = new ProductPersistenceService();
+  // recordPrices is private; the rules under test are entirely inside it.
+  await (service as never as { recordPrices: Function }).recordPrices(CLIENT, 42, scraped, source);
+}
+
+const price = (p: number, currency: string | null = 'USD') => ({ price: p, currency });
+
+describe('Price history persistence rules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    priceHistory.getLatest.mockResolvedValue(null);
+  });
+
+  describe('everything runs on the caller transaction', () => {
+    it('passes the transaction client to every price write and read', async () => {
+      await record({ price: price(10), selectedMethod: 'css' });
+
+      // The bug this replaces: these used the module-level pool, so a
+      // price-history row committed on its own and survived a rollback of the
+      // product write it belonged to.
+      expect(priceHistory.getLatest).toHaveBeenCalledWith(42, 'standard', CLIENT);
+      expect(priceHistory.create.mock.calls[0].at(-1)).toBe(CLIENT);
+      expect(product.updateAnchorPrice).toHaveBeenCalledWith(42, 10, CLIENT);
+      expect(product.updateExtractionMethod).toHaveBeenCalledWith(42, 'css', CLIENT);
+    });
+  });
+
+  describe('currency is part of change detection', () => {
+    it('records when only the currency changed', async () => {
+      priceHistory.getLatest.mockResolvedValue({ price: 100, currency: 'USD' });
+
+      await record({ price: price(100, 'AUD') });
+
+      // Comparing the number alone wrote no row, so the product kept reporting
+      // the old currency indefinitely.
+      expect(priceHistory.create).toHaveBeenCalledTimes(1);
+      expect(priceHistory.create.mock.calls[0][2]).toBe('AUD');
+    });
+
+    it('does not record when price and currency are both unchanged', async () => {
+      priceHistory.getLatest.mockResolvedValue({ price: 100, currency: 'USD' });
+      await record({ price: price(100, 'USD') });
+      expect(priceHistory.create).not.toHaveBeenCalled();
+    });
+
+    it('compares correctly when the driver returns the price as a string', async () => {
+      priceHistory.getLatest.mockResolvedValue({ price: '100.00', currency: 'USD' });
+      await record({ price: price(100, 'USD') });
+      expect(priceHistory.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('prices awaiting review are not authoritative', () => {
+    it('does not record a refresh price flagged for review', async () => {
+      await record({ price: price(9.99), needsReview: true });
+
+      expect(priceHistory.create).not.toHaveBeenCalled();
+      // Nor may it become the anchor: that would make an unconfirmed
+      // extraction the baseline for drift detection.
+      expect(product.updateAnchorPrice).not.toHaveBeenCalled();
+      expect(info.mock.calls.flat().join(' ')).toContain('awaiting review');
+    });
+
+    it('records when the user confirms it, because that is the review', async () => {
+      await record({ price: price(9.99), needsReview: true }, 'manual-confirm');
+      expect(priceHistory.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('holds back member and original prices for the same reason', async () => {
+      await record({
+        price: price(10),
+        memberPrice: price(8),
+        originalPrice: price(12),
+        needsReview: true,
+      });
+      expect(priceHistory.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('missing currency is reported for every price type', () => {
+    it('warns and skips a standard price with no currency', async () => {
+      await record({ price: price(10, null) });
+      expect(priceHistory.create).not.toHaveBeenCalled();
+      expect(warn.mock.calls.flat().join(' ')).toContain('no currency resolved');
+    });
+
+    it('warns and skips a member price with no currency', async () => {
+      // These were skipped silently, so a retailer whose member price never had
+      // a resolvable currency looked identical to one with no member price.
+      await record({ memberPrice: price(8, null) });
+      expect(priceHistory.create).not.toHaveBeenCalled();
+      expect(warn.mock.calls.flat().join(' ')).toContain('member-price');
+    });
+
+    it('warns and skips an original price with no currency', async () => {
+      await record({ originalPrice: price(12, null) });
+      expect(priceHistory.create).not.toHaveBeenCalled();
+      expect(warn.mock.calls.flat().join(' ')).toContain('original-price');
+    });
+  });
+
+  describe('normal recording still works', () => {
+    it('records a first price', async () => {
+      await record({ price: price(19.99, 'EUR') });
+      expect(priceHistory.create).toHaveBeenCalledWith(42, 19.99, 'EUR', undefined, null, 'standard', CLIENT);
+    });
+
+    it('records all three price types when they change', async () => {
+      await record({ price: price(10), memberPrice: price(8), originalPrice: price(12) });
+      const types = priceHistory.create.mock.calls.map((c) => c[5]);
+      expect(types).toEqual(['standard', 'member-price', 'original-price']);
+    });
+
+    it('records an unchanged price on manual confirmation', async () => {
+      priceHistory.getLatest.mockResolvedValue({ price: 10, currency: 'USD' });
+      await record({ price: price(10) }, 'manual-confirm');
+      expect(priceHistory.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Wave 4 of the backlog plan. Seven of the eight gaps in #91.

## The sharp one: the transaction was mostly decorative

`saveScrapeResult` opens a transaction and takes `pg_advisory_xact_lock`, then handed `_client` to three private methods that **ignored it** and used the module-level pool:

```ts
private async updateMetadata(
  _client: PoolClient, // Reserved for future transactional needs
```

So metadata, stock status, stock history, price history, the anchor price and the reschedule all committed independently. A failure late in the save rolled back almost nothing, and price history could describe a state the product never reached.

Repository methods now take an optional executor (`Pool | PoolClient`) and the service passes the transaction client to every one of them.

This is also why the new SQL tracing from #111 was worth doing first — it makes exactly this class of problem visible.

## Concurrency (item 5)

With the read and the insert on the same client, the check-then-insert is atomic inside the advisory lock instead of straddling two connections. No schema change needed; the lock was already there and doing its job for anything that actually used the client.

## Currency in change detection (item 2)

```
Previous: 100 USD
New:      100 AUD
```

compared the number only, wrote no row, and the product kept reporting USD indefinitely. Currency is now part of the comparison, and it tolerates the driver returning a numeric as a string.

## Unreviewed prices (item 1)

A refresh producing a price while also setting `needsReview` still wrote it, making an unconfirmed extraction both the current price **and the drift anchor**. Held back now for standard, member and original alike. A manual confirmation still records, because confirming *is* the review.

## Mixed price types (item 6)

The dashboard sparkline and the all-time-low query had no `price_type` filter:

- A member-only price was plotted as a price drop that never happened.
- A member price could become the product's all-time low — a price this user could not pay.

`getStats` aggregated across all types for the same reason. All three now scope to `standard`.

## Missing currency (item 8)

Member and original prices were skipped silently while standard prices warned, so a retailer whose member price never had a resolvable currency looked identical to one with no member price at all. All three now log.

## Left open

**Item 7** — whether deal and pre-order prices deserve their own history types, or are simply the current standard price. That is a product decision rather than a defect, so I have not guessed at it. #91 stays open for it.

## Verification

13 new unit tests covering the transaction plumbing, currency comparison, review gating and per-type currency diagnostics (backend total 165 -> 178). `tsc`, full suite, emoji lint, `git diff --check` all pass.

Refs #91