### PR TITLE
fix(ui): card overlap on tablets, squashed filter pills, quick-track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Product search results now offer both **Track** and **Configure**. Track adds
+  the product straight away with the default settings; Configure opens the usual
+  form for setting an interval or categories first. Repeated clicks while a
+  track is in flight no longer add the product twice.
 - Admin Retailers, Users and API Tokens now refresh in the background, so
   retailers the scraper auto-creates, accounts SSO provisions on first sign-in,
   and tokens managed outside the UI appear without reloading the page. Search
@@ -93,6 +97,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The product card's price and status no longer overlap the sparkline in the
+  two-column layout on tablets. The stacked layout now responds to the width of
+  the card rather than the width of the window, so it applies whenever a card is
+  narrow instead of only on a narrow screen.
+- Price selection dialog filter pills no longer squash their labels; the row
+  scrolls as intended when the filters do not fit.
 - SSO accounts can no longer have a local password set or their email changed
   from the admin user editor. Setting a password on an account provisioned for
   external sign-in enabled local authentication on it, and a locally changed

--- a/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.css
+++ b/frontend/src/features/products/components/PriceSelectionModal/PriceSelectionModal.css
@@ -248,6 +248,10 @@
   cursor: pointer;
   white-space: nowrap;
   transition: all 0.15s ease;
+  /* Flex items shrink before their container overflows, so without this the
+     pills compress and their labels spill out of the rounded background rather
+     than the row scrolling as the overflow-x above intends. */
+  flex-shrink: 0;
 }
 
 .price-filter-tab:hover {

--- a/frontend/src/features/products/components/ProductCard/ProductCard.css
+++ b/frontend/src/features/products/components/ProductCard/ProductCard.css
@@ -1,4 +1,9 @@
+/* The dashboard lays cards out in two columns down to a 768px viewport, so a
+   card can be ~350px wide while the viewport is wide. Viewport media queries
+   cannot see that, which is why the stacked layout below is a container query
+   on the card itself. */
 .pb-card {
+  container-type: inline-size;
   display: flex;
   background: var(--surface);
   border-radius: 0.75rem;
@@ -117,6 +122,10 @@
   margin-left: auto;
   align-self: center;
   padding-right: 0.5rem;
+  /* The sparkline renders a fixed-width SVG. Without this the flex item is
+     squeezed below that width and the SVG spills over the product details
+     beside it. */
+  flex-shrink: 0;
 }
 
 .pb-card-actions {
@@ -213,6 +222,25 @@
     display: flex;
     flex-basis: 100%; 
     justify-content: center; 
+    margin-left: 0;
+    margin-top: 0.5rem;
+    padding-right: 0;
+  }
+}
+
+/* Same layout, keyed to the card rather than the window. This is what catches
+   the two-column tablet case, where each card is narrow but the viewport is
+   not. The media query above stays as the fallback for browsers without
+   container query support. */
+@container (max-width: 520px) {
+  .pb-card-content { padding: 0.75rem; gap: 0.75rem; flex-wrap: wrap; }
+  .pb-card-image-wrapper { width: 60px; height: 60px; }
+  .pb-card-info { flex-basis: calc(100% - 60px - 0.75rem); }
+  .pb-card-price { font-size: 1.25rem; }
+  .pb-card-chart {
+    display: flex;
+    flex-basis: 100%;
+    justify-content: center;
     margin-left: 0;
     margin-top: 0.5rem;
     padding-right: 0;

--- a/frontend/src/features/products/components/ProductForm/ProductForm.css
+++ b/frontend/src/features/products/components/ProductForm/ProductForm.css
@@ -186,6 +186,20 @@
 
 .result-actions {
   margin-left: 1.5rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  /* Two buttons now; keep them beside the result rather than letting the
+     result text squeeze them. */
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .result-actions {
+    margin-left: 0;
+    margin-top: 0.75rem;
+    width: 100%;
+  }
 }
 
 .empty-search-state {

--- a/frontend/src/features/products/components/ProductForm/ProductForm.tsx
+++ b/frontend/src/features/products/components/ProductForm/ProductForm.tsx
@@ -30,6 +30,8 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
   const [refreshInterval, setRefreshInterval] = useState(43200);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ReactNode>('');
+  // Which search result is being tracked, so only that row shows a spinner.
+  const [trackingUrl, setTrackingUrl] = useState<string | null>(null);
 
   const handleSearch = async (e: FormEvent) => {
     e.preventDefault();
@@ -66,9 +68,32 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    await submitUrl(url);
+  };
+
+  /**
+   * Tracks a search result immediately with the current defaults.
+   *
+   * Choosing a result used to drop the user back into the URL form with the
+   * field filled in, so tracking something with default settings took an extra
+   * step for no decision. Configure still opens that form for anyone who wants
+   * to set an interval or categories first.
+   */
+  const handleQuickTrack = async (resultUrl: string) => {
+    // A second click while the first is in flight would add the product twice.
+    if (isLoading) return;
+    setTrackingUrl(resultUrl);
+    try {
+      await submitUrl(resultUrl);
+    } finally {
+      setTrackingUrl(null);
+    }
+  };
+
+  const submitUrl = async (rawUrl: string) => {
     setError('');
 
-    let processedUrl = url.trim();
+    let processedUrl = rawUrl.trim();
 
     if (!/^https?:\/\//i.test(processedUrl)) {
       processedUrl = 'https://' + processedUrl;
@@ -269,14 +294,22 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
                     <p className="result-content">{result.content}</p>
                   </div>
                   <div className="result-actions">
-                    <button 
+                    <button
+                      className="btn btn-primary btn-sm"
+                      disabled={isLoading}
+                      onClick={() => void handleQuickTrack(result.url)}
+                    >
+                      {trackingUrl === result.url ? <LoadingSpinner size="1rem" /> : 'Track'}
+                    </button>
+                    <button
                       className="btn btn-secondary btn-sm"
+                      disabled={isLoading}
                       onClick={() => {
                         setUrl(result.url);
                         setMode('url');
                       }}
                     >
-                      Track this
+                      Configure
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
Closes #117; the concrete parts of #54 and #94.

## Card overlap (#117)

The dashboard lays cards out in **two columns down to a 768px viewport**, but the stacked card layout only applied **below 480px**. In between, a card is roughly 350px wide while the window is not — so the desktop layout ran in a space it does not fit:

- `.pb-card-chart` had no `flex-shrink` guard, so it was squeezed below the sparkline's fixed SVG width.
- The SVG keeps `width={100}` regardless, so it spilled over the product details beside it.

**A viewport media query cannot fix this, because the viewport is not the thing that is narrow.** The stacked rules are now a **container query on the card itself**, so they apply whenever a card is narrow regardless of screen size — which is exactly the two-column tablet case in your screenshot. The 480px media query stays as the fallback for browsers without container query support, and the chart gets an explicit `flex-shrink: 0` so the SVG can never be compressed even above the breakpoint.

## Filter pills (#54)

`.price-filter-tabs` sets `overflow-x: auto`, but flex items shrink *before* their container overflows — so the pills compressed and their labels spilled out of the rounded background instead of the row scrolling. `flex-shrink: 0` lets the overflow actually happen, which is what the `auto` was for.

## Track and Configure (#94)

Choosing a search result dropped the user back into the URL form with the field filled in, so tracking something with default settings cost an extra step for no decision.

- **Track** adds it directly with the defaults.
- **Configure** opens the existing form for anyone who wants to set an interval or categories first.

The submit body is shared rather than duplicated, so quick-track gets the same 409 / 403 / 400 error handling — including the "you already track this, click to view" link — and errors render in the search pane, not only the URL pane. An in-flight guard stops a second click adding the product twice, which the issue calls out specifically.

## Scope

**#54 and #94 stay open.**

- #54 is an explicit catch-all ("put all front end issues in this issue"). The filter-pill alignment from its screenshot is fixed; it will not close until it is split into per-screen items.
- #94's SearXNG result-relevance half is open-ended research and is untouched.

## Verification

Route acceptance 13/13, frontend unit tests, build and typecheck, emoji lint, `git diff --check` — all pass.