### PR TITLE
fix(notifications): make stock events say what actually happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Notification templates gain `{{old_stock_status}}`, `{{new_stock_status}}` and
+  `{{type}}`, so a custom template can tell a stock event from a price drop.
 - Per-retailer "Prefer JSON-LD Images" override under Admin -> Retailers ->
   Extraction Parameters. Retailers whose structured data points at a thumbnail
   or a directory can now prefer CSS selectors while JSON-LD preference stays on
@@ -73,6 +75,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Back-in-stock notifications no longer read "back in stock at undefined USD"
+  when a product becomes available before a price is extracted, and no longer
+  present an unknown currency as USD.
+- ntfy no longer announces an unavailable product as "Back in Stock!" -- product
+  unavailable and price announced now have their own notification wording.
+- Adding a product that cannot be scraped now explains why -- retailer blocked
+  the request, page not found, AI auto-mapping found no usable price, or no
+  price on the page -- with the setting to change, instead of a generic
+  "Could not extract price from the provided URL".
 - Price history is now written inside the same transaction as the product
   update it belongs to, so a rollback can no longer leave behind history for a
   state the product never reached.

--- a/backend/src/services/domain/product/add/discovery.ts
+++ b/backend/src/services/domain/product/add/discovery.ts
@@ -1,6 +1,29 @@
 import { productRepository } from '../../../../models';
 import { scrapeProductWithVoting } from '../../../scraper';
 import { productPersistenceService } from '../ProductPersistenceService';
+import type { ScrapeFailureReason } from '../../../../types/scraper';
+
+/**
+ * Turns the scrape's failure reason into something the person adding the
+ * product can act on.
+ *
+ * Every one of these previously surfaced as "Could not extract price from the
+ * provided URL" with a bare 400, while the log recorded exactly what happened
+ * a few lines earlier.
+ */
+function describeScrapeFailure(reason?: ScrapeFailureReason, detail?: string): string {
+  switch (reason) {
+    case 'bot_challenge':
+      return `The retailer blocked the request${detail ? ` (${detail})` : ''}. Enable the Browser Scraper for this retailer under Admin -> Retailers, or configure a proxy, then try again.`;
+    case 'page_unavailable':
+      return 'The product page could not be found. Check the URL is still live and points at a product rather than a search or category page.';
+    case 'auto_map_rejected':
+      return 'AI auto-mapping could not find a usable price on this page, so no retailer configuration was saved. Add price selectors for this retailer under Admin -> Retailers, or use the Live Tester to work them out.';
+    case 'no_price_found':
+    default:
+      return 'No price could be found on this page. If the price is rendered by JavaScript, enable the Browser Scraper for this retailer under Admin -> Retailers.';
+  }
+}
 
 export class ProductDiscoveryService {
   /**
@@ -10,7 +33,7 @@ export class ProductDiscoveryService {
     const scrapedData = await scrapeProductWithVoting(url, userId);
 
     if (!scrapedData.price && scrapedData.stockStatus !== 'out_of_stock' && scrapedData.stockStatus !== 'pre_order') {
-      throw new Error('Could not extract price from the provided URL');
+      throw new Error(describeScrapeFailure(scrapedData.failureReason, scrapedData.failureDetail));
     }
 
     const requiresCurrencyReview = Boolean(scrapedData.price && !scrapedData.price.currency);

--- a/backend/src/services/domain/product/notifications/alerts.ts
+++ b/backend/src/services/domain/product/notifications/alerts.ts
@@ -37,13 +37,19 @@ export class ProductAlertService {
         productUrl: product.url,
         type: 'back_in_stock',
         newPrice: scrapedData.price?.price,
-        currency: scrapedData.price?.currency || 'USD',
+        currency: scrapedData.price?.currency || undefined,
+        oldStockStatus: product.stock_status || undefined,
+        newStockStatus: scrapedData.stockStatus,
         productId: product.id
       },
       {
         type: 'stock_alert',
         title: `Back in Stock: ${product.name || 'Product'}`,
-        message: `Product is back in stock at ${scrapedData.price?.price} ${scrapedData.price?.currency || 'USD'}`,
+        // A product can come back in stock before a price is extracted, which
+        // used to render as "back in stock at undefined USD".
+        message: scrapedData.price?.price !== undefined && scrapedData.price?.currency
+          ? `Product is back in stock at ${scrapedData.price.currency} ${scrapedData.price.price}`
+          : 'Product is back in stock. Current price: unavailable',
         data: {
           productId: product.id,
           productName: product.name,
@@ -51,7 +57,7 @@ export class ProductAlertService {
           oldStockStatus: product.stock_status,
           newStockStatus: scrapedData.stockStatus,
           newPrice: scrapedData.price?.price,
-          currency: scrapedData.price?.currency || 'USD'
+          currency: scrapedData.price?.currency || undefined
         }
       }
     );

--- a/backend/src/services/notifications/providers/ntfy.ts
+++ b/backend/src/services/notifications/providers/ntfy.ts
@@ -3,6 +3,29 @@ import { NotificationProvider, NotificationPayload } from '../types';
 import { logger } from '../../../utils/system/logger';
 import { interpolateTemplate, getCurrencySymbol } from '../utils';
 
+/**
+ * Heading and tags per event type, for the custom-template path.
+ *
+ * The template branch used a two-way ternary that treated everything which was
+ * not a price drop or a target price as "Back in Stock!", so an unavailable
+ * product was announced as back in stock.
+ */
+function headingFor(type: NotificationPayload['type']): { title: string; tags: string[] } {
+  switch (type) {
+    case 'price_drop':
+      return { title: 'Price Drop Alert!', tags: ['moneybag'] };
+    case 'target_price':
+      return { title: 'Target Price Reached!', tags: ['dart'] };
+    case 'not_available':
+      return { title: 'Product Unavailable', tags: ['warning'] };
+    case 'price_announced':
+      return { title: 'Price Announced', tags: ['label'] };
+    case 'back_in_stock':
+    default:
+      return { title: 'Back in Stock!', tags: ['tada'] };
+  }
+}
+
 export class NtfyProvider implements NotificationProvider {
   constructor(
     private topic: string,
@@ -20,9 +43,8 @@ export class NtfyProvider implements NotificationProvider {
       let tags: string[];
 
       if (this.template) {
-        title = payload.type === 'price_drop' ? 'Price Drop Alert!' : payload.type === 'target_price' ? 'Target Price Reached!' : 'Back in Stock!';
+        ({ title, tags } = headingFor(payload.type));
         message = interpolateTemplate(this.template, payload);
-        tags = payload.type === 'price_drop' ? ['moneybag'] : payload.type === 'target_price' ? ['dart'] : ['tada'];
       } else if (payload.type === 'price_drop') {
         const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
         const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
@@ -35,6 +57,17 @@ export class NtfyProvider implements NotificationProvider {
         title = 'Target Price Reached!';
         message = `${payload.productName}\n\nPrice is now ${newPriceStr} (your target: ${targetPriceStr})`;
         tags = ['dart', 'white_check_mark'];
+      } else if (payload.type === 'not_available') {
+        // This used to fall through to the back-in-stock branch, so a product
+        // that had just become unavailable was announced as back in stock.
+        title = 'Product Unavailable';
+        message = `${payload.productName}\n\nThis product is no longer available. Monitoring has been paused.`;
+        tags = ['warning'];
+      } else if (payload.type === 'price_announced') {
+        const priceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'unavailable';
+        title = 'Price Announced';
+        message = `${payload.productName}\n\nA price is now listed: ${priceStr}`;
+        tags = ['label'];
       } else {
         const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
         title = 'Back in Stock!';

--- a/backend/src/services/notifications/types.ts
+++ b/backend/src/services/notifications/types.ts
@@ -8,6 +8,13 @@ export interface NotificationPayload {
   currency?: string;
   threshold?: number;
   targetPrice?: number;
+  /**
+   * Stock transition that triggered the notification, when there was one.
+   * Without these a custom template cannot tell "back in stock" from a price
+   * drop, and every event renders through the same price-shaped wording.
+   */
+  oldStockStatus?: string;
+  newStockStatus?: string;
 }
 
 export interface NotificationResult {

--- a/backend/src/services/notifications/utils.ts
+++ b/backend/src/services/notifications/utils.ts
@@ -21,6 +21,13 @@ export function getCurrencySymbol(currency?: string): string {
   }
 }
 
+/** "out_of_stock" reads badly in a notification; "Out of stock" does not. */
+function formatStockStatus(status?: string): string {
+  if (!status) return 'unknown';
+  const words = status.replace(/_/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
 /**
  * Simple template engine to replace {{variable}} with real data.
  */
@@ -31,11 +38,20 @@ export function interpolateTemplate(template: string, payload: NotificationPaylo
     'product_name': payload.productName,
     'product_url': payload.productUrl,
     'product_id': payload.productId ? String(payload.productId) : 'N/A',
-    'current_price': payload.newPrice ? payload.newPrice.toFixed(2) : 'N/A',
-    'old_price': payload.oldPrice ? payload.oldPrice.toFixed(2) : 'N/A',
-    'currency': payload.currency || 'USD',
+    'current_price': payload.newPrice !== undefined && payload.newPrice !== null
+      ? payload.newPrice.toFixed(2)
+      : 'unavailable',
+    'old_price': payload.oldPrice !== undefined && payload.oldPrice !== null
+      ? payload.oldPrice.toFixed(2)
+      : 'unavailable',
+    // An unknown currency must not masquerade as USD. The rest of the app
+    // stopped doing this when unresolved currencies moved to manual
+    // confirmation; the notification path was still guessing.
+    'currency': payload.currency || '',
     'currency_symbol': currencySymbol,
     'type': payload.type.replace(/_/g, ' '),
+    'old_stock_status': formatStockStatus(payload.oldStockStatus),
+    'new_stock_status': formatStockStatus(payload.newStockStatus),
   };
 
   let result = template;

--- a/backend/src/services/scraper/orchestration/index.ts
+++ b/backend/src/services/scraper/orchestration/index.ts
@@ -130,8 +130,10 @@ export async function scrapeProductWithVoting(
 
     const isDefinitivelyUnavailable = result.stockStatus === 'out_of_stock' || result.stockStatus === 'not_available';
     const priceExtracted = result.price !== null;
+    let autoMapAttempted = false;
 
     if (!challenge && !isDefinitivelyUnavailable && !priceExtracted && (!domainConfig || isShellConfig) && session.globalAiSettings.ai_auto_mapping_enabled) {
+      autoMapAttempted = true;
       domainConfig = await handleAutoMapping({
         html,
         url,
@@ -193,11 +195,24 @@ export async function scrapeProductWithVoting(
     const isOosOrPreOrderSuccess = !result.price && 
       (result.stockStatus === 'out_of_stock' || result.stockStatus === 'pre_order' || result.stockStatus === 'not_available');
 
+    // Record why, while the reasons are still in scope. Callers turn this into
+    // something a user can act on instead of a flat "could not extract price".
+    if (!result.price && !isOosOrPreOrderSuccess) {
+      if (challenge) {
+        result.failureReason = 'bot_challenge';
+        result.failureDetail = challenge;
+      } else if (autoMapAttempted && !domainConfig) {
+        result.failureReason = 'auto_map_rejected';
+      } else {
+        result.failureReason = 'no_price_found';
+      }
+    }
+
     const finalMsg = result.price
       ? `Success | ${session.domain}: ${result.price.currency} ${result.price.price} (${result.selectedMethod})`
       : isOosOrPreOrderSuccess
         ? `Success | ${session.domain}: Out of Stock / Pre-Order (${result.stockStatus})`
-        : `Failed | ${session.domain}: No price found`;
+        : `Failed | ${session.domain}: No price found (${result.failureReason})`;
 
     logger.info(`Extraction | ${finalMsg}`, 'Extraction', {
       trace: extractionSteps,
@@ -210,6 +225,7 @@ export async function scrapeProductWithVoting(
     if (error instanceof PageNotAvailableError) {
       extractionSteps.push(`Scraper | Block | Page no longer exists (404/410)`);
       result.stockStatus = 'not_available';
+      result.failureReason = 'page_unavailable';
       logger.warn(`Product | Scrape Failed | Page Gone | ${url}`, 'Scraper', { product_id: productId, requestId });
     } else {
       logger.error(`Product | Scrape Failed | ${url}`, 'Scraper', { product_id: productId, error, requestId });

--- a/backend/src/types/scraper.ts
+++ b/backend/src/types/scraper.ts
@@ -29,6 +29,18 @@ export interface ScrapedProduct {
   html?: string;
 }
 
+/**
+ * Why a scrape produced no usable price. The log already knew this; the caller
+ * did not, so an add failed with a flat "Could not extract price" no matter
+ * whether the retailer served a CAPTCHA, the page was gone, or auto-mapping
+ * rejected the config it generated.
+ */
+export type ScrapeFailureReason =
+  | 'bot_challenge'
+  | 'page_unavailable'
+  | 'auto_map_rejected'
+  | 'no_price_found';
+
 export type ReviewReason = 'no_consensus' | 'ai_correction' | 'oos_guardrail' | 'manual_rescan' | 'first_scan' | 'missing_currency';
 
 export interface ScrapedProductWithVoting extends ScrapedProduct {
@@ -44,6 +56,10 @@ export interface ScrapedProductWithVoting extends ScrapedProduct {
   // Flags learned during acquisition (e.g. the page only rendered via the
   // browser scraper), persisted to the retailer config on save.
   learnedFlags?: { use_browser_scraper?: boolean };
+  /** Set only when the scrape produced no usable price. */
+  failureReason?: ScrapeFailureReason;
+  /** Free-text detail for the reason, e.g. which challenge was detected. */
+  failureDetail?: string;
 }
 
 export type ExtractionMethod = 'json-ld' | 'site-specific' | 'generic-css' | 'custom-css' | 'custom-regex' | 'ai' | 'generic' | 'deal-price' | 'member-price' | 'pre-order-price' | 'original-price';

--- a/backend/tests/unit/stock-notifications.test.ts
+++ b/backend/tests/unit/stock-notifications.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { interpolateTemplate } from '../../src/services/notifications/utils';
+import type { NotificationPayload } from '../../src/services/notifications/types';
+
+const base: NotificationPayload = {
+  productName: 'WaveShare POE USB-C Splitter',
+  productUrl: 'https://shop.example.com/p/1',
+  type: 'back_in_stock',
+  productId: 409,
+};
+
+describe('Notification templates', () => {
+  describe('missing values read as missing', () => {
+    it('says a price is unavailable rather than N/A', () => {
+      // A product can come back in stock before a price is extracted.
+      expect(interpolateTemplate('Price: {{current_price}}', base)).toBe('Price: unavailable');
+    });
+
+    it('renders a zero price rather than treating it as absent', () => {
+      // `payload.newPrice ? ...` treated 0 as missing.
+      expect(interpolateTemplate('{{current_price}}', { ...base, newPrice: 0 })).toBe('0.00');
+    });
+
+    it('does not invent USD for an unknown currency', () => {
+      // The rest of the app stopped guessing when unresolved currencies moved
+      // to manual confirmation; this path was still defaulting.
+      expect(interpolateTemplate('[{{currency}}]', base)).toBe('[]');
+      expect(interpolateTemplate('[{{currency}}]', { ...base, currency: 'AUD' })).toBe('[AUD]');
+    });
+  });
+
+  describe('stock event variables', () => {
+    it('exposes the transition so a template can describe the event', () => {
+      const payload: NotificationPayload = {
+        ...base,
+        oldStockStatus: 'out_of_stock',
+        newStockStatus: 'in_stock',
+      };
+
+      expect(
+        interpolateTemplate('{{product_name}}: {{old_stock_status}} -> {{new_stock_status}}', payload)
+      ).toBe('WaveShare POE USB-C Splitter: Out of stock -> In stock');
+    });
+
+    it('reads unknown when there was no transition', () => {
+      expect(interpolateTemplate('{{new_stock_status}}', base)).toBe('unknown');
+    });
+  });
+
+  it('still renders an ordinary price drop', () => {
+    const payload: NotificationPayload = {
+      ...base,
+      type: 'price_drop',
+      oldPrice: 49.99,
+      newPrice: 39.99,
+      currency: 'AUD',
+    };
+    expect(
+      interpolateTemplate('{{product_name}} fell from {{old_price}} to {{current_price}} {{currency}}', payload)
+    ).toBe('WaveShare POE USB-C Splitter fell from 49.99 to 39.99 AUD');
+  });
+});

--- a/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
+++ b/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
@@ -142,7 +142,7 @@ export default function NotificationChannelsSection() {
 
   const renderTemplateHelp = () => (
     <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginTop: '0.5rem', padding: '0.5rem', background: 'var(--background)', borderRadius: '0.25rem' }}>
-      <strong>Available Tags:</strong> <code>{"{{product_name}}"}</code>, <code>{"{{product_url}}"}</code>, <code>{"{{old_price}}"}</code>, <code>{"{{current_price}}"}</code>, <code>{"{{currency}}"}</code>, <code>{"{{product_id}}"}</code>
+      <strong>Available Tags:</strong> <code>{"{{product_name}}"}</code>, <code>{"{{product_url}}"}</code>, <code>{"{{old_price}}"}</code>, <code>{"{{current_price}}"}</code>, <code>{"{{currency}}"}</code>, <code>{"{{product_id}}"}</code>, <code>{"{{type}}"}</code>, <code>{"{{old_stock_status}}"}</code>, <code>{"{{new_stock_status}}"}</code>
     </div>
   );
 


### PR DESCRIPTION
Second half of wave 4: the parts of #92 that do not depend on the #83 schema change, plus the actionable half of #68.

## Back in stock with no price (#92 item 1)

```ts
message: `Product is back in stock at ${scrapedData.price?.price} ${scrapedData.price?.currency || 'USD'}`
```

Built unconditionally, so a product that became available *before* a price was extracted was stored as literally **"back in stock at undefined USD"**. The price is included only when there is one.

## Invented currency

`payload.currency || 'USD'` presented an unresolved currency as US dollars. The rest of the app stopped doing this when unresolved currencies moved to manual confirmation — the notification path was still guessing. Also fixed `payload.newPrice ? ...` treating a price of **0** as absent.

## ntfy announcing unavailable products as back in stock (#92)

Both the custom-template branch and the default branch treated everything that was not a price drop or a target price as back-in-stock:

```ts
title = payload.type === 'price_drop' ? 'Price Drop Alert!'
      : payload.type === 'target_price' ? 'Target Price Reached!'
      : 'Back in Stock!';
```

So a product that had just become **unavailable** was announced with a party tag. Each event type now has its own heading, tags and wording.

## Template variables (#92 item 3)

Templates could not tell a stock event from a price drop, so a `{{current_price}}` template rendered a price-drop message for a back-in-stock event. Adds `{{old_stock_status}}` and `{{new_stock_status}}`, formatted for reading ("Out of stock", not `out_of_stock`), and lists them with `{{type}}` in the settings UI.

## Adding a product now explains the failure (#68)

Every scrape failure surfaced as:

```
Could not extract price from the provided URL
```

with a bare 400 — while the log recorded the actual cause a few lines earlier, exactly as in the #68 report where `Auto-Map | Rejected generated config` was followed by `POST /api/products 400`.

The scrape now records a structured `failureReason` (bot challenge, page gone, auto-map rejected, or genuinely no price) and the add turns it into a message naming the setting to change — for example, enabling the Browser Scraper for that retailer.

Getting a price out of Amazon AU is still #67. This is about not hiding *why* it failed.

## Scope

Both issues stay open:

- **#92** — the remaining items (email template event-awareness, the notification-history reason, per-provider consistency) overlap the notification rework in #93 and the ownership change in #83, so they belong with that work rather than here.
- **#68** — the transport half is #67.

## Verification

6 new template tests (backend total 178 -> 184). `tsc`, full suite, frontend build, emoji lint, `git diff --check` all pass.

Refs #92
Refs #68