### PR TITLE
feat(admin): SSO-aware user editing, last-active and account metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Admin user management shows when each account last signed in, when it joined,
+  and how many products it tracks, with a search box for installations with many
+  accounts.
+- Administrators can now change a local account's email address from the user
+  editor. The backend always supported it; there was no field.
 - Original Price (RRP) selectors can now be edited from the admin interface,
   both per retailer under Extraction Parameters and globally under Extraction
   Rules. The database always supported them; there was no way to set them
@@ -79,6 +84,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SSO accounts can no longer have a local password set or their email changed
+  from the admin user editor. Setting a password on an account provisioned for
+  external sign-in enabled local authentication on it, and a locally changed
+  email either breaks the match at next sign-in or is silently overwritten by
+  the identity provider. Both are refused by the API, not just hidden in the UI.
 - Custom regex selectors now match against the denoised page instead of the raw
   response, so a pattern written for the product area no longer picks up prices
   from sidebars, related-product carousels or tracking payloads. Scripts holding

--- a/backend/src/migrations/015_user_last_login.ts
+++ b/backend/src/migrations/015_user_last_login.ts
@@ -1,0 +1,26 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Records when each account last signed in (issue #85).
+ *
+ * The admin user table could show that an account existed but not whether
+ * anyone had ever used it, which is the question an administrator is usually
+ * asking before deleting or auditing one.
+ *
+ * Nullable with no backfill: NULL means "has not signed in since this shipped",
+ * which the UI shows as "Never". Backfilling from created_at would invent a
+ * sign-in that never happened and make a dormant account look active.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  await pool.query(`
+    ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS last_login_at timestamp with time zone;
+  `);
+};
+
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  await pool.query(`
+    ALTER TABLE public.users
+    DROP COLUMN IF EXISTS last_login_at;
+  `);
+};

--- a/backend/src/models/types/user.ts
+++ b/backend/src/models/types/user.ts
@@ -61,6 +61,12 @@ export interface UserProfile {
   disabled: boolean;
   categories: string[];
   created_at: Date;
+  /** 'local' or 'oidc'. Decides which fields an administrator may change. */
+  auth_provider?: string;
+  /** Null until the account signs in for the first time after 015. */
+  last_login_at?: Date | null;
+  /** Products this user tracks. Present only on the admin listing. */
+  product_count?: number;
 }
 
 export interface NotificationSettings {

--- a/backend/src/routes/auth/oidc.ts
+++ b/backend/src/routes/auth/oidc.ts
@@ -9,6 +9,7 @@ import {
 } from '../../services/domain/auth/oidc';
 import { generateToken } from '../../middleware/auth';
 import { logger } from '../../utils/system/logger';
+import { userRepository } from '../../models';
 
 const router = Router();
 
@@ -112,6 +113,15 @@ router.get('/callback', async (req: Request, res: Response) => {
 
     const claims = await completeFlow(params, state);
     const user = await authService.resolveOidcUser(claims, cfg.oidc_jit_enabled);
+
+    // Stamped here rather than inside resolveOidcUser: that function returns a
+    // user from three separate branches, and this is the single point where all
+    // three have succeeded.
+    if (user) {
+      await userRepository.recordLogin(user.id).catch((err) =>
+        logger.warn(`Auth | Could not record login time for user ${user.id}: ${err}`, 'Auth')
+      );
+    }
 
     if (!user) {
       redirectWithError(

--- a/backend/src/services/domain/auth/index.ts
+++ b/backend/src/services/domain/auth/index.ts
@@ -64,6 +64,12 @@ export class AuthService {
     // 7. Generate token
     const token = generateToken(user.id);
 
+    // Not knowing when somebody last signed in is a reporting gap, not a reason
+    // to refuse them entry, so a failure here must not fail the login.
+    await userRepository.recordLogin(user.id).catch((err) =>
+      logger.warn(`Auth | Could not record login time for user ${user.id}: ${err}`, 'Auth')
+    );
+
     return {
       token,
       user: {

--- a/backend/src/services/domain/user/UserAccountService.ts
+++ b/backend/src/services/domain/user/UserAccountService.ts
@@ -42,6 +42,37 @@ export class UserAccountService {
     const { email, name, currency, locale, password, is_admin, disabled } = data;
     const updates: any = {};
 
+    // SSO accounts are governed by the identity provider, and these two rules
+    // are enforced here rather than only in the admin UI: hiding a control does
+    // not stop anyone calling the endpoint.
+    const target = await userRepository.findById(targetId);
+    if (!target) {
+      throw new Error('User not found');
+    }
+    const isSsoAccount = target.auth_provider === 'oidc';
+
+    if (isSsoAccount && password) {
+      // An SSO account is provisioned without a password hash. Setting one
+      // turns on local sign-in for a profile that was meant to authenticate
+      // externally, which is an authentication bypass rather than a
+      // convenience.
+      const err = new Error(
+        'This account signs in through SSO. Passwords are managed by the identity provider and cannot be set here.'
+      );
+      (err as any).statusCode = 400;
+      throw err;
+    }
+
+    if (isSsoAccount && email !== undefined && email !== target.email) {
+      // The identity provider owns the email. Changing it locally either breaks
+      // the match on next sign-in or is silently overwritten by the provider.
+      const err = new Error(
+        'This account signs in through SSO. Its email address is managed by the identity provider and must be changed there.'
+      );
+      (err as any).statusCode = 400;
+      throw err;
+    }
+
     if (email !== undefined) {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(email)) {

--- a/backend/src/services/domain/user/repositories/user-account.repository.ts
+++ b/backend/src/services/domain/user/repositories/user-account.repository.ts
@@ -83,10 +83,30 @@ export const userAccountRepository = {
 
   // Admin queries
   findAll: async (): Promise<UserProfile[]> => {
+    // auth_provider drives which fields the admin UI may edit, last_login_at
+    // answers "is this account actually in use", and the product count shows
+    // how much of the scraper's budget each account is spending.
     const result = await pool.query(
-      'SELECT id, email, name, currency, locale, is_admin, disabled, created_at FROM users ORDER BY created_at ASC'
+      `SELECT u.id, u.email, u.name, u.currency, u.locale, u.is_admin, u.disabled,
+              u.created_at, u.auth_provider, u.last_login_at,
+              COUNT(p.id)::int AS product_count
+         FROM users u
+         LEFT JOIN products p ON p.user_id = u.id
+        GROUP BY u.id
+        ORDER BY u.created_at ASC`
     );
     return result.rows;
+  },
+
+  /**
+   * Stamps a successful sign-in. Called from both the local and the OIDC paths.
+   *
+   * Failures are swallowed by the caller rather than blocking the login: not
+   * knowing when somebody last signed in is a reporting gap, not a reason to
+   * refuse them entry.
+   */
+  recordLogin: async (id: number): Promise<void> => {
+    await pool.query('UPDATE users SET last_login_at = CURRENT_TIMESTAMP WHERE id = $1', [id]);
   },
 
   delete: async (id: number): Promise<boolean> => {

--- a/backend/tests/unit/admin-user-sso-guards.test.ts
+++ b/backend/tests/unit/admin-user-sso-guards.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * SSO accounts are provisioned without a password hash and are identified by
+ * claims from the identity provider. Two admin operations are unsafe on them,
+ * and both have to be refused by the service rather than only hidden in the UI
+ * -- a disabled input does not stop anyone calling the endpoint.
+ */
+
+const users = {
+  findById: vi.fn(),
+  adminUpdateUser: vi.fn(),
+};
+
+vi.mock('../../src/models', () => ({
+  userRepository: users,
+}));
+
+vi.mock('../../src/utils/system/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const LOCAL = { id: 1, email: 'local@example.test', auth_provider: 'local' };
+const SSO = { id: 2, email: 'sso@example.test', auth_provider: 'oidc' };
+
+async function update(target: typeof LOCAL, body: Record<string, unknown>) {
+  users.findById.mockResolvedValue(target);
+  users.adminUpdateUser.mockResolvedValue({ ...target, ...body });
+
+  const { userService } = await import('../../src/services/domain/user');
+  // 999 is a different admin, so the self-demotion guards do not interfere.
+  return userService.adminUpdateUser(target.id, 999, body);
+}
+
+describe('Admin user updates on SSO accounts', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses to set a password on an SSO account', async () => {
+    // Setting one turns on local sign-in for a profile meant to authenticate
+    // externally, which is an authentication bypass rather than a convenience.
+    await expect(update(SSO, { password: 'longenoughpassword' })).rejects.toThrow(/SSO/);
+    expect(users.adminUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('refuses to change the email on an SSO account', async () => {
+    // The provider owns the email; changing it locally either breaks the match
+    // on next sign-in or is silently overwritten.
+    await expect(update(SSO, { email: 'moved@example.test' })).rejects.toThrow(/SSO/);
+    expect(users.adminUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('allows resubmitting the same email on an SSO account', async () => {
+    // The edit form posts the whole user, so an unrelated change must not be
+    // rejected just because the email field was present and unchanged.
+    await expect(update(SSO, { email: SSO.email, name: 'Renamed' })).resolves.toBeTruthy();
+  });
+
+  it('allows edits that the identity provider does not own', async () => {
+    await expect(update(SSO, { name: 'Renamed', currency: 'AUD' })).resolves.toBeTruthy();
+    expect(users.adminUpdateUser).toHaveBeenCalled();
+  });
+
+  it('leaves local accounts fully editable', async () => {
+    await expect(update(LOCAL, { password: 'longenoughpassword' })).resolves.toBeTruthy();
+    await expect(update(LOCAL, { email: 'moved@example.test' })).resolves.toBeTruthy();
+  });
+
+  it('still rejects a short password on a local account', async () => {
+    await expect(update(LOCAL, { password: 'short' })).rejects.toThrow(/at least 8/);
+  });
+
+  it('fails clearly when the account does not exist', async () => {
+    users.findById.mockResolvedValue(null);
+    const { userService } = await import('../../src/services/domain/user');
+    await expect(userService.adminUpdateUser(404, 999, { name: 'x' })).rejects.toThrow(/not found/i);
+  });
+});

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { UserAdminService } from '../../services/UserAdminService';
 import { UserProfile, GlobalCurrency } from '../../../../types/api';
 import { useToast } from '../../../../context/ToastContext';
@@ -9,6 +9,7 @@ import SearchableSelect from '../../../../components/SearchableSelect';
 import { ToggleSwitch } from '../../components';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
 import { AUTOMATIC_CURRENCY_OPTION, AUTOMATIC_LOCALE_OPTION, LOCALE_OPTIONS } from '../../../settings/regionalOptions';
+import { formatDate, formatRelativeDate } from '../../../../utils/format';
 
 interface UsersSectionProps {
   globalCurrencies: GlobalCurrency[];
@@ -21,6 +22,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   const [isAddingUser, setIsAddingUser] = useState(false);
   const [editingUser, setEditingUser] = useState<Partial<UserProfile> | null>(null);
   const [userToDelete, setUserToDelete] = useState<UserProfile | null>(null);
+  const [userSearch, setUserSearch] = useState('');
 
   // Add User states
   const [newUserEmail, setNewUserEmail] = useState('');
@@ -32,6 +34,21 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   // Edit User states
   const [editUserPassword, setEditUserPassword] = useState('');
   const [editUserConfirmPassword, setEditUserConfirmPassword] = useState('');
+
+  const { user: currentUser } = useAuth();
+
+  // Filtering is local state, so a background refresh of the list leaves the
+  // search box and its results alone.
+  const visibleUsers = useMemo(() => {
+    const term = userSearch.trim().toLowerCase();
+    if (!term) return users;
+    return users.filter(u =>
+      (u.email || '').toLowerCase().includes(term) ||
+      (u.name || '').toLowerCase().includes(term)
+    );
+  }, [users, userSearch]);
+
+  const isSsoUser = (u: Partial<UserProfile> | null) => u?.auth_provider === 'oidc';
 
   useEffect(() => {
     fetchUsers();
@@ -94,7 +111,18 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
         <div className="settings-card">
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
             <h2 className="settings-card-title" style={{ margin: 0 }}>User Management</h2>
-            <button className="btn btn-primary btn-sm" onClick={() => setIsAddingUser(true)}>+ Add User</button>
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                type="search"
+                className="form-control"
+                style={{ width: 'auto', minWidth: '200px' }}
+                placeholder="Search name or email"
+                value={userSearch}
+                onChange={e => setUserSearch(e.target.value)}
+                aria-label="Search users"
+              />
+              <button className="btn btn-primary btn-sm" onClick={() => setIsAddingUser(true)}>+ Add User</button>
+            </div>
           </div>
 
           <div className="mobile-scroll-hint">Swipe left to see more →</div>
@@ -104,15 +132,26 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
                 <tr>
                   <th>User Account</th>
                   <th className="mobile-hide">Privileges</th>
+                  <th className="mobile-hide">Last Active</th>
+                  <th className="mobile-hide">Joined</th>
+                  <th className="mobile-hide">Tracked</th>
                   <th style={{ textAlign: 'right' }}>Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {users.map(u => (
+                {visibleUsers.map(u => (
                   <tr key={u.id}>
                     <td>
                        <div style={{ fontWeight: 600 }}>{u.name || 'Unnamed User'}</div>
                        <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{u.email}</div>
+                       {isSsoUser(u) && (
+                         <span style={{
+                           fontSize: '0.6rem', fontWeight: 800, color: 'var(--text-muted)',
+                           marginTop: '0.25rem', display: 'inline-block'
+                         }}>
+                           SSO
+                         </span>
+                       )}
                        {u.disabled && (
                          <span style={{ 
                            fontSize: '0.6rem', fontWeight: 800, color: 'var(--danger)', 
@@ -131,6 +170,15 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
                       }}>
                         {u.is_admin ? 'ADMIN' : 'USER'}
                       </span>
+                    </td>
+                    <td className="mobile-hide" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>
+                      {u.last_login_at ? formatRelativeDate(u.last_login_at, currentUser?.locale) : 'Never'}
+                    </td>
+                    <td className="mobile-hide" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>
+                      {formatDate(u.created_at, currentUser?.locale)}
+                    </td>
+                    <td className="mobile-hide" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>
+                      {u.product_count ?? 0}
                     </td>
                     <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
                       <button className="btn btn-secondary btn-sm" onClick={() => { setEditingUser(u); setEditUserPassword(''); setEditUserConfirmPassword(''); }} style={{ marginRight: '0.5rem' }}>Edit</button>
@@ -194,6 +242,22 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
       {editingUser && (
         <div className="settings-card" style={{ border: '2px solid var(--primary)' }}>
           <h3 className="settings-card-title">Edit User: {editingUser.email}</h3>
+          {isSsoUser(editingUser) && (
+            <div className="alert" style={{ background: 'var(--background)', border: '1px solid var(--border)', color: 'var(--text-muted)', fontSize: '0.85rem' }}>
+              This account signs in through SSO. Its email address and password are
+              managed by the identity provider and cannot be changed here.
+            </div>
+          )}
+          <div className="form-group">
+            <label htmlFor="edit-user-email">Email Address</label>
+            <input
+              id="edit-user-email"
+              type="email"
+              value={editingUser.email || ''}
+              disabled={isSsoUser(editingUser)}
+              onChange={e => setEditingUser({ ...editingUser, email: e.target.value })}
+            />
+          </div>
           <div className="form-group"><label>Display Name</label><input type="text" value={editingUser.name || ''} onChange={e => setEditingUser({ ...editingUser, name: e.target.value })} /></div>
           <div className="form-grid">
             <div className="form-group">
@@ -221,10 +285,12 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
               />
             </div>
           </div>
-          <div className="form-grid" style={{ marginTop: '1rem' }}>
-            <div className="form-group"><label>New Password (Optional)</label><PasswordInput secret value={editUserPassword} onChange={e => setEditUserPassword(e.target.value)} autoComplete="new-password" /></div>
-            <div className="form-group"><label>Confirm New Password</label><PasswordInput secret value={editUserConfirmPassword} onChange={e => setEditUserConfirmPassword(e.target.value)} autoComplete="new-password" /></div>
-          </div>
+          {!isSsoUser(editingUser) && (
+            <div className="form-grid" style={{ marginTop: '1rem' }}>
+              <div className="form-group"><label>New Password (Optional)</label><PasswordInput secret value={editUserPassword} onChange={e => setEditUserPassword(e.target.value)} autoComplete="new-password" /></div>
+              <div className="form-group"><label>Confirm New Password</label><PasswordInput secret value={editUserConfirmPassword} onChange={e => setEditUserConfirmPassword(e.target.value)} autoComplete="new-password" /></div>
+            </div>
+          )}
           
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'var(--background)', padding: '0.75rem', borderRadius: '0.5rem', marginTop: '1rem' }}>
             <span style={{ fontWeight: 600, fontSize: '0.875rem' }}>Administrator Access</span>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -147,6 +147,12 @@ export interface UserProfile {
   disabled: boolean;
   categories: string[];
   created_at: string;
+  /** 'local' or 'oidc'. Decides which fields an administrator may change. */
+  auth_provider?: string;
+  /** Null until the account signs in for the first time. */
+  last_login_at?: string | null;
+  /** Products this user tracks. Present only on the admin listing. */
+  product_count?: number;
 }
 
 export interface NotificationSettings {


### PR DESCRIPTION
Wave 5 of the backlog plan, first block. Closes #81, #85 and #76.

## #76 is a duplicate of #81

Both ask for admin email editing and better password UX. #81 additionally handles the SSO case that #76 would have got wrong, so I implemented #81 and closed #76 against it rather than doing the work twice.

## The security part (#81)

Two admin operations are unsafe on an account provisioned by an identity provider:

- **Setting a password.** The account has no password hash by design. Giving it one enables local sign-in on a profile meant to authenticate externally — an authentication bypass, not a convenience.
- **Changing the email.** The provider owns it, so a local change either breaks the match at the next sign-in or is silently overwritten.

Both are refused in `adminUpdateUser`, and the controls are hidden or disabled with an explanation. **The service check is the real one** — a disabled input does not stop anyone calling `PUT /api/admin/users/:id`. The issue frames this as a UI problem; it is not.

Everything the provider does not own (display name, currency, locale, admin, disabled) stays editable on SSO accounts. Resubmitting an unchanged email is allowed, since the form posts the whole user.

## Email editing for local accounts

The update payload already carried `email` and the service already validated it — the form simply had no field. The capability existed and was unreachable.

## Account metadata (#85)

`findAll` now returns `auth_provider`, `last_login_at` and a tracked-product count; the table gains **Last Active**, **Joined** and **Tracked** plus a search box. Filtering is local component state, so a background refresh leaves the search and its results alone — which also sets this up correctly for the polling work in #86.

`last_login_at` is stamped on both the local login and the OIDC callback. The OIDC stamp sits in the **route** rather than `resolveOidcUser`, because that function returns a user from three separate branches (existing subject, linked by email, JIT-provisioned) and the route is the single point where all three have succeeded. A failure to record the time is logged and swallowed — not knowing when somebody last signed in is a reporting gap, not a reason to refuse them entry.

Migration 015 adds the column nullable **with no backfill**. Backfilling from `created_at` would invent a sign-in that never happened and make a dormant account look active; NULL renders as "Never".

## Verification

Against PostgreSQL 16 (installed locally for this work, per CLAUDE.md's requirement that migrations be tested against a real database):

- Migration applies and re-applies cleanly.
- `findAll` returns the right provider and product count per account.
- `recordLogin` stamps correctly.
- All five guard cases resolve correctly against real rows: password-on-SSO **rejected**, email-on-SSO **rejected**, rename-SSO **allowed**, password-on-local **allowed**, email-on-local **allowed**.

7 new unit tests (backend 188 -> 195). `tsc`, full suite, frontend build, emoji lint, `git diff --check` all pass.

Closes #81
Closes #85
Closes #76