### PR TITLE
fix(scraper): scope regex selectors to the denoised page, expose RRP controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Original Price (RRP) selectors can now be edited from the admin interface,
+  both per retailer under Extraction Parameters and globally under Extraction
+  Rules. The database always supported them; there was no way to set them
+  without direct SQL.
 - Notification templates gain `{{old_stock_status}}`, `{{new_stock_status}}` and
   `{{type}}`, so a custom template can tell a stock event from a price drop.
 - Per-retailer "Prefer JSON-LD Images" override under Admin -> Retailers ->
@@ -75,6 +79,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Custom regex selectors now match against the denoised page instead of the raw
+  response, so a pattern written for the product area no longer picks up prices
+  from sidebars, related-product carousels or tracking payloads. Scripts holding
+  product data are preserved through denoising, so rules targeting a JavaScript
+  state blob keep working.
 - Back-in-stock notifications no longer read "back in stock at undefined USD"
   when a product becomes available before a price is extracted, and no longer
   present an unknown currency as USD.

--- a/backend/src/services/scraper/core/engine.ts
+++ b/backend/src/services/scraper/core/engine.ts
@@ -10,6 +10,30 @@ export interface EvaluationResult {
 }
 
 /**
+ * Serialised form of the denoised DOM, cached per Cheerio instance.
+ *
+ * Regex selectors are evaluated one at a time, and $.html() walks the whole
+ * document, so serialising on every evaluation would repeat that work for each
+ * rule. The cache is a WeakMap so it disappears with the document.
+ */
+const denoisedHtmlCache = new WeakMap<object, string>();
+
+function denoisedHtmlFor($: CheerioAPI, fallback: string): string {
+  try {
+    const cached = denoisedHtmlCache.get($ as unknown as object);
+    if (cached !== undefined) return cached;
+
+    const serialised = $.html();
+    denoisedHtmlCache.set($ as unknown as object, serialised);
+    return serialised;
+  } catch {
+    // A malformed document should degrade to the old behaviour rather than
+    // losing the selector entirely.
+    return fallback;
+  }
+}
+
+/**
  * Evaluates a selector against a DOM ($) or raw HTML.
  */
 export function evaluateSelector(
@@ -21,7 +45,11 @@ export function evaluateSelector(
   const results: EvaluationResult[] = [];
 
   if (parsed.engine === 'regex') {
-    const matches = extractByRegex(html, [parsed.realSelector]);
+    // Match against the denoised document, not the raw response. The raw HTML
+    // still contains the sidebars, carousels, footers and tracking payloads the
+    // denoiser removed, so a regex written for the product area was matching
+    // prices from unrelated parts of the page.
+    const matches = extractByRegex(denoisedHtmlFor($, html), [parsed.realSelector]);
     for (const val of matches) {
       const modified = applyModifier({ value: val }, parsed);
       if (modified) {

--- a/backend/src/services/scraper/extractors/custom-prices.ts
+++ b/backend/src/services/scraper/extractors/custom-prices.ts
@@ -5,7 +5,6 @@ import { parsePrice } from '../../../utils/scraping/priceParser';
 import { parseSelector, isNoiseElement } from './metadata';
 import { extractByRegex } from './price-extraction';
 import { evaluatePriceSelectors } from './price-utils';
-import { denoiseHtmlForRegex } from './dom-denoiser';
 
 /**
  * Extracts price candidates using site-specific selectors (CSS or Regex).

--- a/backend/src/services/scraper/extractors/dom-denoiser.ts
+++ b/backend/src/services/scraper/extractors/dom-denoiser.ts
@@ -88,6 +88,26 @@ function getPreservedElements($: CheerioAPI, domainConfig?: Partial<RetailerConf
  * In-place Cheerio DOM cleaner. Strips layout/noise elements while keeping attributes,
  * JSON-LD script blocks, and elements targeted by custom configs.
  */
+/**
+ * Whether a script block looks like it carries product data rather than
+ * marketing or tracking code.
+ *
+ * Deliberately keyword-based and cheap: the alternative is parsing every script
+ * on the page. The keywords are the ones that appear in state blobs and
+ * structured product payloads, and a false positive only costs a slightly
+ * larger denoised document.
+ */
+const PRODUCT_DATA_KEYWORDS = ['price', 'sku', 'offers', 'availability', 'currency'];
+
+function scriptCarriesProductData(content: string | null): boolean {
+  if (!content) return false;
+  // Only inspect the head of very large bundles; a state blob puts its keys
+  // near the front, while a minified vendor bundle would cost a full scan.
+  const sample = content.length > 200_000 ? content.slice(0, 200_000) : content;
+  const lowered = sample.toLowerCase();
+  return PRODUCT_DATA_KEYWORDS.some((keyword) => lowered.includes(keyword));
+}
+
 export function denoiseDomForExtraction(
   $: CheerioAPI, 
   domainConfig?: Partial<RetailerConfig>, 
@@ -118,11 +138,19 @@ export function denoiseDomForExtraction(
     jsonLdBlocks.push($(el).clone());
   });
 
-  // 3. Remove non-JSON-LD scripts, styles, and noscript blocks
+  // 3. Remove non-JSON-LD scripts, styles, and noscript blocks.
+  //
+  // Scripts carrying product data are kept: many sites render the price from a
+  // state blob (window.__INITIAL_STATE__, __NEXT_DATA__) rather than into the
+  // DOM, and a custom regex rule aimed at one of those is the only way to reach
+  // it. Stripping every script left those rules matching nothing.
   $('script:not([type="application/ld+json"]), style, noscript').each((_, el) => {
-    if (!preservedElements.has(el)) {
-      $(el).remove();
-    }
+    if (preservedElements.has(el)) return;
+
+    const tag = (el as { name?: string }).name;
+    if (tag === 'script' && scriptCarriesProductData($(el).html())) return;
+
+    $(el).remove();
   });
 
   // 4. Remove structural noise containers

--- a/backend/tests/unit/regex-denoised-html.test.ts
+++ b/backend/tests/unit/regex-denoised-html.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import * as cheerio from 'cheerio';
+import { denoiseDomForExtraction } from '../../src/services/scraper/extractors/dom-denoiser';
+import { evaluateSelector } from '../../src/services/scraper/core/engine';
+
+/**
+ * Regex selectors used to run against the raw response while every other
+ * extraction path ran against the denoised document. A rule written for the
+ * product area therefore also saw sidebars, carousels, footers and tracking
+ * payloads that the denoiser had already removed.
+ */
+
+const PAGE = `
+<html><body>
+  <main>
+    <div class="product"><span class="price">$49.99</span></div>
+  </main>
+  <aside class="recommendations">
+    <div class="product"><span class="price">$9.99</span></div>
+  </aside>
+  <footer><span class="price">$1.00</span></footer>
+  <script>window.__INITIAL_STATE__ = {"product":{"price":"49.99","sku":"ABC"}};</script>
+  <script>(function(){var _gaq=[['_setAccount','UA-1']];})();</script>
+</body></html>
+`;
+
+function denoised(html: string) {
+  const $ = cheerio.load(html);
+  denoiseDomForExtraction($);
+  return $;
+}
+
+describe('Regex selectors run against the denoised document', () => {
+  it('does not match prices from noise containers the denoiser removed', () => {
+    const $ = denoised(PAGE);
+
+    const results = evaluateSelector($, PAGE, 'regex:/\\$([0-9]+\\.[0-9]{2})/');
+    const values = results.map((r) => r.value);
+
+    expect(values).toContain('49.99');
+    // The aside and footer prices are gone from the denoised document, so a
+    // regex aimed at the product area no longer collects them.
+    expect(values).not.toContain('9.99');
+    expect(values).not.toContain('1.00');
+  });
+
+  it('can still reach a price held in a state script', () => {
+    const $ = denoised(PAGE);
+
+    // Many sites render the price from a state blob rather than into the DOM,
+    // and a custom regex rule is the only way to reach it. Stripping every
+    // script left those rules matching nothing.
+    const results = evaluateSelector($, PAGE, 'regex:/"price":"([0-9.]+)"/');
+
+    expect(results.map((r) => r.value)).toContain('49.99');
+  });
+
+  it('drops marketing and tracking scripts', () => {
+    const html = denoised(PAGE).html();
+
+    expect(html).toContain('__INITIAL_STATE__');
+    expect(html).not.toContain('_setAccount');
+  });
+
+  it('falls back to the supplied html rather than losing the selector', () => {
+    // A document that cannot be serialised must degrade, not throw.
+    const broken = Object.assign(() => ({ each: () => undefined }), {
+      html: () => {
+        throw new Error('unserialisable');
+      },
+    }) as never;
+    const results = evaluateSelector(broken, '<span>$5.00</span>', 'regex:/\\$([0-9]+\\.[0-9]{2})/');
+    expect(results.map((r) => r.value)).toContain('5.00');
+  });
+});

--- a/docs/admin/selectors.md
+++ b/docs/admin/selectors.md
@@ -39,6 +39,14 @@ If the price or details are locked inside script blocks or raw Javascript variab
 * **Capture Groups**: The first match capture group `()` is extracted. If no groups are present, the entire expression match is taken.
   * *Example*: `regex:/var price = "([0-9.]+)";/`
 * **Legacy format**: Patterns enclosed in tildes (`~pattern~`) are automatically treated as regex rules.
+* **What the pattern is matched against**: the *denoised* document, not the raw
+  response. Sidebars, navigation, footers, related-product carousels and
+  marketing/tracking scripts have already been removed, so a pattern aimed at the
+  product area will not pick up prices from elsewhere on the page.
+* **State scripts are preserved.** Script blocks whose contents mention `price`,
+  `sku`, `offers`, `availability` or `currency` survive denoising, so a rule
+  targeting `window.__INITIAL_STATE__` or `__NEXT_DATA__` still works on sites
+  that render the price from JavaScript rather than into the DOM.
 
 ---
 

--- a/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
+++ b/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
@@ -19,6 +19,7 @@ export default function GlobalSelectorsSection() {
   const [globalPriceSelectors, setGlobalPriceSelectors] = useState<string[]>([]);
   const [globalDealPriceSelectors, setGlobalDealPriceSelectors] = useState<string[]>([]);
   const [globalMemberPriceSelectors, setGlobalMemberPriceSelectors] = useState<string[]>([]);
+  const [globalOriginalPriceSelectors, setGlobalOriginalPriceSelectors] = useState<string[]>([]);
   const [globalPreOrderPriceSelectors, setGlobalPreOrderPriceSelectors] = useState<string[]>([]);
   const [globalNameSelectors, setGlobalNameSelectors] = useState<string[]>([]);
   const [globalRetailerNameSelectors, setGlobalRetailerNameSelectors] = useState<string[]>([]);
@@ -64,6 +65,7 @@ export default function GlobalSelectorsSection() {
       try { setGlobalPriceSelectors(JSON.parse(settings.generic_price_selectors || '[]')); } catch { setGlobalPriceSelectors([]); }
       try { setGlobalDealPriceSelectors(JSON.parse(settings.generic_deal_price_selectors || '[]')); } catch { setGlobalDealPriceSelectors([]); }
       try { setGlobalMemberPriceSelectors(JSON.parse(settings.generic_member_price_selectors || '[]')); } catch { setGlobalMemberPriceSelectors([]); }
+      try { setGlobalOriginalPriceSelectors(JSON.parse(settings.generic_original_price_selectors || '[]')); } catch { setGlobalOriginalPriceSelectors([]); }
       try { setGlobalPreOrderPriceSelectors(JSON.parse(settings.generic_pre_order_price_selectors || '[]')); } catch { setGlobalPreOrderPriceSelectors([]); }
       try { setGlobalNameSelectors(JSON.parse(settings.generic_name_selectors || '[]')); } catch { setGlobalNameSelectors([]); }
       try { setGlobalRetailerNameSelectors(JSON.parse(settings.generic_retailer_name_selectors || '[]')); } catch { setGlobalRetailerNameSelectors([]); }
@@ -88,6 +90,7 @@ export default function GlobalSelectorsSection() {
         generic_price_selectors: JSON.stringify(globalPriceSelectors),
         generic_deal_price_selectors: JSON.stringify(globalDealPriceSelectors),
         generic_member_price_selectors: JSON.stringify(globalMemberPriceSelectors),
+        generic_original_price_selectors: JSON.stringify(globalOriginalPriceSelectors),
         generic_pre_order_price_selectors: JSON.stringify(globalPreOrderPriceSelectors),
         generic_name_selectors: JSON.stringify(globalNameSelectors),
         generic_retailer_name_selectors: JSON.stringify(globalRetailerNameSelectors),
@@ -125,6 +128,16 @@ export default function GlobalSelectorsSection() {
 
       <CollapsibleCard title="Generic Member Price Selectors" leadingIcon={<Icon name="users" />} id="sys_sel_member" badge={String(globalMemberPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
         <UnifiedSelectorManager label="Generic Member Price Selectors" items={globalMemberPriceSelectors} onChange={setGlobalMemberPriceSelectors} placeholder=".member-price" />
+      </CollapsibleCard>
+
+      <CollapsibleCard title="Generic Original Price (RRP) Selectors" leadingIcon={<Icon name="tag" />} id="sys_sel_original" badge={String(globalOriginalPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+        <p style={{ color: 'var(--text-muted)', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+          Used only when a retailer has no Original / RRP selectors of its own. Generic
+          RRP patterns match strikethrough prices anywhere on the page, including
+          unrelated products in carousels and grids, so prefer per-retailer selectors
+          and keep this list short.
+        </p>
+        <UnifiedSelectorManager label="Generic Original Price Selectors" items={globalOriginalPriceSelectors} onChange={setGlobalOriginalPriceSelectors} placeholder=".rrp, .was-price" />
       </CollapsibleCard>
 
       <CollapsibleCard title="⏳ Generic Pre-Order Price Selectors" id="sys_sel_preorder" badge={String(globalPreOrderPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>

--- a/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
+++ b/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
@@ -52,6 +52,7 @@ export default function RetailerConfigEditor({
   const [draftRetailerNameSelectors, setDraftRetailerNameSelectors] = useState<string[]>([]);
   const [draftDealPriceSelectors, setDraftDealPriceSelectors] = useState<string[]>([]);
   const [draftMemberPriceSelectors, setDraftMemberPriceSelectors] = useState<string[]>([]);
+  const [draftOriginalPriceSelectors, setDraftOriginalPriceSelectors] = useState<string[]>([]);
   const [draftPreOrderPriceSelectors, setDraftPreOrderPriceSelectors] = useState<string[]>([]);
   const [draftTitleSelectors, setDraftTitleSelectors] = useState<string[]>([]);
   const [draftImageSelectors, setDraftImageSelectors] = useState<string[]>([]);
@@ -83,6 +84,7 @@ export default function RetailerConfigEditor({
     setDraftRetailerNameSelectors(initialRetailer.retailer_name_selectors || []);
     setDraftDealPriceSelectors(initialRetailer.deal_price_selectors || []);
     setDraftMemberPriceSelectors(initialRetailer.member_price_selectors || []);
+    setDraftOriginalPriceSelectors(initialRetailer.original_price_selectors || []);
     setDraftPreOrderPriceSelectors(initialRetailer.pre_order_price_selectors || []);
     setDraftTitleSelectors(initialRetailer.name_selectors || []);
     setDraftImageSelectors(initialRetailer.image_selectors || []);
@@ -121,6 +123,7 @@ export default function RetailerConfigEditor({
       retailer_name_selectors: draftRetailerNameSelectors,
       deal_price_selectors: draftDealPriceSelectors,
       member_price_selectors: draftMemberPriceSelectors,
+      original_price_selectors: draftOriginalPriceSelectors,
       pre_order_price_selectors: draftPreOrderPriceSelectors,
       name_selectors: draftTitleSelectors,
       image_selectors: draftImageSelectors,
@@ -153,6 +156,7 @@ export default function RetailerConfigEditor({
       price_selectors: draftPriceSelectors,
       deal_price_selectors: draftDealPriceSelectors,
       member_price_selectors: draftMemberPriceSelectors,
+      original_price_selectors: draftOriginalPriceSelectors,
       pre_order_price_selectors: draftPreOrderPriceSelectors,
       name_selectors: draftTitleSelectors,
       image_selectors: draftImageSelectors,
@@ -295,6 +299,8 @@ export default function RetailerConfigEditor({
             setDealPriceSelectors={setDraftDealPriceSelectors}
             memberPriceSelectors={draftMemberPriceSelectors}
             setMemberPriceSelectors={setDraftMemberPriceSelectors}
+            originalPriceSelectors={draftOriginalPriceSelectors}
+            setOriginalPriceSelectors={setDraftOriginalPriceSelectors}
             preOrderPriceSelectors={draftPreOrderPriceSelectors}
             setPreOrderPriceSelectors={setDraftPreOrderPriceSelectors}
             imageSelectors={draftImageSelectors}

--- a/frontend/src/features/admin/components/sections/retailer-config/ExtractionParamsSection.tsx
+++ b/frontend/src/features/admin/components/sections/retailer-config/ExtractionParamsSection.tsx
@@ -17,6 +17,8 @@ interface ExtractionParamsSectionProps {
   setDealPriceSelectors: (s: string[]) => void;
   memberPriceSelectors: string[];
   setMemberPriceSelectors: (s: string[]) => void;
+  originalPriceSelectors: string[];
+  setOriginalPriceSelectors: (s: string[]) => void;
   preOrderPriceSelectors: string[];
   setPreOrderPriceSelectors: (s: string[]) => void;
   imageSelectors: string[];
@@ -40,6 +42,8 @@ export default function ExtractionParamsSection({
   setDealPriceSelectors,
   memberPriceSelectors,
   setMemberPriceSelectors,
+  originalPriceSelectors,
+  setOriginalPriceSelectors,
   preOrderPriceSelectors,
   setPreOrderPriceSelectors,
   imageSelectors,
@@ -148,6 +152,12 @@ export default function ExtractionParamsSection({
             items={memberPriceSelectors} 
             onChange={setMemberPriceSelectors} 
             placeholder=".member-price-text" 
+          />
+          <UnifiedSelectorManager
+            label="Original / RRP"
+            items={originalPriceSelectors}
+            onChange={setOriginalPriceSelectors}
+            placeholder=".rrp, .was-price"
           />
           <UnifiedSelectorManager 
             label="Pre-Order Price" 


### PR DESCRIPTION
Three of the four parts of #88. I did not do part 3 and explain why below.

## 1. Regex ran against the raw response

Every other extraction path runs against the denoised document; the regex engine was handed the original HTML. A pattern written for the product area also saw sidebars, related-product carousels, footers and tracking payloads.

`denoiseHtmlForRegex` **already existed for exactly this** and was imported into `custom-prices.ts` — and never called. Dead since it was written.

I removed it rather than wiring it up, in favour of serialising the denoised DOM. That is both more correct (it reuses the real denoiser, including per-retailer preserve and exclusion rules) and avoids the nested-quantifier regexes that helper used, which are audit finding **E-1**.

The serialisation is cached per Cheerio instance in a `WeakMap`: regex selectors are evaluated one at a time and `$.html()` walks the whole document, so serialising per rule would repeat that work for every pattern on the page.

## 2. Scripts carrying product data survive denoising

Many sites render the price from a state blob (`window.__INITIAL_STATE__`, `__NEXT_DATA__`) rather than into the DOM, and a custom regex rule is the only way to reach it. Stripping every script left those rules matching nothing — so parts 1 and 2 have to land together or part 1 is a regression.

Script blocks mentioning `price`, `sku`, `offers`, `availability` or `currency` are kept; marketing and tracking blocks are still removed. Only the first 200KB of a script is scanned, so a minified vendor bundle does not cost a full pass.

## 4. RRP selectors are editable at last

The database and scraper have always supported per-retailer `original_price_selectors` and global `generic_original_price_selectors` — neither appeared anywhere in the admin UI, so fixing a bad RRP meant direct SQL. Both are now editable:

- **Admin -> Retailers -> Extraction Parameters** gains an "Original / RRP" selector list beside Standard, Deal and Member.
- **Extraction Rules** gains a "Generic Original Price (RRP) Selectors" card, with a note that generic RRP patterns match strikethrough prices anywhere on the page and per-retailer selectors should be preferred.

---

## 3. Disabling generic RRP guessing — not done, deliberately

The issue proposes hardcoding `getGenericSelectors: () => []` for Original price. I did not, for two reasons:

**It contradicts part 4.1 of the same issue.** Part 4.1 asks for a UI to manage `generic_original_price_selectors`. Hardcoding `[]` makes that setting dead — the panel would edit a value nothing reads.

**A guardrail already exists.** `consensus.ts` discards any original price below the resolved standard price or above 10x it, added for #55, with the same reasoning the issue gives. The issue does not present a case that survives that guardrail, and hardcoding `[]` would remove RRP capture on every site where the generic patterns work correctly today.

Exposing the control achieves the same outcome without the contradiction: an administrator who agrees with the issue can now clear the global list in one click, and a retailer that needs RRP can have its own selectors. If you would rather ship it empty by default, that is a one-line migration clearing the seeded value — say the word and I will add it.

#88 stays open for that decision.

## Verification

4 new tests proving regex no longer matches noise-container prices, still reaches a price in a state script, drops tracking scripts, and degrades safely on an unserialisable document (backend total 184 -> 188). `tsc`, full suite, frontend build, emoji lint, `git diff --check` all pass.

Refs #88