### PR TITLE
feat(admin): regroup the extraction screens by what each rule does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Global Selectors** is now **Extraction Rules**, grouped by the job each rule
+  does -- product information, pricing, availability, false-positive prevention
+  -- rather than listed in storage order, and it states the rule priority
+  (retailer rules, then these, then built-in fallbacks) and the stock detection
+  order.
+- The retailer editor is grouped the same way. Its single "Extraction
+  Parameters" card, which held the title, image, five price types, both JSON-LD
+  keys, exclusions and the raw selector JSON, is now three focused cards, and a
+  sticky header keeps the retailer name and the save action in reach.
 - **Breaking:** the three per-retailer scraper toggles (`use_browser`,
   `is_js_heavy`, `use_remote_scraper`) are consolidated into a single
   "Browser Scraper" flag; existing configurations migrate automatically.
@@ -28,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Re-run auto-map** on the retailer editor regenerates a retailer's selectors
+  from a product page you supply, without having to delete the retailer and
+  re-scrape a product through it first.
+- Both extraction screens now say that saved changes reach a running scraper
+  within 30 minutes, with an **Apply now** button that clears the cache
+  immediately.
 - Product search results now offer both **Track** and **Configure**. Track adds
   the product straight away with the default settings; Configure opens the usual
   form for setting an interval or categories first. Repeated clicks while a

--- a/backend/src/routes/admin/retailers.ts
+++ b/backend/src/routes/admin/retailers.ts
@@ -2,6 +2,7 @@ import { Router, Response } from 'express';
 import { AuthRequest } from '../../middleware/auth';
 import { retailerService } from '../../services/domain/retailer';
 import { asyncHandler, parseIdParam } from '../../utils/system/route-helpers';
+import { randomUUID } from 'node:crypto';
 
 const router = Router();
 
@@ -50,6 +51,83 @@ router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const updated = await retailerService.upsertRetailer(config);
   res.json(updated);
 }, 'Admin | Upsert Retailer', 'Admin', 'Failed to save retailer'));
+
+/**
+ * Re-runs AI auto-mapping for an existing retailer against a product URL.
+ *
+ * Auto-mapping normally fires only for an unknown domain or a shell config, so
+ * the way to fix a bad retailer configuration was to delete the retailer and
+ * re-scrape a product through it (issue #74). This re-runs the same generation
+ * against a URL the administrator supplies and saves the result, without
+ * destroying the row first.
+ *
+ * Keyed on the URL rather than a retailer id: the URL is what determines which
+ * retailer this is, so the two cannot disagree.
+ *
+ * A product URL is required and cannot be inferred -- mapping works by reading a
+ * real product page, and a retailer's home page has no price to learn from.
+ */
+router.post('/remap', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const { url } = req.body ?? {};
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ error: 'A product URL from this retailer is required.' });
+    return;
+  }
+
+  const { regionalMappingCache, configCache } = await import('../../utils/cache');
+  const domain = await regionalMappingCache.getLookupDomain(url);
+
+  const existing = await retailerService.getRetailerByDomain(domain);
+  if (!existing) {
+    res.status(404).json({ error: `No retailer is configured for ${domain}.` });
+    return;
+  }
+
+  const { acquireHtml } = await import('../../services/scraper/acquisition');
+  const { handleAutoMapping } = await import('../../services/scraper/orchestration/maintenance');
+
+  const extractionSteps: string[] = [];
+  const acquired = await acquireHtml({
+    url,
+    domain,
+    domainConfig: existing,
+    extractionSteps,
+    requestId: `REMAP-${randomUUID()}`,
+  });
+
+  if (!acquired.html) {
+    res.status(502).json({
+      error: 'Could not fetch that page. If the retailer blocks plain requests, enable the Browser Scraper for it first.',
+      trace: extractionSteps,
+    });
+    return;
+  }
+
+  const config = await handleAutoMapping({
+    html: acquired.html,
+    url,
+    domain,
+    currencyHint: existing.currency_hint || null,
+    localeHint: 'en-US',
+    extractionSteps,
+    learnedFlags: acquired.learnedFlags || {},
+    isRefresh: true,
+  });
+
+  if (!config) {
+    res.status(422).json({
+      error: 'Auto-mapping could not find a usable price on that page, so nothing was changed.',
+      trace: extractionSteps,
+    });
+    return;
+  }
+
+  // The running scraper caches configs; without this the next scrape would keep
+  // using the previous one for up to 30 minutes.
+  configCache.invalidate(domain);
+
+  res.json({ success: true, retailer: config, trace: extractionSteps });
+}, 'Admin | Retailer Remap', 'Admin', 'Failed to re-run auto-mapping'));
 
 router.delete('/:id', asyncHandler(async (req: AuthRequest, res: Response) => {
   const id = parseIdParam(req, 'id');

--- a/docs/admin/admin_guide.md
+++ b/docs/admin/admin_guide.md
@@ -12,13 +12,46 @@ The System Administration screen is organized into eight specialized tabs:
 Configure network proxy routing, remote Puppeteer scraper links, browser timeouts/referrers, product discovery via SearXNG, and master toggles for registrations or debug pages.
 * *For details, see [system.md](system.md).*
 
-### 2. Global Selectors
-Configure default system-wide extraction selectors. These act as universal fallbacks if a retailer has no domain-specific configuration defined.
-* **Global Price Selectors**: Standard class and attribute patterns used to find price strings.
-* **Global Stock Selectors**: Universal phrases or attribute schemas (like `[itemprop="availability"]`) used to assess stock levels.
+### 2. Extraction Rules
+Default system-wide extraction rules, used as fallbacks when a retailer has no
+site-specific configuration of its own.
+
+Rule priority: **retailer rules -> these default rules -> built-in fallbacks.**
+
+The screen is grouped by the job each rule does:
+
+* **Product information**: product title, retailer identity, product image.
+  Retailer identity is the shop, not the manufacturer.
+* **Pricing**: current, sale/deal, member, pre-order, and original/RRP. Only the
+  current price becomes the tracked price; the rest are recorded alongside it.
+* **Availability**: stock evidence selectors, then the status phrases read inside
+  them. Detection order is member only -> pre-order -> out of stock -> in stock.
+* **False-positive prevention**: exclusion selectors, removed from the page
+  before extraction runs.
+
+Saved changes reach a running scraper within 30 minutes, because settings are
+cached. The **Apply now** button on this screen clears that cache immediately.
 
 ### 3. Retailers
-Manage configurations on a domain-by-domain basis. You can add new domains, inspect selector counts, configure anti-bot proxies, test scraper configs, or edit custom selectors.
+Manage configurations on a domain-by-domain basis. The editor is grouped the same
+way as Extraction Rules:
+
+* **Retailer identity**: friendly name, domain, notes, and the selectors that
+  identify the shop.
+* **Page acquisition**: browser scraper, proxy, currency hint, user agent,
+  referrer.
+* **Product information**: title and image selectors, and their JSON-LD keys.
+* **Pricing**: the five price types, the JSON-LD price key, and the per-retailer
+  **Prefer JSON-LD Images** override.
+* **False-positive prevention**: exclusion selectors and the raw selector JSON.
+* **Availability**: stock evidence and status phrases.
+* **Validation**: the live tester and AI preprocessor selectors.
+
+**Re-run auto-map** in the sticky header regenerates a retailer's selectors from a
+product page you supply, without deleting the retailer first. A product URL is
+required: mapping works by reading a real product page, and a home page has no
+price to learn from. The generated configuration replaces what is saved, and the
+scraper's config cache is cleared so the next scrape uses it.
 * *For selector syntax rules and eviction mechanics, see [selectors.md](selectors.md).*
 
 ### 4. Users

--- a/frontend/src/features/admin/components/RuleGroup.tsx
+++ b/frontend/src/features/admin/components/RuleGroup.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react';
+
+/**
+ * A labelled band of related rule cards.
+ *
+ * Both extraction screens previously listed every selector list as a sibling in
+ * storage order, which told an administrator what the fields are called but not
+ * what they are for. Grouping them by the job they do -- product information,
+ * pricing, availability -- is what makes either screen navigable.
+ */
+export function RuleGroup({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section style={{ marginTop: '1.75rem' }}>
+      <h3
+        style={{
+          fontSize: '0.7rem',
+          fontWeight: 700,
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: 'var(--text-muted)',
+          margin: '0 0 0.5rem',
+          paddingTop: '1rem',
+          borderTop: '1px solid var(--border)',
+        }}
+      >
+        {title}
+      </h3>
+      {description && (
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', margin: '0 0 1rem', maxWidth: '70ch' }}>
+          {description}
+        </p>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>{children}</div>
+    </section>
+  );
+}
+
+/**
+ * States an ordering the scraper actually applies. Both the rule precedence and
+ * the stock detection order are real behaviour that is currently documented
+ * nowhere a user will look, and not knowing the first one is what makes a
+ * learned site-specific selector silently beating a working generic one so hard
+ * to diagnose.
+ */
+export function PriorityNote({ label, steps }: { label: string; steps: string[] }) {
+  return (
+    <div
+      style={{
+        background: 'rgba(var(--primary-rgb), 0.06)',
+        borderLeft: '3px solid var(--primary)',
+        borderRadius: '0 0.35rem 0.35rem 0',
+        padding: '0.6rem 0.85rem',
+        margin: '0 0 1rem',
+        fontSize: '0.8rem',
+        color: 'var(--text-muted)',
+      }}
+    >
+      <strong style={{ color: 'var(--text)', display: 'block', marginBottom: '0.15rem' }}>{label}</strong>
+      <span style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem', alignItems: 'center' }}>
+        {steps.map((step, i) => (
+          <span key={step} style={{ display: 'inline-flex', gap: '0.35rem', alignItems: 'center' }}>
+            {step}
+            {i < steps.length - 1 && <span aria-hidden="true">&rarr;</span>}
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}
+
+/** Sits under a rule card to say what the field is for, in one sentence. */
+export function FieldHelp({ children }: { children: ReactNode }) {
+  return (
+    <p style={{ fontSize: '0.8rem', color: 'var(--text-muted)', margin: '0.5rem 0 0', maxWidth: '70ch' }}>
+      {children}
+    </p>
+  );
+}

--- a/frontend/src/features/admin/components/SettingsCacheNotice.tsx
+++ b/frontend/src/features/admin/components/SettingsCacheNotice.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { AdminSystemService } from '../services/AdminSystemService';
+import { useToast } from '../../../context/ToastContext';
+import Icon from '../../../components/Icon';
+
+/**
+ * Explains that a saved extraction change is not live yet, and offers to make it
+ * live.
+ *
+ * The backend caches system settings and retailer configs for 30 minutes. An
+ * administrator who edits a selector, re-scrapes and sees no change has no way
+ * to tell whether the selector is wrong or simply not loaded yet -- so they
+ * assume it is wrong and keep editing.
+ *
+ * The command behind the button already existed and was wired into System
+ * settings and the debug page, but not into either screen where selectors are
+ * actually edited.
+ */
+export default function SettingsCacheNotice({ compact = false }: { compact?: boolean }) {
+  const { showToast } = useToast();
+  const [isClearing, setIsClearing] = useState(false);
+  const [cleared, setCleared] = useState(false);
+
+  const handleApply = async () => {
+    setIsClearing(true);
+    try {
+      await AdminSystemService.executeCommand('clear-settings-cache');
+      setCleared(true);
+      showToast('Extraction rules are now live', 'success');
+    } catch {
+      showToast('Could not refresh the settings cache', 'error');
+    } finally {
+      setIsClearing(false);
+    }
+  };
+
+  return (
+    <div
+      className="alert"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '1rem',
+        flexWrap: 'wrap',
+        background: 'var(--background)',
+        border: '1px solid var(--border)',
+        color: 'var(--text-muted)',
+        fontSize: '0.8rem',
+        marginBottom: compact ? '1rem' : '1.5rem',
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <Icon name="clock" size="1rem" />
+        {cleared
+          ? 'Caches cleared. The next scrape uses these rules.'
+          : 'Saved changes reach a running scraper within 30 minutes.'}
+      </span>
+      {!cleared && (
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={() => void handleApply()}
+          disabled={isClearing}
+        >
+          {isClearing ? 'Applying...' : 'Apply now'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/components/index.ts
+++ b/frontend/src/features/admin/components/index.ts
@@ -3,3 +3,5 @@ export { default as CollapsibleCard } from '../../../components/CollapsibleCard'
 export { default as UnifiedSelectorManager } from './UnifiedSelectorManager';
 export { default as ToggleSwitch } from './ToggleSwitch';
 export { default as ListManager } from './ListManager';
+export { default as SettingsCacheNotice } from './SettingsCacheNotice';
+export { RuleGroup, PriorityNote, FieldHelp } from './RuleGroup';

--- a/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
+++ b/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
@@ -2,9 +2,13 @@ import { useState, useEffect } from 'react';
 import { AdminSystemService } from '../../services/AdminSystemService';
 import { useToast } from '../../../../context/ToastContext';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
-import { 
-  CollapsibleCard, 
-  UnifiedSelectorManager 
+import {
+  CollapsibleCard,
+  UnifiedSelectorManager,
+  SettingsCacheNotice,
+  RuleGroup,
+  PriorityNote,
+  FieldHelp
 } from '../../components';
 import Icon from '../../../../components/Icon';
 import { queryClient } from '../../../../api/queryClient';
@@ -104,9 +108,9 @@ export default function GlobalSelectorsSection() {
 
       const updated = await AdminSystemService.updateSystemSettings(payload);
       queryClient.setQueryData(queryKeys.adminSystemSettings, updated);
-      showToast('Global selectors saved successfully', 'success');
+      showToast('Extraction rules saved', 'success');
     } catch {
-      showToast('Failed to save selectors', 'error');
+      showToast('Failed to save extraction rules', 'error');
     } finally {
       setIsSaving(false);
     }
@@ -116,73 +120,121 @@ export default function GlobalSelectorsSection() {
 
   return (
     <div className="settings-card">
-      <h2 className="settings-card-title">Global HTML Selector Configuration</h2>
+      <h2 className="settings-card-title">Extraction Rules</h2>
+      <p style={{ color: 'var(--text-muted)', fontSize: '0.9rem', marginTop: '-0.75rem', marginBottom: '1rem', maxWidth: '70ch' }}>
+        Fallbacks used when a retailer has no site-specific rules of its own.
+      </p>
 
-      <CollapsibleCard title="Generic Price Selectors" leadingIcon={<Icon name="search" />} id="sys_sel_price" badge={String(globalPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Price Selectors" items={globalPriceSelectors} onChange={setGlobalPriceSelectors} placeholder=".price, #price" />
-      </CollapsibleCard>
+      <PriorityNote
+        label="Rule priority"
+        steps={['Retailer rules', 'These default rules', 'Built-in fallbacks']}
+      />
 
-      <CollapsibleCard title="Deal / Sale / Clearance Price Selectors" leadingIcon={<Icon name="tag" />} id="sys_sel_deal" badge={String(globalDealPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Deal / Sale / Clearance Price Selectors" items={globalDealPriceSelectors} onChange={setGlobalDealPriceSelectors} placeholder=".price-item--sale" />
-      </CollapsibleCard>
+      <SettingsCacheNotice />
 
-      <CollapsibleCard title="Generic Member Price Selectors" leadingIcon={<Icon name="users" />} id="sys_sel_member" badge={String(globalMemberPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Member Price Selectors" items={globalMemberPriceSelectors} onChange={setGlobalMemberPriceSelectors} placeholder=".member-price" />
-      </CollapsibleCard>
+      <RuleGroup
+        title="Product information"
+        description="What is being tracked, and which shop it came from."
+      >
+        <CollapsibleCard title="Product title" leadingIcon={<Icon name="fileText" />} id="sys_sel_name" badge={String(globalNameSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Product title selectors" items={globalNameSelectors} onChange={setGlobalNameSelectors} placeholder="h1, .product-name" />
+          <FieldHelp>Identifies the product being tracked.</FieldHelp>
+        </CollapsibleCard>
 
-      <CollapsibleCard title="Generic Original Price (RRP) Selectors" leadingIcon={<Icon name="tag" />} id="sys_sel_original" badge={String(globalOriginalPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <p style={{ color: 'var(--text-muted)', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
-          Used only when a retailer has no Original / RRP selectors of its own. Generic
-          RRP patterns match strikethrough prices anywhere on the page, including
-          unrelated products in carousels and grids, so prefer per-retailer selectors
-          and keep this list short.
-        </p>
-        <UnifiedSelectorManager label="Generic Original Price Selectors" items={globalOriginalPriceSelectors} onChange={setGlobalOriginalPriceSelectors} placeholder=".rrp, .was-price" />
-      </CollapsibleCard>
+        <CollapsibleCard title="Retailer identity" leadingIcon={<Icon name="building" />} id="sys_sel_retailer" badge={String(globalRetailerNameSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Retailer identity selectors" items={globalRetailerNameSelectors} onChange={setGlobalRetailerNameSelectors} placeholder="meta[property='og:site_name']" />
+          <FieldHelp>
+            Identifies the shop, not the product manufacturer. Brand selectors do not
+            belong here: they make a store take the first scraped product's brand as
+            its name.
+          </FieldHelp>
+        </CollapsibleCard>
 
-      <CollapsibleCard title="Generic Pre-Order Price Selectors" leadingIcon={<Icon name="clock" />} id="sys_sel_preorder" badge={String(globalPreOrderPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Pre-Order Price Selectors" items={globalPreOrderPriceSelectors} onChange={setGlobalPreOrderPriceSelectors} placeholder=".preorder-price" />
-      </CollapsibleCard>
+        <CollapsibleCard title="Product image" leadingIcon={<Icon name="image" />} id="sys_sel_image" badge={String(globalImageSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Product image selectors" items={globalImageSelectors} onChange={setGlobalImageSelectors} placeholder="img.product" />
+          <FieldHelp>Identifies the main product image. Relative and protocol-relative URLs are resolved against the product page.</FieldHelp>
+        </CollapsibleCard>
+      </RuleGroup>
 
-      <CollapsibleCard title="Generic Name Selectors" leadingIcon={<Icon name="fileText" />} id="sys_sel_name" badge={String(globalNameSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Name Selectors" items={globalNameSelectors} onChange={setGlobalNameSelectors} placeholder="h1, .product-name" />
-      </CollapsibleCard>
+      <RuleGroup
+        title="Pricing"
+        description="Only the current price becomes the product's tracked price. The others are recorded alongside it."
+      >
+        <CollapsibleCard title="Current price" leadingIcon={<Icon name="search" />} id="sys_sel_price" badge={String(globalPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Current price selectors" items={globalPriceSelectors} onChange={setGlobalPriceSelectors} placeholder=".price, #price" />
+          <FieldHelp>The price saved as the product's tracked price.</FieldHelp>
+        </CollapsibleCard>
 
-      <CollapsibleCard title="Generic Retailer Name Selectors" leadingIcon={<Icon name="building" />} id="sys_sel_retailer" badge={String(globalRetailerNameSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Retailer Name Selectors" items={globalRetailerNameSelectors} onChange={setGlobalRetailerNameSelectors} placeholder="meta[property='og:site_name']" />
-      </CollapsibleCard>
+        <CollapsibleCard title="Sale / deal price" leadingIcon={<Icon name="tag" />} id="sys_sel_deal" badge={String(globalDealPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Sale / deal price selectors" items={globalDealPriceSelectors} onChange={setGlobalDealPriceSelectors} placeholder=".price-item--sale" />
+          <FieldHelp>A public promotional price. Takes priority over the current price when found.</FieldHelp>
+        </CollapsibleCard>
 
-      <CollapsibleCard title="Generic Image Selectors" leadingIcon={<Icon name="image" />} id="sys_sel_image" badge={String(globalImageSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Image Selectors" items={globalImageSelectors} onChange={setGlobalImageSelectors} placeholder="img.product" />
-      </CollapsibleCard>
+        <CollapsibleCard title="Member price" leadingIcon={<Icon name="users" />} id="sys_sel_member" badge={String(globalMemberPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Member price selectors" items={globalMemberPriceSelectors} onChange={setGlobalMemberPriceSelectors} placeholder=".member-price" />
+          <FieldHelp>A loyalty or account-holder price. Recorded separately and never used as the all-time low.</FieldHelp>
+        </CollapsibleCard>
 
-      <CollapsibleCard title="Generic Stock Selectors" leadingIcon={<Icon name="package" />} id="sys_sel_stock" badge={String(globalStockSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Stock Selectors" items={globalStockSelectors} onChange={setGlobalStockSelectors} placeholder=".stock-status, .availability" />
-      </CollapsibleCard>
+        <CollapsibleCard title="Pre-order price" leadingIcon={<Icon name="clock" />} id="sys_sel_preorder" badge={String(globalPreOrderPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Pre-order price selectors" items={globalPreOrderPriceSelectors} onChange={setGlobalPreOrderPriceSelectors} placeholder=".preorder-price" />
+          <FieldHelp>A price for an item not yet released.</FieldHelp>
+        </CollapsibleCard>
 
-      <CollapsibleCard title="Generic Exclusion Selectors" leadingIcon={<Icon name="ban" />} id="sys_sel_exclusion" badge={String(globalExclusionSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <UnifiedSelectorManager label="Generic Exclusion Selectors" items={globalExclusionSelectors} onChange={setGlobalExclusionSelectors} placeholder=".ad-container, .carousel" />
-      </CollapsibleCard>
+        <CollapsibleCard title="Original / RRP price" leadingIcon={<Icon name="tag" />} id="sys_sel_original" badge={String(globalOriginalPriceSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Original / RRP selectors" items={globalOriginalPriceSelectors} onChange={setGlobalOriginalPriceSelectors} placeholder=".rrp, .was-price" />
+          <FieldHelp>
+            Reference price only; never saved as the tracked price. Generic RRP
+            patterns match strikethrough prices anywhere on the page, including
+            unrelated products in carousels, so prefer per-retailer selectors and
+            keep this list short.
+          </FieldHelp>
+        </CollapsibleCard>
+      </RuleGroup>
 
-      <CollapsibleCard title="Global Stock Phrases" leadingIcon={<Icon name="package" />} id="sys_phrases" badge={String(globalInStockPhrases.length + globalOutOfStockPhrases.length + globalPreOrderPhrases.length) + ' total'} expandedSections={expandedSections} onToggle={toggleSection}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', marginTop: '0.5rem' }}>
-          <CollapsibleCard title="Generic In-Stock Phrases" leadingIcon={<Icon name="checkCircle" />} id="sys_phr_instock" badge={String(globalInStockPhrases.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-            <UnifiedSelectorManager label="Generic In-Stock Phrases" items={globalInStockPhrases} onChange={setGlobalInStockPhrases} placeholder="in stock, available" />
-          </CollapsibleCard>
+      <RuleGroup
+        title="Availability"
+        description="Stock is read from page evidence first, then from the wording found inside it. Prefer buy buttons, stock badges and availability elements over broad selectors."
+      >
+        <CollapsibleCard title="Stock evidence" leadingIcon={<Icon name="package" />} id="sys_sel_stock" badge={String(globalStockSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Stock evidence selectors" items={globalStockSelectors} onChange={setGlobalStockSelectors} placeholder=".stock-status, .availability" />
+          <FieldHelp>Where availability text or purchase controls are found.</FieldHelp>
+        </CollapsibleCard>
 
-          <CollapsibleCard title="Generic Out-of-Stock Phrases" leadingIcon={<Icon name="xCircle" />} id="sys_phr_outofstock" badge={String(globalOutOfStockPhrases.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-            <UnifiedSelectorManager label="Generic Out-of-Stock Phrases" items={globalOutOfStockPhrases} onChange={setGlobalOutOfStockPhrases} placeholder="out of stock, sold out" />
-          </CollapsibleCard>
+        <CollapsibleCard title="Status phrases" leadingIcon={<Icon name="fileText" />} id="sys_phrases" badge={String(globalInStockPhrases.length + globalOutOfStockPhrases.length + globalPreOrderPhrases.length) + ' total'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <PriorityNote
+            label="Detection order"
+            steps={['Member only', 'Pre-order', 'Out of stock', 'In stock']}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', marginTop: '0.5rem' }}>
+            <CollapsibleCard title="In stock" leadingIcon={<Icon name="checkCircle" />} id="sys_phr_instock" badge={String(globalInStockPhrases.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+              <UnifiedSelectorManager label="In-stock phrases" items={globalInStockPhrases} onChange={setGlobalInStockPhrases} placeholder="in stock, available" />
+            </CollapsibleCard>
 
-          <CollapsibleCard title="Generic Pre-Order Phrases" leadingIcon={<Icon name="clock" />} id="sys_phr_preorder" badge={String(globalPreOrderPhrases.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
-            <UnifiedSelectorManager label="Generic Pre-Order Phrases" items={globalPreOrderPhrases} onChange={setGlobalPreOrderPhrases} placeholder="pre-order, preorder" />
-          </CollapsibleCard>
-        </div>
-      </CollapsibleCard>
+            <CollapsibleCard title="Out of stock" leadingIcon={<Icon name="xCircle" />} id="sys_phr_outofstock" badge={String(globalOutOfStockPhrases.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+              <UnifiedSelectorManager label="Out-of-stock phrases" items={globalOutOfStockPhrases} onChange={setGlobalOutOfStockPhrases} placeholder="out of stock, sold out" />
+            </CollapsibleCard>
+
+            <CollapsibleCard title="Pre-order" leadingIcon={<Icon name="clock" />} id="sys_phr_preorder" badge={String(globalPreOrderPhrases.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+              <UnifiedSelectorManager label="Pre-order phrases" items={globalPreOrderPhrases} onChange={setGlobalPreOrderPhrases} placeholder="pre-order, preorder" />
+            </CollapsibleCard>
+          </div>
+          <FieldHelp>Specific states take priority over generic "available" text.</FieldHelp>
+        </CollapsibleCard>
+      </RuleGroup>
+
+      <RuleGroup
+        title="False-positive prevention"
+        description="Regions removed from the page before price and stock extraction runs."
+      >
+        <CollapsibleCard title="Exclusion selectors" leadingIcon={<Icon name="ban" />} id="sys_sel_exclusion" badge={String(globalExclusionSelectors.length) + ' items'} expandedSections={expandedSections} onToggle={toggleSection}>
+          <UnifiedSelectorManager label="Exclusion selectors" items={globalExclusionSelectors} onChange={setGlobalExclusionSelectors} placeholder=".ad-container, .carousel" />
+          <FieldHelp>Removes adverts, related products and carousels, which are the usual source of a price belonging to a different item.</FieldHelp>
+        </CollapsibleCard>
+      </RuleGroup>
 
       <div className="settings-actions">
         <button className="btn btn-secondary" onClick={fetchSelectorData}>Cancel</button>
-        <button className="btn btn-primary" onClick={handleSaveSelectors} disabled={isSaving}>Save Selectors</button>
+        <button className="btn btn-primary" onClick={handleSaveSelectors} disabled={isSaving}>Save rules</button>
       </div>
     </div>
   );

--- a/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
+++ b/frontend/src/features/admin/components/sections/RetailerConfigEditor.tsx
@@ -5,11 +5,14 @@ import { RetailerAdminService } from '../../services/RetailerAdminService';
 import { useAuth } from '../../../auth';
 import { useAsyncAction } from '../../../../hooks/useAsyncAction';
 import { 
+  FieldHelp,
+  SettingsCacheNotice,
   CollapsibleCard, 
   ToggleSwitch
 } from '../../components';
 import SearchableSelect from '../../../../components/SearchableSelect';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
+import { apiErrorMessage } from '../../../../api/error';
 
 // Sub-sections
 import ScraperEngineSection from './retailer-config/ScraperEngineSection';
@@ -39,6 +42,32 @@ export default function RetailerConfigEditor({
   
   const [draftConfig, setDraftConfig] = useState<Partial<RetailerConfig>>(initialRetailer);
   const { execute: runSaveRetailer, isLoading: isSavingRetailer } = useAsyncAction();
+  const [showRemap, setShowRemap] = useState(false);
+  const [remapUrl, setRemapUrl] = useState('');
+  const [isRemapping, setIsRemapping] = useState(false);
+
+  /**
+   * Re-runs AI auto-mapping against a product URL (issue #74).
+   *
+   * The previous way to fix a bad retailer configuration was to delete the
+   * retailer and re-scrape a product through it, because auto-mapping only fires
+   * for an unknown domain or a shell config.
+   */
+  const handleRemap = async () => {
+    setIsRemapping(true);
+    try {
+      const res = await RetailerAdminService.remapRetailer(remapUrl.trim());
+      showToast('Retailer re-mapped from that page', 'success');
+      setShowRemap(false);
+      setRemapUrl('');
+      onSave();
+      void res;
+    } catch (err) {
+      showToast(apiErrorMessage(err) || 'Auto-mapping failed', 'error');
+    } finally {
+      setIsRemapping(false);
+    }
+  };
   const { execute: runTestConfig, isLoading: isTestingConfig } = useAsyncAction();
   const { execute: runDeleteRetailer } = useAsyncAction();
   
@@ -67,7 +96,9 @@ export default function RetailerConfigEditor({
 
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
     engine: false,
-    selectors: false,
+    selectors_product: false,
+    selectors_pricing: false,
+    selectors_pruning: false,
     phrases: false,
     tester: false,
     ai_selectors: false,
@@ -196,6 +227,56 @@ export default function RetailerConfigEditor({
         isDanger={true}
       />
       
+      <div className="retailer-editor-header">
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontWeight: 700, fontSize: '1rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {draftConfig.name || draftConfig.domain || 'New retailer'}
+          </div>
+          <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {draftConfig.domain}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setShowRemap(true)}
+            disabled={!draftConfig.domain}
+            title="Regenerate this retailer's selectors from a product page"
+          >
+            Re-run auto-map
+          </button>
+          <button className="btn btn-secondary btn-sm" onClick={onCancel}>Discard</button>
+          <button className="btn btn-primary btn-sm" onClick={handleSaveRetailer} disabled={isSavingRetailer}>
+            {isSavingRetailer ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {showRemap && (
+        <div className="settings-card" style={{ border: '1px solid var(--primary)', marginBottom: '1.5rem' }}>
+          <h4 style={{ margin: '0 0 0.5rem' }}>Re-run auto-mapping</h4>
+          <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', margin: '0 0 0.75rem', maxWidth: '70ch' }}>
+            Regenerates this retailer's selectors by reading a real product page. A
+            product URL is required &mdash; a home page has no price to learn from.
+            The generated configuration replaces what is saved here.
+          </p>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <input
+              type="url"
+              className="form-control"
+              style={{ flex: 1, minWidth: '260px' }}
+              value={remapUrl}
+              onChange={e => setRemapUrl(e.target.value)}
+              placeholder={`https://${draftConfig.domain || 'example.com'}/product/...`}
+            />
+            <button className="btn btn-primary" onClick={() => void handleRemap()} disabled={isRemapping || !remapUrl.trim()}>
+              {isRemapping ? 'Mapping...' : 'Run'}
+            </button>
+            <button className="btn btn-secondary" onClick={() => setShowRemap(false)} disabled={isRemapping}>Cancel</button>
+          </div>
+        </div>
+      )}
+
       <div className="form-grid">
         <div className="form-group">
           <label>Primary Domain</label>
@@ -277,16 +358,18 @@ export default function RetailerConfigEditor({
         </div>
       </div>
 
+      <SettingsCacheNotice compact />
+
       <div style={{ marginTop: '2rem' }}>
-        <CollapsibleCard title="Scraper Configuration" leadingIcon={<Icon name="globe" />} id="engine" expandedSections={expandedSections} onToggle={toggleSection}>
+        <CollapsibleCard title="Page acquisition" leadingIcon={<Icon name="globe" />} id="engine" expandedSections={expandedSections} onToggle={toggleSection}>
           <ScraperEngineSection 
             draftConfig={draftConfig} 
             onUpdateConfig={handleUpdateDraft} 
           />
         </CollapsibleCard>
 
-        <CollapsibleCard title="Extraction Parameters" leadingIcon={<Icon name="search" />} id="selectors" expandedSections={expandedSections} onToggle={toggleSection}>
-          <ExtractionParamsSection 
+        <CollapsibleCard title="Product information" leadingIcon={<Icon name="fileText" />} id="selectors_product" expandedSections={expandedSections} onToggle={toggleSection}>
+          <ExtractionParamsSection
             draftConfig={draftConfig}
             onUpdateConfig={handleUpdateDraft}
             titleSelectors={draftTitleSelectors}
@@ -309,10 +392,70 @@ export default function RetailerConfigEditor({
             setExclusionSelectors={setDraftExclusionSelectors}
             customSelectorsJson={draftCustomSelectorsJson}
             setCustomSelectorsJson={setDraftCustomSelectorsJson}
+            part="product"
           />
+          <FieldHelp>Title, image and the JSON-LD keys they are read from. Retailer identity is the shop, not the manufacturer.</FieldHelp>
         </CollapsibleCard>
 
-        <CollapsibleCard title="Stock Status & Phrases" leadingIcon={<Icon name="package" />} id="phrases" expandedSections={expandedSections} onToggle={toggleSection}>
+        <CollapsibleCard title="Pricing" leadingIcon={<Icon name="tag" />} id="selectors_pricing" expandedSections={expandedSections} onToggle={toggleSection}>
+          <ExtractionParamsSection
+            draftConfig={draftConfig}
+            onUpdateConfig={handleUpdateDraft}
+            titleSelectors={draftTitleSelectors}
+            setTitleSelectors={setDraftTitleSelectors}
+            retailerNameSelectors={draftRetailerNameSelectors}
+            setRetailerNameSelectors={setDraftRetailerNameSelectors}
+            priceSelectors={draftPriceSelectors}
+            setPriceSelectors={setDraftPriceSelectors}
+            dealPriceSelectors={draftDealPriceSelectors}
+            setDealPriceSelectors={setDraftDealPriceSelectors}
+            memberPriceSelectors={draftMemberPriceSelectors}
+            setMemberPriceSelectors={setDraftMemberPriceSelectors}
+            originalPriceSelectors={draftOriginalPriceSelectors}
+            setOriginalPriceSelectors={setDraftOriginalPriceSelectors}
+            preOrderPriceSelectors={draftPreOrderPriceSelectors}
+            setPreOrderPriceSelectors={setDraftPreOrderPriceSelectors}
+            imageSelectors={draftImageSelectors}
+            setImageSelectors={setDraftImageSelectors}
+            exclusionSelectors={draftExclusionSelectors}
+            setExclusionSelectors={setDraftExclusionSelectors}
+            customSelectorsJson={draftCustomSelectorsJson}
+            setCustomSelectorsJson={setDraftCustomSelectorsJson}
+            part="pricing"
+          />
+          <FieldHelp>Only the standard price becomes the tracked price. Original / RRP is a reference value and is never saved as it.</FieldHelp>
+        </CollapsibleCard>
+
+        <CollapsibleCard title="False-positive prevention" leadingIcon={<Icon name="ban" />} id="selectors_pruning" expandedSections={expandedSections} onToggle={toggleSection}>
+          <ExtractionParamsSection
+            draftConfig={draftConfig}
+            onUpdateConfig={handleUpdateDraft}
+            titleSelectors={draftTitleSelectors}
+            setTitleSelectors={setDraftTitleSelectors}
+            retailerNameSelectors={draftRetailerNameSelectors}
+            setRetailerNameSelectors={setDraftRetailerNameSelectors}
+            priceSelectors={draftPriceSelectors}
+            setPriceSelectors={setDraftPriceSelectors}
+            dealPriceSelectors={draftDealPriceSelectors}
+            setDealPriceSelectors={setDraftDealPriceSelectors}
+            memberPriceSelectors={draftMemberPriceSelectors}
+            setMemberPriceSelectors={setDraftMemberPriceSelectors}
+            originalPriceSelectors={draftOriginalPriceSelectors}
+            setOriginalPriceSelectors={setDraftOriginalPriceSelectors}
+            preOrderPriceSelectors={draftPreOrderPriceSelectors}
+            setPreOrderPriceSelectors={setDraftPreOrderPriceSelectors}
+            imageSelectors={draftImageSelectors}
+            setImageSelectors={setDraftImageSelectors}
+            exclusionSelectors={draftExclusionSelectors}
+            setExclusionSelectors={setDraftExclusionSelectors}
+            customSelectorsJson={draftCustomSelectorsJson}
+            setCustomSelectorsJson={setDraftCustomSelectorsJson}
+            part="pruning"
+          />
+          <FieldHelp>Removed from the page before extraction runs. Carousels and related products are the usual source of a price belonging to a different item.</FieldHelp>
+        </CollapsibleCard>
+
+        <CollapsibleCard title="Availability" leadingIcon={<Icon name="package" />} id="phrases" expandedSections={expandedSections} onToggle={toggleSection}>
           <StockPhrasesSection 
             stockSelectors={draftStockSelectors}
             setStockSelectors={setDraftStockSelectors}
@@ -334,7 +477,7 @@ export default function RetailerConfigEditor({
           />
         </CollapsibleCard>
 
-        <CollapsibleCard title="Validation Hub" leadingIcon={<Icon name="flask" />} id="tester" isExpanded={expandedSections.tester} onToggle={toggleSection}>
+        <CollapsibleCard title="Validation" leadingIcon={<Icon name="flask" />} id="tester" isExpanded={expandedSections.tester} onToggle={toggleSection}>
           <ScrapeValidationHub 
             testUrl={testUrl}
             setTestUrl={setTestUrl}
@@ -347,10 +490,6 @@ export default function RetailerConfigEditor({
         </CollapsibleCard>
       </div>
 
-      <div className="settings-actions">
-        <button className="btn btn-secondary" onClick={onCancel}>Discard</button>
-        <button className="btn btn-primary" onClick={handleSaveRetailer} disabled={isSavingRetailer}>Push Configuration</button>
-      </div>
     </div>
   );
 }

--- a/frontend/src/features/admin/components/sections/retailer-config/ExtractionParamsSection.tsx
+++ b/frontend/src/features/admin/components/sections/retailer-config/ExtractionParamsSection.tsx
@@ -27,6 +27,12 @@ interface ExtractionParamsSectionProps {
   setExclusionSelectors: (s: string[]) => void;
   customSelectorsJson: string;
   setCustomSelectorsJson: (s: string) => void;
+  /**
+   * Which half to render. The editor shows these as separate collapsible cards
+   * so "Extraction Parameters" stops being one card holding the title, image,
+   * five price types, both JSON-LD keys, exclusions and the raw selector JSON.
+   */
+  part?: 'product' | 'pricing' | 'pruning';
 }
 
 export default function ExtractionParamsSection({
@@ -51,7 +57,8 @@ export default function ExtractionParamsSection({
   exclusionSelectors,
   setExclusionSelectors,
   customSelectorsJson,
-  setCustomSelectorsJson
+  setCustomSelectorsJson,
+  part
 }: ExtractionParamsSectionProps) {
   // Name the value being inherited: "Use global setting" on its own leaves an
   // admin guessing which behaviour that actually is.
@@ -61,9 +68,14 @@ export default function ExtractionParamsSection({
     systemSettings?.prefer_jsonld_image === 'true';
   const globalPreferLabel = globalPrefersJsonLd ? 'JSON-LD images' : 'CSS selectors';
 
+  const showProduct = !part || part === 'product';
+  const showPricing = !part || part === 'pricing';
+  const showPruning = !part || part === 'pruning';
+
   return (
     <div className="extraction-params-section">
       <div className="form-grid">
+        {showProduct && (
         <div className="settings-card" style={{ padding: '1rem', background: 'var(--surface)', marginBottom: 0 }}>
           <h4 className="mb-3">Metadata</h4>
           <UnifiedSelectorManager 
@@ -132,7 +144,9 @@ export default function ExtractionParamsSection({
             </small>
           </div>
         </div>
+        )}
 
+        {showPricing && (
         <div className="settings-card" style={{ padding: '1rem', background: 'var(--surface)', marginBottom: 0 }}>
           <h4 className="mb-3">Pricing Strategy</h4>
           <UnifiedSelectorManager 
@@ -175,8 +189,11 @@ export default function ExtractionParamsSection({
             />
           </div>
         </div>
+        )}
       </div>
-      
+
+      {showPruning && (
+      <>
       <div style={{ marginTop: '1.5rem', padding: '1rem', background: 'var(--surface)', borderRadius: '0.5rem', border: '1px solid var(--border)' }}>
         <h4 className="mb-2"><Icon name="ban" /> Structural Pruning (Exclusions)</h4>
         <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '1rem' }}>
@@ -203,6 +220,8 @@ export default function ExtractionParamsSection({
           placeholder='{ "custom_price": ".my-price" }'
         />
       </div>
+      </>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/admin/pages/AdminPage.tsx
+++ b/frontend/src/features/admin/pages/AdminPage.tsx
@@ -51,7 +51,7 @@ export default function Admin({ activeSection }: { activeSection: AdminSection }
           onChange={(e) => setActiveSection(e.target.value as AdminSection)}
         >
           <option value="system">System</option>
-          <option value="selectors">Global Selectors</option>
+          <option value="selectors">Extraction Rules</option>
           <option value="retailers">Retailers</option>
           <option value="users">Users</option>
           <option value="tokens">API Tokens</option>
@@ -62,7 +62,7 @@ export default function Admin({ activeSection }: { activeSection: AdminSection }
         <aside className="settings-sidebar-new">
           <nav className="settings-nav-new">
             <button className={`settings-nav-item-new ${activeSection === 'system' ? 'active' : ''}`} onClick={() => setActiveSection('system')}><Icon name="settings" /><span>System</span></button>
-            <button className={`settings-nav-item-new ${activeSection === 'selectors' ? 'active' : ''}`} onClick={() => setActiveSection('selectors')}><Icon name="search" /><span>Global Selectors</span></button>
+            <button className={`settings-nav-item-new ${activeSection === 'selectors' ? 'active' : ''}`} onClick={() => setActiveSection('selectors')}><Icon name="search" /><span>Extraction Rules</span></button>
             <button className={`settings-nav-item-new ${activeSection === 'retailers' ? 'active' : ''}`} onClick={() => setActiveSection('retailers')}><Icon name="store" /><span>Retailers</span></button>
             <button className={`settings-nav-item-new ${activeSection === 'users' ? 'active' : ''}`} onClick={() => setActiveSection('users')}><Icon name="users" /><span>Users</span></button>
             <button className={`settings-nav-item-new ${activeSection === 'tokens' ? 'active' : ''}`} onClick={() => setActiveSection('tokens')}><Icon name="key" /><span>API Tokens</span></button>

--- a/frontend/src/features/admin/services/RetailerAdminService.ts
+++ b/frontend/src/features/admin/services/RetailerAdminService.ts
@@ -13,4 +13,6 @@ export const RetailerAdminService = {
 
   debugExtract: (url: string, config?: Partial<RetailerConfig>, mode?: string, returnHtml?: boolean, use_ai?: boolean, force_ai?: boolean) => 
     api.post<any>('/admin/debug/extract', { url, config, mode, returnHtml, use_ai, force_ai }),
+  remapRetailer: (url: string) =>
+    api.post<{ success: boolean; retailer: RetailerConfig; trace: string[] }>('/admin/retailers/remap', { url }),
 };

--- a/frontend/src/features/debug/pages/useDebugScraper.ts
+++ b/frontend/src/features/debug/pages/useDebugScraper.ts
@@ -140,7 +140,7 @@ export function useDebugScraper() {
     setTempRetailerNameSelectors(parseSelectors(globalSettings.generic_retailer_name_selectors));
     setTempStockSelectors(parseSelectors(globalSettings.generic_stock_selectors));
     setTempExclusionSelectors(parseSelectors(globalSettings.generic_exclusion_selectors));
-    showToast('Pre-populated fields with system Global Selectors.');
+    showToast('Pre-populated fields with the system Extraction Rules.');
   }, [useOverride, globalSettings]);
 
   // Reset selector states when override is toggled off

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -687,3 +687,32 @@ display: block;
   width: 1.25rem;
   height: 1.25rem;
 }
+
+/* Retailer editor sticky header.
+   The editor is a long form; without this the save action and the name of the
+   retailer being edited scroll away, and it is easy to lose track of which
+   retailer a change belongs to. Deliberately carries only three things --
+   identity, the primary action, and discard -- because a full toolbar pinned to
+   the top of a form is worse than no toolbar at all. */
+.retailer-editor-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  margin: -0.5rem -0.5rem 1.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow);
+}
+
+@media (max-width: 640px) {
+  .retailer-editor-header {
+    position: static;
+  }
+}


### PR DESCRIPTION
Implements the [proposal](https://claude.ai/code/artifact/fb211555-eaaf-490c-89a4-96df600231b8) for #89 and #90, and folds in #74.

## What was wrong

Both screens listed every selector list as a sibling in storage order. That tells an administrator what the fields are called, but not what they are for, which of them ever takes effect, or when a saved change becomes live.

The retailer editor was worse: one card, **Extraction Parameters**, held the title, retailer name, image, five price types, both JSON-LD keys, exclusions *and* the raw selector JSON.

## Grouping

Both screens now share one vocabulary — **product information / pricing / availability / false-positive prevention** — so what you learn on one applies to the other. The overloaded card becomes three focused ones.

`ExtractionParamsSection` takes a `part` prop rather than being duplicated, so the field wiring stays in one place.

## Explaining the rules

Both screens state the priority chain — **retailer rules &rarr; these defaults &rarr; built-in fallbacks** — and Availability states the detection order (**member only &rarr; pre-order &rarr; out of stock &rarr; in stock**).

Neither was documented anywhere a user would look. Not knowing the first one is exactly what made #101 so hard to diagnose: a learned site-specific selector silently beat the generic one that worked.

Per-field help now says which price becomes the tracked price and which are reference values.

## Cache visibility — the addition

`clear-settings-cache` already existed and was wired into System settings and the debug page, but **not** into either screen where selectors are actually edited. The control existed and was absent from precisely where it was needed.

An admin who edits a selector, re-scrapes and sees no change cannot tell whether the selector is wrong or simply not loaded yet — so they assume it is wrong and keep editing. Both screens now say saved changes take up to 30 minutes, with an **Apply now** button.

## Re-run auto-map (#74)

Auto-mapping only fires for an unknown domain or a shell config, so fixing a bad retailer meant deleting it and re-scraping a product through it — exactly what the issue describes.

`POST /api/admin/retailers/remap` re-runs the same generation against a URL you supply and invalidates the config cache. **Keyed on the URL rather than a retailer id**, because the URL is what determines which retailer this is, so the two cannot disagree. A product URL is required and cannot be inferred: a home page has no price to learn from.

## Deliberately not built

- **The paired side-by-side selector cards.** They read well in monospace only because monospace has no minimum content width. Two selector editors at admin widths are ~300px each, and `meta[property="og:site_name"]::attr(content)` either wraps badly or overflows — the squeeze that caused #117.
- **Per-card item counts.** `CollapsibleCard` already takes a `badge` prop and every card uses it.
- **The "3 groups" section counters.** They count the UI, not the configuration.

## Also

The bottom Discard/Save pair is removed — the sticky header carries both and is always reachable, so a second copy was redundant. On mobile the header is non-sticky, where a pinned bar costs more screen than it earns.

## Verification

`tsc`, 202 backend tests, frontend build and tests, route acceptance 13/13, emoji lint, `git diff --check` — all pass. Docs updated in `docs/admin/admin_guide.md`.

Closes #90
Closes #89
Closes #74