### PR TITLE
fix(admin): remove an emoji the check could not see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed an hourglass emoji from the admin Extraction Rules panel and closed
+  the gap in the emoji check that let it through, so the icon set stays the only
+  thing rendering symbols in the UI.
 - The product card's price and status no longer overlap the sparkline in the
   two-column layout on tablets. The stacked layout now responds to the width of
   the card rather than the width of the window, so it applies whenever a card is

--- a/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
+++ b/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
@@ -140,7 +140,7 @@ export default function GlobalSelectorsSection() {
         <UnifiedSelectorManager label="Generic Original Price Selectors" items={globalOriginalPriceSelectors} onChange={setGlobalOriginalPriceSelectors} placeholder=".rrp, .was-price" />
       </CollapsibleCard>
 
-      <CollapsibleCard title="⏳ Generic Pre-Order Price Selectors" id="sys_sel_preorder" badge={String(globalPreOrderPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+      <CollapsibleCard title="Generic Pre-Order Price Selectors" leadingIcon={<Icon name="clock" />} id="sys_sel_preorder" badge={String(globalPreOrderPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
         <UnifiedSelectorManager label="Generic Pre-Order Price Selectors" items={globalPreOrderPriceSelectors} onChange={setGlobalPreOrderPriceSelectors} placeholder=".preorder-price" />
       </CollapsibleCard>
 

--- a/scripts/check-no-emoji.mjs
+++ b/scripts/check-no-emoji.mjs
@@ -24,7 +24,20 @@ const RANGES = [
   [0x2b00, 0x2bff], // misc symbols and arrows (⬅ ⬆ ⭐ …)
   [0xfe00, 0xfe0f], // variation selectors (the "️" that trails many emoji)
   [0x1f1e6, 0x1f1ff], // regional indicators (flags)
+
+  // Emoji inside Miscellaneous Technical (U+2300–23FF). Listed as three narrow
+  // ranges rather than the whole block, which also holds genuine technical
+  // symbols. An hourglass (⏳ U+23F3) sat in the admin UI unnoticed because
+  // nothing here reached this far.
+  [0x231a, 0x231b], // ⌚ ⌛
+  [0x23e9, 0x23f3], // ⏩ ⏪ ⏫ ⏬ ⏭ ⏮ ⏯ ⏰ ⏱ ⏲ ⏳
+  [0x23f8, 0x23fa], // ⏸ ⏹ ⏺
+  [0x2934, 0x2935], // ⤴ ⤵ arrows presented as emoji
 ];
+
+// Deliberately NOT flagged, because CLAUDE.md permits them as genuine text:
+// plain arrows (U+2190–21FF), bullets, em-dashes, ellipses, and the geometric
+// shapes (▼ ▲) used as sort and disclosure indicators.
 
 const inRange = (cp) => RANGES.some(([lo, hi]) => cp >= lo && cp <= hi);
 


### PR DESCRIPTION
CLAUDE.md rule 1 forbids emoji in the UI and CI enforces it. An hourglass has been sitting in the admin **Extraction Rules** panel title, and `pnpm run lint` passed the whole time.

```tsx
<CollapsibleCard title="⏳ Generic Pre-Order Price Selectors" ...>
```

## Why the check missed it

`scripts/check-no-emoji.mjs` scans a set of codepoint ranges. U+23F3 lives in **Miscellaneous Technical** (U+2300–23FF), which none of them reached — the nearest range starts at U+2600.

## Fix

- Replaced the emoji with the `Icon` component the other cards in that panel already use.
- Extended the check to cover the emoji inside Miscellaneous Technical: `U+231A–231B`, `U+23E9–23F3`, `U+23F8–23FA`, plus `U+2934–2935`.

Added as **three narrow ranges rather than the whole block**, because U+2300–23FF also holds genuine technical symbols.

## Deliberately still not flagged

I scanned the rest of the frontend for characters in the uncovered ranges. Everything else is real typography, and CLAUDE.md permits it:

| Character | Used for |
|---|---|
| `→ ← ↑ ↓` | back links, sort indicators, the scroll hint |
| `•` | password strength dots |
| `— …` | em-dashes and ellipses in copy |
| `▼ ▲` | disclosure and sort indicators |

Flagging the geometric shapes would be the same overreach as flagging the arrows — they are indicators, not decoration.

## Verification

Re-introduced the emoji: the check **fails** on it. Removed it again: **passes**. So this is a fix to the guard, not just to the one instance.