### PR TITLE
feat(admin): allow administrators to open any tracked product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Administrators can now open, edit and delete any tracked product by following
+  a direct link to it, instead of getting a "not found" for products belonging
+  to other accounts. Their own dashboard still lists only their own products,
+  and reaching into another account's product is recorded in the event log.
 - Admin user management shows when each account last signed in, when it joined,
   and how many products it tracks, with a search box for installations with many
   accounts.

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -7,6 +7,12 @@ export interface AuthRequest extends Request {
   userId?: number;
   isSystemToken?: boolean;
   tokenLabel?: string;
+  /**
+   * Resolved on demand by routes that offer an administrator bypass, not on
+   * every request. It is deliberately not carried in the JWT: a token minted
+   * before a demotion would keep asserting admin until it expired.
+   */
+  isAdmin?: boolean;
 }
 
 interface JwtPayload {

--- a/backend/src/routes/prices/index.ts
+++ b/backend/src/routes/prices/index.ts
@@ -2,7 +2,7 @@ import { Router, Response } from 'express';
 import { AuthRequest, authMiddleware } from '../../middleware/auth';
 import { productHistoryService, productRefreshService } from '../../services/domain/product';
 import { logger } from '../../utils/system/logger';
-import { asyncHandler } from '../../utils/system/route-helpers';
+import { asyncHandler, callerIsAdmin } from '../../utils/system/route-helpers';
 
 const router = Router();
 
@@ -20,7 +20,7 @@ router.get('/:productId/history', asyncHandler(async (req: AuthRequest, res: Res
   }
 
   const days = req.query.days ? parseInt(req.query.days as string, 10) : undefined;
-  const result = await productHistoryService.getPriceHistory(productId, userId, days);
+  const result = await productHistoryService.getPriceHistory(productId, userId, days, await callerIsAdmin(req));
 
   res.json(result);
 }, 'Prices | Fetch History', 'Prices', 'Failed to fetch price history'));
@@ -63,7 +63,7 @@ router.get('/:productId/stock-history', asyncHandler(async (req: AuthRequest, re
   }
 
   const days = req.query.days ? parseInt(req.query.days as string, 10) : 30;
-  const result = await productHistoryService.getStockHistory(productId, userId, days);
+  const result = await productHistoryService.getStockHistory(productId, userId, days, await callerIsAdmin(req));
 
   res.json(result);
 }, 'Prices | Fetch Stock History', 'Prices', 'Failed to fetch stock status history'));

--- a/backend/src/routes/products/crud.ts
+++ b/backend/src/routes/products/crud.ts
@@ -1,9 +1,10 @@
 import { Router, Response } from 'express';
 import { AuthRequest } from '../../middleware/auth';
 import { productAddService, productHistoryService } from '../../services/domain/product';
-import { asyncHandler, parseIdParam } from '../../utils/system/route-helpers';
+import { asyncHandler, parseIdParam, callerIsAdmin } from '../../utils/system/route-helpers';
 
 const router = Router();
+
 
 router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const userId = req.userId!;
@@ -38,7 +39,7 @@ router.get('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const product = await productHistoryService.getProduct(productId, userId);
+  const product = await productHistoryService.getProduct(productId, userId, await callerIsAdmin(req));
 
   if (!product) {
     res.status(404).json({ error: 'Product not found' });
@@ -57,7 +58,7 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const updated = await productHistoryService.updateProduct(productId, userId, req.body);
+  const updated = await productHistoryService.updateProduct(productId, userId, req.body, await callerIsAdmin(req));
   if (!updated) {
     res.status(404).json({ error: 'Product not found' });
     return;
@@ -75,7 +76,7 @@ router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const deleted = await productHistoryService.deleteProduct(productId, userId);
+  const deleted = await productHistoryService.deleteProduct(productId, userId, await callerIsAdmin(req));
 
   if (!deleted) {
     res.status(404).json({ error: 'Product not found' });

--- a/backend/src/services/domain/product/ProductHistoryService.ts
+++ b/backend/src/services/domain/product/ProductHistoryService.ts
@@ -7,47 +7,77 @@ import {
   ProductWithSparkline
 } from '../../../models';
 import { syncUserCategories } from './utils';
+import { logger } from '../../../utils/system/logger';
 
 export class ProductHistoryService {
   async getUserProducts(userId: number): Promise<ProductWithSparkline[]> {
     return await productRepository.findByUserIdWithSparkline(userId);
   }
 
-  async getProduct(productId: number, userId: number): Promise<ProductWithLatestPrice | null> {
-    return await productRepository.findById(productId, userId);
+  async getProduct(productId: number, userId: number, asAdmin = false): Promise<ProductWithLatestPrice | null> {
+    const product = await productRepository.findById(productId, userId, { asAdmin });
+    this.auditAdminAccess('view', product, userId, asAdmin);
+    return product;
   }
 
-  async deleteProduct(productId: number, userId: number): Promise<boolean> {
-    return await productRepository.delete(productId, userId);
+  async deleteProduct(productId: number, userId: number, asAdmin = false): Promise<boolean> {
+    // Read first so the audit line can name the owner; the row is gone after.
+    const product = await productRepository.findById(productId, userId, { asAdmin });
+    if (!product) return false;
+    this.auditAdminAccess('delete', product, userId, asAdmin);
+    return await productRepository.delete(productId, userId, { asAdmin });
+  }
+
+  /**
+   * An administrator reaching into another account's product is legitimate but
+   * not routine, so it leaves a trace. Acting on your own product logs nothing.
+   */
+  private auditAdminAccess(
+    action: string,
+    product: { id: number; user_id?: number } | null,
+    userId: number,
+    asAdmin: boolean
+  ): void {
+    if (!asAdmin || !product || product.user_id === userId) return;
+    logger.info(
+      `Product ${product.id} | Admin ${action} | Admin ${userId} accessed a product owned by user ${product.user_id}`,
+      'Admin',
+      { product_id: product.id }
+    );
   }
 
   async bulkUpdatePauseStatus(ids: number[], userId: number, paused: boolean): Promise<number> {
     return await productRepository.bulkSetCheckingPaused(ids, userId, paused);
   }
 
-  async updateProduct(productId: number, userId: number, data: any): Promise<ProductWithLatestPrice | null> {
+  async updateProduct(productId: number, userId: number, data: any, asAdmin = false): Promise<ProductWithLatestPrice | null> {
     if (data.category !== undefined) {
       data.category = data.category?.trim() || null;
     }
-    const updated = await productRepository.update(productId, userId, data);
-    
+    const updated = await productRepository.update(productId, userId, data, undefined, { asAdmin });
+
+    // Categories belong to the owner of the product, not to whoever edited it.
+    // Syncing them to the admin's own list would pollute their category filter
+    // with somebody else's categories.
     if (updated && data.category) {
-      await syncUserCategories(userId, data.category);
+      await syncUserCategories(updated.user_id ?? userId, data.category);
     }
-    
-    return await productRepository.findById(productId, userId);
+
+    const product = await productRepository.findById(productId, userId, { asAdmin });
+    this.auditAdminAccess('update', product, userId, asAdmin);
+    return product;
   }
 
-  async getPriceHistory(productId: number, userId: number, days?: number) {
-    const product = await productRepository.findById(productId, userId);
+  async getPriceHistory(productId: number, userId: number, days?: number, asAdmin = false) {
+    const product = await productRepository.findById(productId, userId, { asAdmin });
     if (!product) throw new Error('Product not found');
 
     const prices = await priceHistoryRepository.findByProductId(productId, days);
     return { product, prices };
   }
 
-  async getStockHistory(productId: number, userId: number, days: number = 30) {
-    const product = await productRepository.findById(productId, userId);
+  async getStockHistory(productId: number, userId: number, days: number = 30, asAdmin = false) {
+    const product = await productRepository.findById(productId, userId, { asAdmin });
     if (!product) throw new Error('Product not found');
 
     let history = await stockHistoryRepository.getByProductId(productId, days);

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -33,7 +33,7 @@ export class ProductPersistenceService {
       await client.query('SELECT pg_advisory_xact_lock($1)', [productId]);
 
       // 1. Fetch current state
-      const product = await productRepository.findById(productId, userId, client);
+      const product = await productRepository.findById(productId, userId, { executor: client });
       if (!product) {
         await client.query('ROLLBACK');
         return;

--- a/backend/src/services/domain/product/repositories/product-core.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-core.repository.ts
@@ -52,8 +52,19 @@ export const productQueryCoreRepository = {
     return result.rows;
   },
 
-  findById: async (id: number, userId: number, executor?: Executor): Promise<ProductWithLatestPrice | null> => {
-    const result = await asExecutor(executor).query(
+  /**
+   * `asAdmin` lifts the ownership filter so an administrator can open a product
+   * belonging to another account. It is an options field rather than a
+   * positional boolean so that every bypass is spelled out at the call site --
+   * a stray `true` in an argument list is not something a reviewer should have
+   * to count parameters to catch.
+   */
+  findById: async (
+    id: number,
+    userId: number,
+    options?: { executor?: Executor; asAdmin?: boolean }
+  ): Promise<ProductWithLatestPrice | null> => {
+    const result = await asExecutor(options?.executor).query(
       `SELECT p.*, ph.price as current_price, ph.currency, ph.ai_status,
               ph_m.price as member_price,
               ph_o.price as original_price,
@@ -107,8 +118,8 @@ export const productQueryCoreRepository = {
          ORDER BY length(domain) DESC
          LIMIT 1
        ) rc ON true
-       WHERE p.id = $1 AND p.user_id = $2`,
-      [id, userId]
+       WHERE p.id = $1 AND ($3::boolean = true OR p.user_id = $2)`,
+      [id, userId, options?.asAdmin === true]
     );
     return result.rows[0] || null;
   },

--- a/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
@@ -43,7 +43,8 @@ export const productLifecycleRepository = {
       needs_price_review?: boolean;
       ai_status?: string;
     },
-    client?: any
+    client?: any,
+    options?: { asAdmin?: boolean }
   ): Promise<Product | null> => {
     const executor = client || pool;
     const fields: string[] = [];
@@ -66,20 +67,21 @@ export const productLifecycleRepository = {
 
     if (fields.length === 0) return null;
 
-    values.push(id, userId);
+    // Order matters: the WHERE clause numbers these as id, userId, admin flag.
+    values.push(id, userId, options?.asAdmin === true);
     const result = await executor.query(
       `UPDATE products SET ${fields.join(', ')}
-       WHERE id = $${paramIndex++} AND user_id = $${paramIndex}
+       WHERE id = $${paramIndex++} AND ($${paramIndex + 1}::boolean = true OR user_id = $${paramIndex})
        RETURNING *`,
       values
     );
     return result.rows[0] || null;
   },
 
-  delete: async (id: number, userId: number): Promise<boolean> => {
+  delete: async (id: number, userId: number, options?: { asAdmin?: boolean }): Promise<boolean> => {
     const result = await pool.query(
-      'DELETE FROM products WHERE id = $1 AND user_id = $2',
-      [id, userId]
+      'DELETE FROM products WHERE id = $1 AND ($3::boolean = true OR user_id = $2)',
+      [id, userId, options?.asAdmin === true]
     );
     return (result.rowCount ?? 0) > 0;
   },

--- a/backend/src/utils/system/route-helpers.ts
+++ b/backend/src/utils/system/route-helpers.ts
@@ -1,6 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from '../../middleware/auth';
 import { logger } from './logger';
+import { userRepository } from '../../models';
 
 export function asyncHandler(
   handler: (req: AuthRequest, res: Response) => Promise<any>,
@@ -56,4 +57,27 @@ export function parseIdParam(req: AuthRequest, paramName: string = 'id'): number
     return null;
   }
   return id;
+}
+
+
+/**
+ * Whether the caller is an administrator.
+ *
+ * Resolved per request from the database rather than from the token, so
+ * revoking someone's admin rights takes effect immediately instead of when
+ * their JWT expires. Only routes that offer a cross-user bypass should call it
+ * -- listing routes deliberately do not, because an administrator's own
+ * dashboard must keep showing only their own products.
+ */
+export async function callerIsAdmin(req: AuthRequest): Promise<boolean> {
+  if (req.isAdmin !== undefined) return req.isAdmin;
+  // A system token acts on behalf of the installation rather than a person and
+  // is scoped elsewhere; it does not get the cross-user bypass.
+  if (req.isSystemToken || !req.userId) {
+    req.isAdmin = false;
+    return false;
+  }
+  const user = await userRepository.findById(req.userId);
+  req.isAdmin = user?.is_admin === true;
+  return req.isAdmin;
 }

--- a/backend/tests/unit/admin-product-access.test.ts
+++ b/backend/tests/unit/admin-product-access.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The administrator bypass lifts an ownership check, so the cases that matter
+ * most are the ones where it must NOT apply. A regression here is silent: the
+ * feature keeps working while the boundary quietly stops holding.
+ */
+
+const products = {
+  findById: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../../src/models', () => ({
+  productRepository: products,
+  priceHistoryRepository: { findByProductId: vi.fn().mockResolvedValue([]) },
+  stockHistoryRepository: { getByProductId: vi.fn().mockResolvedValue([]), getStats: vi.fn().mockResolvedValue(null) },
+}));
+
+const info = vi.fn();
+vi.mock('../../src/utils/system/logger', () => ({
+  logger: { info: (...a: unknown[]) => info(...a), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../src/services/domain/product/utils', () => ({
+  syncUserCategories: vi.fn(),
+}));
+
+const OWNER = 7;
+const ADMIN = 9;
+const PRODUCT = { id: 1, user_id: OWNER, name: 'Owned' };
+
+async function service() {
+  const mod = await import('../../src/services/domain/product/ProductHistoryService');
+  return mod.productHistoryService;
+}
+
+describe('Administrator access to another account product', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    products.findById.mockResolvedValue(PRODUCT);
+    products.update.mockResolvedValue(PRODUCT);
+    products.delete.mockResolvedValue(true);
+  });
+
+  describe('the bypass is opt-in', () => {
+    it('does not bypass ownership by default', async () => {
+      await (await service()).getProduct(1, ADMIN);
+      expect(products.findById).toHaveBeenCalledWith(1, ADMIN, { asAdmin: false });
+    });
+
+    it('passes the flag through on read, update and delete', async () => {
+      const svc = await service();
+
+      await svc.getProduct(1, ADMIN, true);
+      expect(products.findById).toHaveBeenCalledWith(1, ADMIN, { asAdmin: true });
+
+      await svc.updateProduct(1, ADMIN, { name: 'x' }, true);
+      expect(products.update).toHaveBeenCalledWith(1, ADMIN, { name: 'x' }, undefined, { asAdmin: true });
+
+      await svc.deleteProduct(1, ADMIN, true);
+      expect(products.delete).toHaveBeenCalledWith(1, ADMIN, { asAdmin: true });
+    });
+
+    it('refuses to delete a product the caller cannot see', async () => {
+      // Without the pre-read, delete would report success on a row it never
+      // matched, because rowCount 0 and "not yours" look the same from outside.
+      products.findById.mockResolvedValue(null);
+      expect(await (await service()).deleteProduct(1, ADMIN, false)).toBe(false);
+      expect(products.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auditing', () => {
+    it('logs when an admin reaches into another account', async () => {
+      await (await service()).getProduct(1, ADMIN, true);
+      expect(info.mock.calls.flat().join(' ')).toContain('Admin view');
+    });
+
+    it('logs nothing when an admin acts on their own product', async () => {
+      // Otherwise every action an administrator takes on their own dashboard
+      // would file an audit line, and the real ones would be lost in it.
+      products.findById.mockResolvedValue({ ...PRODUCT, user_id: ADMIN });
+      await (await service()).getProduct(1, ADMIN, true);
+      expect(info).not.toHaveBeenCalled();
+    });
+
+    it('logs nothing for an ordinary user', async () => {
+      await (await service()).getProduct(1, OWNER, false);
+      expect(info).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('categories follow the owner, not the editor', () => {
+    it('syncs the category to the product owner', async () => {
+      const { syncUserCategories } = await import('../../src/services/domain/product/utils');
+      products.update.mockResolvedValue({ ...PRODUCT, user_id: OWNER });
+
+      await (await service()).updateProduct(1, ADMIN, { category: 'Games' }, true);
+
+      // Syncing to the admin instead would pollute their own category filter
+      // with somebody else's categories.
+      expect(syncUserCategories).toHaveBeenCalledWith(OWNER, 'Games');
+    });
+  });
+});


### PR DESCRIPTION
Wave 5, second block. Closes #82.

This one moves an authorisation boundary, so the notes below are mostly about what is deliberately *not* bypassed.

## The bypass is opt-in at every layer

Repositories take an **options object** rather than the positional `isAdmin` boolean the issue proposes:

```ts
findById(id, userId, { asAdmin: true })
```

A stray `true` in an argument list is not something a reviewer should have to count parameters to catch. Services default it to `false`; only the by-id routes pass it.

## Deliberately not bypassed

- **`findByUserId`** — an administrator's own dashboard still lists only their own products. The issue asks for this explicitly, and it is the difference between a support tool and a shared inbox.
- **`bulkSetCheckingPaused`** — acts on a set the caller assembled from their own dashboard.
- **System tokens** — they act for the installation rather than a person and are scoped elsewhere, so they do not get a cross-user bypass.

## Admin status is not in the token

Resolved per request from the database. A JWT minted before a demotion would keep asserting admin until it expired. Only routes offering the bypass pay for the lookup — the product list deliberately does not.

## Auditing

Reaching into another account's product writes an event-log line naming the admin, the product and its owner. Acting on **your own** product logs nothing — otherwise every action an administrator takes on their own dashboard files an audit line and the real ones are lost in the noise.

## Two things that fell out of the change

- **`deleteProduct` now reads before deleting.** Without a pre-read, a delete on a product the caller cannot see reports *success*, because "no such row" and "not yours" are indistinguishable from a `rowCount` of 0. That was true before this PR too.
- **A category set by an administrator syncs to the product's owner**, not to the administrator — whose own category filter would otherwise fill up with other people's categories.

## Verification

Against PostgreSQL 16 with real rows:

| case | result |
|---|---|
| non-admin GET another user's product | **DENIED** |
| non-admin UPDATE | **DENIED** |
| non-admin DELETE | **DENIED** |
| owner GET | ALLOWED |
| admin GET / UPDATE / DELETE | ALLOWED |
| ownership preserved through admin edit | yes |
| audit line written | yes |

7 new unit tests, weighted toward the cases where the bypass must not apply (backend 195 -> 202). `tsc`, full suite, frontend build, emoji lint, `git diff --check` all pass.

Closes #82