### PR TITLE
feat(admin): refresh retailers, users and tokens in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Admin Retailers, Users and API Tokens now refresh in the background, so
+  retailers the scraper auto-creates, accounts SSO provisions on first sign-in,
+  and tokens managed outside the UI appear without reloading the page. Search
+  filters are untouched by a background refresh, and polling stops when the tab
+  is hidden.
 - Administrators can now open, edit and delete any tracked product by following
   a direct link to it, instead of getting a "not found" for products belonging
   to other accounts. Their own dashboard still lists only their own products,

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -4,8 +4,13 @@ import { ProfileService } from '../features/settings/services/ProfileService';
 import { NotificationService } from '../features/notifications/services/NotificationService';
 import { SharedService } from '../services/SharedService';
 import { AdminSystemService } from '../features/admin/services/AdminSystemService';
+import { UserAdminService } from '../features/admin/services/UserAdminService';
+import { RetailerAdminService } from '../features/admin/services/RetailerAdminService';
 
 export const queryKeys = {
+  adminUsers: ['admin', 'users'] as const,
+  adminTokens: ['admin', 'system-tokens'] as const,
+  adminRetailers: ['admin', 'retailers'] as const,
   products: { all: ['products'] as const, detail: (id: number) => ['products', id] as const },
   discoveryStatus: ['settings', 'discovery-status'] as const,
   profile: ['profile'] as const,
@@ -62,6 +67,37 @@ export const notificationSettingsQuery = () => queryOptions({
   queryKey: queryKeys.notificationSettings,
   queryFn: ({ signal }) => ProfileService.getNotificationSettings({ signal }),
   staleTime: 10 * 60_000,
+});
+
+/**
+ * Admin lists fall out of date on their own: the scraper auto-creates retailer
+ * configs, SSO provisions users on first sign-in, and tokens can be managed by
+ * scripts. Polling means an administrator sees those without reloading.
+ *
+ * Slower than the product dashboard because these change on human timescales,
+ * and React Query stops polling a hidden tab by itself.
+ */
+const ADMIN_POLL_INTERVAL = 30_000;
+
+export const adminUsersQuery = () => queryOptions({
+  queryKey: queryKeys.adminUsers,
+  queryFn: ({ signal }) => UserAdminService.getUsers({ signal }),
+  staleTime: ADMIN_POLL_INTERVAL,
+  refetchInterval: ADMIN_POLL_INTERVAL,
+});
+
+export const adminTokensQuery = () => queryOptions({
+  queryKey: queryKeys.adminTokens,
+  queryFn: ({ signal }) => AdminSystemService.getSystemApiTokens({ signal }),
+  staleTime: ADMIN_POLL_INTERVAL,
+  refetchInterval: ADMIN_POLL_INTERVAL,
+});
+
+export const adminRetailersQuery = () => queryOptions({
+  queryKey: queryKeys.adminRetailers,
+  queryFn: ({ signal }) => RetailerAdminService.getRetailers({ signal }),
+  staleTime: ADMIN_POLL_INTERVAL,
+  refetchInterval: ADMIN_POLL_INTERVAL,
 });
 
 export const adminSystemSettingsQuery = () => queryOptions({

--- a/frontend/src/features/admin/components/sections/RetailersSection.tsx
+++ b/frontend/src/features/admin/components/sections/RetailersSection.tsx
@@ -1,16 +1,10 @@
 import { useState } from 'react';
-import { queryOptions, useQuery } from '@tanstack/react-query';
-import { RetailerAdminService } from '../../services/RetailerAdminService';
+import { useQuery } from '@tanstack/react-query';
 import { RetailerConfig, GlobalCurrency } from '../../../../types/api';
 import RetailerConfigEditor from './RetailerConfigEditor';
 import Icon from '../../../../components/Icon';
 import { queryClient } from '../../../../api/queryClient';
-
-const retailersQuery = () => queryOptions({
-  queryKey: ['admin', 'retailers'] as const,
-  queryFn: RetailerAdminService.getRetailers,
-  staleTime: 10 * 60_000,
-});
+import { adminRetailersQuery } from '../../../../api/queries';
 
 interface RetailersSectionProps {
   globalCurrencies: GlobalCurrency[];
@@ -20,7 +14,7 @@ interface RetailersSectionProps {
 export default function RetailersSection({ globalCurrencies, initialSearch }: RetailersSectionProps) {
   const [retailerSearch, setRetailerSearch] = useState(initialSearch || '');
   const [editingRetailer, setEditingRetailer] = useState<Partial<RetailerConfig> | null>(null);
-  const retailersResult = useQuery(retailersQuery());
+  const retailersResult = useQuery(adminRetailersQuery());
   const retailers = retailersResult.data ?? [];
 
   const handleEditRetailer = (r: Partial<RetailerConfig>) => {

--- a/frontend/src/features/admin/components/sections/SystemApiTokensSection.tsx
+++ b/frontend/src/features/admin/components/sections/SystemApiTokensSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { AdminSystemService } from '../../services/AdminSystemService';
 import { SystemApiToken } from '../../../../types/api';
 import { useToast } from '../../../../context/ToastContext';
@@ -6,11 +6,18 @@ import ConfirmationModal from '../../../../components/ConfirmationModal';
 import Icon from '../../../../components/Icon';
 import { useAuth } from '../../../auth';
 import { formatDate } from '../../../../utils/format';
+import { useQuery } from '@tanstack/react-query';
+import { adminTokensQuery, queryKeys } from '../../../../api/queries';
+import { queryClient } from '../../../../api/queryClient';
 
 export default function SystemApiTokensSection() {
   const { user } = useAuth();
   const { showToast } = useToast();
-  const [tokens, setTokens] = useState<SystemApiToken[]>([]);
+  // Polled rather than loaded once: tokens can be created or revoked by CLI
+  // scripts and external integrations, and the panel used to show a stale list
+  // until the whole page was reloaded.
+  const tokensResult = useQuery(adminTokensQuery());
+  const tokens: SystemApiToken[] = tokensResult.data ?? [];
   const [isAddingToken, setIsAddingToken] = useState(false);
   const [newTokenLabel, setNewTokenLabel] = useState('');
   const [newTokenDescription, setNewTokenDescription] = useState('');
@@ -18,18 +25,7 @@ export default function SystemApiTokensSection() {
   const [isLoading, setIsLoading] = useState(false);
   const [tokenToDelete, setTokenToDelete] = useState<SystemApiToken | null>(null);
 
-  useEffect(() => {
-    fetchTokens();
-  }, []);
-
-  const fetchTokens = async () => {
-    try {
-      const res = await AdminSystemService.getSystemApiTokens();
-      setTokens(res);
-    } catch {
-      showToast('Failed to load system API tokens', 'error');
-    }
-  };
+  const fetchTokens = () => queryClient.invalidateQueries({ queryKey: queryKeys.adminTokens });
 
   const handleCreateToken = async () => {
     if (!newTokenLabel) {

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -1,9 +1,12 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { UserAdminService } from '../../services/UserAdminService';
 import { UserProfile, GlobalCurrency } from '../../../../types/api';
 import { useToast } from '../../../../context/ToastContext';
 import { apiErrorMessage } from '../../../../api/error';
 import { useAuth } from '../../../auth';
+import { useQuery } from '@tanstack/react-query';
+import { adminUsersQuery, queryKeys } from '../../../../api/queries';
+import { queryClient } from '../../../../api/queryClient';
 import PasswordInput from '../../../../components/PasswordInput';
 import SearchableSelect from '../../../../components/SearchableSelect';
 import { ToggleSwitch } from '../../components';
@@ -17,8 +20,12 @@ interface UsersSectionProps {
 
 export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   const { showToast } = useToast();
-  const { user } = useAuth();
-  const [users, setUsers] = useState<UserProfile[]>([]);
+  const { user: currentUser } = useAuth();
+
+  // Polled rather than loaded once: SSO provisions accounts on first sign-in,
+  // so the panel used to miss users created since it was opened.
+  const usersResult = useQuery(adminUsersQuery());
+  const users: UserProfile[] = usersResult.data ?? [];
   const [isAddingUser, setIsAddingUser] = useState(false);
   const [editingUser, setEditingUser] = useState<Partial<UserProfile> | null>(null);
   const [userToDelete, setUserToDelete] = useState<UserProfile | null>(null);
@@ -35,8 +42,6 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   const [editUserPassword, setEditUserPassword] = useState('');
   const [editUserConfirmPassword, setEditUserConfirmPassword] = useState('');
 
-  const { user: currentUser } = useAuth();
-
   // Filtering is local state, so a background refresh of the list leaves the
   // search box and its results alone.
   const visibleUsers = useMemo(() => {
@@ -50,18 +55,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
 
   const isSsoUser = (u: Partial<UserProfile> | null) => u?.auth_provider === 'oidc';
 
-  useEffect(() => {
-    fetchUsers();
-  }, []);
-
-  const fetchUsers = async () => {
-    try {
-      const res = await UserAdminService.getUsers();
-      setUsers(res);
-    } catch {
-      showToast('Failed to load users', 'error');
-    }
-  };
+  const fetchUsers = () => queryClient.invalidateQueries({ queryKey: queryKeys.adminUsers });
 
   const handleAddUser = async () => {
     if (!newUserEmail || !newUserPassword) { showToast('Email and password required', 'error'); return; }
@@ -182,7 +176,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
                     </td>
                     <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
                       <button className="btn btn-secondary btn-sm" onClick={() => { setEditingUser(u); setEditUserPassword(''); setEditUserConfirmPassword(''); }} style={{ marginRight: '0.5rem' }}>Edit</button>
-                      {u.id !== user?.id && <button className="btn btn-danger btn-sm" onClick={() => setUserToDelete(u)}>Delete</button>}
+                      {u.id !== currentUser?.id && <button className="btn btn-danger btn-sm" onClick={() => setUserToDelete(u)}>Delete</button>}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/features/admin/services/AdminSystemService.ts
+++ b/frontend/src/features/admin/services/AdminSystemService.ts
@@ -20,7 +20,7 @@ export const AdminSystemService = {
   clearLogs: (level?: string, context?: string) => api.delete('/admin/logs/clear', { params: { level, context } }),
 
   // System API Tokens
-  getSystemApiTokens: () => api.get<SystemApiToken[]>('/admin/system-tokens'),
+  getSystemApiTokens: (options?: RequestOptions) => api.get<SystemApiToken[]>('/admin/system-tokens', options),
   createSystemApiToken: (data: { label: string; description?: string; expires_at?: string }) => 
     api.post<CreateSystemApiTokenResponse>('/admin/system-tokens', data),
   deleteSystemApiToken: (id: number) => api.delete(`/admin/system-tokens/${id}`),

--- a/frontend/src/features/admin/services/RetailerAdminService.ts
+++ b/frontend/src/features/admin/services/RetailerAdminService.ts
@@ -1,8 +1,8 @@
-import { api } from '../../../api/client';
+import { api, type RequestOptions } from '../../../api/client';
 import { RetailerConfig, TestRetailerConfigResult } from '../../../types/api';
 
 export const RetailerAdminService = {
-  getRetailers: () => api.get<RetailerConfig[]>('/admin/retailers'),
+  getRetailers: (options?: RequestOptions) => api.get<RetailerConfig[]>('/admin/retailers', options),
   getRetailerByDomain: (domain: string) => api.get<RetailerConfig>(`/admin/retailers/domain/${domain}`),
   lookupRetailerByUrl: (url: string) => api.get<RetailerConfig>('/admin/retailers/lookup', { params: { url } }),
   testRetailerConfig: (config: Partial<RetailerConfig>, testUrl: string) =>

--- a/frontend/src/features/admin/services/UserAdminService.ts
+++ b/frontend/src/features/admin/services/UserAdminService.ts
@@ -1,8 +1,8 @@
-import { api } from '../../../api/client';
+import { api, type RequestOptions } from '../../../api/client';
 import { UserProfile } from '../../../types/api';
 
 export const UserAdminService = {
-  getUsers: () => api.get<UserProfile[]>('/admin/users'),
+  getUsers: (options?: RequestOptions) => api.get<UserProfile[]>('/admin/users', options),
   deleteUser: (id: number) => api.delete(`/admin/users/${id}`),
   updateUser: (id: number, data: Partial<UserProfile> & { password?: string }) => 
     api.put(`/admin/users/${id}`, data),


### PR DESCRIPTION
Wave 5, third block. Closes #86.

## The problem

The three admin lists fell out of date on their own and had no way to notice:

| Section | Before |
|---|---|
| Retailers | TanStack Query with a **10-minute** `staleTime` |
| Users | `useEffect` on mount, never again |
| API Tokens | `useEffect` on mount, never again |

Meanwhile the scraper auto-creates retailer configs, SSO provisions accounts on first sign-in, and tokens can be managed by CLI scripts. An administrator had to reload the whole page to see any of it.

## What changed

All three now share **one** polled query definition in `api/queries.ts`. 30 seconds rather than the dashboard's 15 — these change on human timescales, and React Query stops polling a hidden tab by itself, so an idle admin page costs nothing.

Users and API Tokens move from `useEffect`-plus-manual-fetch to the query, with mutations invalidating the key rather than calling a refetch function.

Search and filter state stays in component state, so a background refresh updates the rows underneath without disturbing what the administrator typed. That is the specific failure the issue describes — filtered results staying empty until a full reload.

Retailers had its **own local query definition** duplicating what now lives in `api/queries.ts`; folded into the shared one so the three cannot drift apart again.

## Two things noticed on the way

- The admin list services did not accept `RequestOptions`, so React Query had no way to cancel an in-flight poll. Added.
- `UsersSection` had ended up with two `useAuth()` calls after #118. Consolidated.

## Verification

Route acceptance suite 13/13, frontend unit tests, build and typecheck, emoji lint, `git diff --check` — all pass. The route specs exercise every admin section, which is what would catch a broken conversion.

Closes #86