### PR TITLE
fix(auth): record last active on sign-in, not only registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Admin user management now records "Last Active" on sign-in. It was only being
+  recorded at registration, so the column read "Never" for everyone.
 - Removed an hourglass emoji from the admin Extraction Rules panel and closed
   the gap in the emoji check that let it through, so the icon set stays the only
   thing rendering symbols in the UI.

--- a/backend/src/services/domain/auth/index.ts
+++ b/backend/src/services/domain/auth/index.ts
@@ -121,6 +121,12 @@ export class AuthService {
 
     const token = generateToken(user.id);
 
+    // Not knowing when somebody last signed in is a reporting gap, not a reason
+    // to refuse them entry, so a failure here must not fail the login.
+    await userRepository.recordLogin(user.id).catch((err) =>
+      logger.warn(`Auth | Could not record login time for user ${user.id}: ${err}`, 'Auth')
+    );
+
     return {
       token,
       user: {

--- a/backend/tests/unit/login-records-last-active.test.ts
+++ b/backend/tests/unit/login-records-last-active.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Both authentication paths must stamp last_login_at.
+ *
+ * This shipped stamping only registration: the edit that added it matched an
+ * identical `const token = generateToken(user.id); return { token, user: {` block
+ * in registerUser before the one in loginUser. Nothing failed, nothing threw,
+ * and the admin column simply read "Never" forever.
+ */
+
+const users = {
+  findByEmail: vi.fn(),
+  create: vi.fn(),
+  count: vi.fn().mockResolvedValue(1),
+  findAll: vi.fn().mockResolvedValue([]),
+  setAdmin: vi.fn(),
+  recordLogin: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../../src/models', () => ({ userRepository: users }));
+vi.mock('../../src/services/domain/system', () => ({
+  systemService: { getSetting: vi.fn().mockResolvedValue('true') },
+}));
+vi.mock('../../src/middleware/auth', () => ({ generateToken: () => 'token' }));
+vi.mock('../../src/utils/system/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('bcryptjs', () => ({
+  default: { compare: vi.fn().mockResolvedValue(true), hash: vi.fn().mockResolvedValue('hashed') },
+}));
+
+const ACCOUNT = {
+  id: 42,
+  email: 'person@example.test',
+  name: 'Person',
+  password_hash: 'hashed',
+  is_admin: false,
+  disabled: false,
+};
+
+async function auth() {
+  const { authService } = await import('../../src/services/domain/auth');
+  return authService;
+}
+
+describe('Recording when an account last signed in', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    users.recordLogin.mockResolvedValue(undefined);
+  });
+
+  it('stamps on a local login', async () => {
+    users.findByEmail.mockResolvedValue(ACCOUNT);
+
+    await (await auth()).loginUser(ACCOUNT.email, 'longenoughpassword');
+
+    expect(users.recordLogin).toHaveBeenCalledWith(ACCOUNT.id);
+  });
+
+  it('stamps on registration', async () => {
+    users.findByEmail.mockResolvedValue(null);
+    users.create.mockResolvedValue({ ...ACCOUNT, id: 7 });
+
+    await (await auth()).registerUser('new@example.test', 'longenoughpassword');
+
+    expect(users.recordLogin).toHaveBeenCalledWith(7);
+  });
+
+  it('does not stamp when the password is wrong', async () => {
+    const bcrypt = (await import('bcryptjs')).default;
+    (bcrypt.compare as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+    users.findByEmail.mockResolvedValue(ACCOUNT);
+
+    await expect((await auth()).loginUser(ACCOUNT.email, 'wrong')).rejects.toThrow();
+    expect(users.recordLogin).not.toHaveBeenCalled();
+  });
+
+  it('does not stamp when the account is disabled', async () => {
+    users.findByEmail.mockResolvedValue({ ...ACCOUNT, disabled: true });
+
+    await expect((await auth()).loginUser(ACCOUNT.email, 'longenoughpassword')).rejects.toThrow();
+    expect(users.recordLogin).not.toHaveBeenCalled();
+  });
+
+  it('still signs the user in if the stamp fails', async () => {
+    // A reporting gap is not a reason to refuse somebody entry.
+    users.findByEmail.mockResolvedValue(ACCOUNT);
+    users.recordLogin.mockRejectedValue(new Error('database unavailable'));
+
+    const result = await (await auth()).loginUser(ACCOUNT.email, 'longenoughpassword');
+
+    expect(result.token).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #121. My mistake in #118.

## What went wrong

The edit that added the `last_login_at` stamp anchored on this block:

```ts
const token = generateToken(user.id);

return {
  token,
  user: {
```

which appears **identically** in `registerUser` and `loginUser`. It replaced the first occurrence, so the stamp landed in registration only.

Nothing failed and nothing threw. Every existing account simply kept reading "Never", because the one path that would ever update them was never called.

The tests I wrote for #118 covered the repository method and the SSO guards — not *which call sites use them* — so they passed too. That is the actual gap, and the new tests close it.

## Fix

- Stamp in `loginUser`, identified by the disabled-account guard that precedes it and that `registerUser` does not have.
- A test per authentication path, plus the cases that must **not** stamp: a wrong password and a disabled account.
- A test that a failed stamp still lets the user in — a reporting gap is not a reason to refuse somebody entry.

## What is still expected

Existing accounts will read "Never" until their next sign-in. That is migration 015 behaving as designed: it adds the column **without a backfill**, because backfilling from `created_at` would invent a sign-in that never happened and make a dormant account look active.

So after this ships, the column fills in as people log in rather than all at once.

## Verification

Against PostgreSQL 16, exercising the real service:

```
after register    STAMPED
cleared           null
after login       STAMPED   <-- was broken
advances          yes
```

207 backend tests (up from 202), `tsc`, emoji lint, `git diff --check` — all pass.