### PR TITLE
fix(admin): call it the Browser Scraper everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The **Remote Scraper URL** system setting is now labelled **Browser Scraper
+  URL**, matching the per-retailer "Use Browser Scraper" toggle it feeds, and its
+  placeholder shows the documented `http://scraper:5100/scrape` rather than a
+  developer's LAN address. Scraper errors name the same thing. The stored setting
+  key is unchanged, so existing configurations keep working.
 - **Global Selectors** is now **Extraction Rules**, grouped by the job each rule
   does -- product information, pricing, availability, false-positive prevention
   -- rather than listed in storage order, and it states the rule priority

--- a/backend/src/services/scraper/transport/browser.ts
+++ b/backend/src/services/scraper/transport/browser.ts
@@ -15,12 +15,12 @@ export async function fetchBrowserHtml(
 ): Promise<string> {
   const rsUrl = await settingsCache.getRemoteScraperUrl();
   if (!rsUrl) {
-    logger.warn('Remote Scraper | Warning | Browser rendering requested but remote_scraper_url is not configured', 'Scraper');
+    logger.warn('Browser Scraper | Warning | Browser rendering requested but remote_scraper_url is not configured', 'Scraper');
     return '';
   }
 
   try {
-    logger.info(`Remote Scraper | Offloading | ${url}${productId ? ` [PROD-${productId}]` : ''}`, 'Scraper');
+    logger.info(`Browser Scraper | Offloading | ${url}${productId ? ` [PROD-${productId}]` : ''}`, 'Scraper');
     const options: any = {};
     if (userAgent) options.userAgent = userAgent;
     if (productId) options.productId = productId;
@@ -42,7 +42,7 @@ export async function fetchBrowserHtml(
     return await fetchRemoteHtml(url, rsUrl, options);
   } catch (error: any) {
     if (error instanceof PageNotAvailableError) throw error;
-    logger.error(`Remote Scraper | Failed | Browser Rendering: ${url}: ${error.message}`, 'Scraper');
+    logger.error(`Browser Scraper | Failed | Browser Rendering: ${url}: ${error.message}`, 'Scraper');
     return '';
   }
 }

--- a/backend/src/services/scraper/transport/remote.ts
+++ b/backend/src/services/scraper/transport/remote.ts
@@ -20,7 +20,7 @@ export async function fetchRemoteHtml(url: string, remoteScraperUrl: string, opt
     const abortTimeout = setTimeout(() => controller.abort(), 65000); // 65s safety timeout
 
     try {
-      const logPrefix = `Remote Scraper | [${requestId}]${productId ? ` [PROD-${productId}]` : ''}`;
+      const logPrefix = `Browser Scraper | [${requestId}]${productId ? ` [PROD-${productId}]` : ''}`;
 
       if (retryCount > 0) {
         logger.info(`${logPrefix} | Retry ${retryCount}/${maxRetries} | ${url}`, 'Scraper');
@@ -60,8 +60,8 @@ export async function fetchRemoteHtml(url: string, remoteScraperUrl: string, opt
 
     } catch (error: any) {
       if (axios.isCancel(error) || error.name === 'AbortError') {
-        logger.warn(`Remote Scraper | [${requestId}] | Aborted | Request for ${url} was canceled by backend`, 'Scraper');
-        throw new Error('Remote Scraper request aborted');
+        logger.warn(`Browser Scraper | [${requestId}] | Aborted | Request for ${url} was canceled by backend`, 'Scraper');
+        throw new Error('Browser Scraper request aborted');
       }
 
       const status = error.response?.status;
@@ -72,23 +72,23 @@ export async function fetchRemoteHtml(url: string, remoteScraperUrl: string, opt
       // Scraper URL endpoint does not exist — a configuration problem, never
       // evidence that the product page is gone.
       if (status === 404 || status === 410) {
-        throw new Error(`Remote Scraper endpoint not found (${status}) — check the Remote Scraper URL setting`);
+        throw new Error(`Browser Scraper endpoint not found (${status}) — check the Browser Scraper URL setting`);
       }
 
       // Handle Rate Limiting (503) with Exponential Backoff
       if (status === 503 && retryCount < maxRetries) {
         retryCount++;
         const delay = Math.pow(2, retryCount) * 1000; // 2s, 4s, 8s
-        logger.warn(`Remote Scraper | [${requestId}] | Busy | Retrying in ${delay}ms...`, 'Scraper');
+        logger.warn(`Browser Scraper | [${requestId}] | Busy | Retrying in ${delay}ms...`, 'Scraper');
         await new Promise(resolve => setTimeout(resolve, delay));
         continue;
       }
 
-      throw new Error(`Remote Scraper Failed (${status}): ${msg}`);
+      throw new Error(`Browser Scraper failed (${status}): ${msg}`);
     } finally {
       clearTimeout(abortTimeout);
     }
   }
 
-  throw new Error('Remote Scraper Failed: Max retries exceeded');
+  throw new Error('Browser Scraper failed: max retries exceeded');
 }

--- a/docs/admin/system.md
+++ b/docs/admin/system.md
@@ -6,7 +6,11 @@ The **System** tab in the Admin Panel provides the core configurations for netwo
 
 ## 1. Network & Integration
 * **Proxy URL/Port (`scraper_proxy`)**: Specify the HTTP/HTTPS proxy address used to route outgoing PDP requests (e.g. `http://user:pass@proxyhost:port`).
-* **Remote Scraper URL (`remote_scraper_url`)**: Sets the address of your containerized stealth Puppeteer scraping service (`scraper`, e.g. `http://scraper:5100/scrape`).
+* **Browser Scraper URL (`remote_scraper_url`)**: Sets the address of your
+  containerized stealth Puppeteer scraping service (`scraper`, e.g.
+  `http://scraper:5100/scrape`). Retailers with **Use Browser Scraper**
+  enabled are fetched through it. The stored setting key keeps its original
+  name so existing configurations are unaffected.
 
 ---
 

--- a/frontend/src/features/admin/components/sections/SystemSection.tsx
+++ b/frontend/src/features/admin/components/sections/SystemSection.tsx
@@ -132,7 +132,14 @@ export default function SystemSection() {
       
       <CollapsibleCard title="Network & Integration" leadingIcon={<Icon name="globe" />} id="sys_network" expandedSections={expandedSections} onToggle={toggleSection}>
         <div className="form-group"><label>Proxy URL/Port</label><input type="text" value={systemSettings?.scraper_proxy || ''} onChange={e => setSystemSettings(s => s ? { ...s, scraper_proxy: e.target.value } : null)} placeholder="http://proxy:port" /></div>
-        <div className="form-group"><label>Remote Scraper URL</label><input type="text" value={systemSettings?.remote_scraper_url || ''} onChange={e => setSystemSettings(s => s ? { ...s, remote_scraper_url: e.target.value } : null)} placeholder="http://192.168.50.215:5100/scrape" /></div>
+        <div className="form-group">
+          <label>Browser Scraper URL</label>
+          <input type="text" value={systemSettings?.remote_scraper_url || ''} onChange={e => setSystemSettings(s => s ? { ...s, remote_scraper_url: e.target.value } : null)} placeholder="http://scraper:5100/scrape" />
+          <small style={{ color: 'var(--text-muted)' }}>
+            Where the browser scraper service is running. Retailers with
+            &ldquo;Use Browser Scraper&rdquo; enabled are fetched through it.
+          </small>
+        </div>
       </CollapsibleCard>
 
       <CollapsibleCard title="Product Discovery (SearXNG)" leadingIcon={<Icon name="search" />} id="sys_discovery" expandedSections={expandedSections} onToggle={toggleSection}>

--- a/frontend/src/features/products/components/ProductForm/ProductForm.tsx
+++ b/frontend/src/features/products/components/ProductForm/ProductForm.tsx
@@ -137,7 +137,7 @@ const ProductForm: React.FC<ProductFormProps> = ({ onSubmit, availableCategories
             </span>
           );
         } else if (status === 403) {
-          setError('Access Denied: The retailer is blocking our scraper. Try enabling the Remote Scraper or a Proxy for this site in Retailer Settings.');
+          setError('Access Denied: The retailer is blocking our scraper. Try enabling the Browser Scraper or a Proxy for this retailer under Admin -> Retailers.');
         } else if (status === 400) {
           setError(serverError || 'Scraping Failed: We could not find a price on this page. Check your selectors in Retailer Settings.');
         } else if (status === 500) {


### PR DESCRIPTION
Closes #127.

The per-retailer toggle says **Use Browser Scraper**, the retailer list says **Browser Scraper**, the debug page says **Browser Scraper** — but the system setting that points at the service all of them use said **Remote Scraper URL**. Someone turning the toggle on had no obvious way to tell which setting feeds it.

## Renamed

- `Remote Scraper URL` -> `Browser Scraper URL`, with a line explaining that retailers with the toggle enabled are fetched through it.
- The scraper transport errors that name the setting to go and check.
- The log prefixes that appear in the **System Event Log** — so searching it for the words on the settings screen now finds the relevant lines. That is the bit that makes the rename actually useful rather than cosmetic.
- The add-product error suggesting you turn it on.

## Not renamed

The stored setting key stays `remote_scraper_url`. Renaming it would orphan every existing configuration for the sake of a label, and the key is not something an administrator ever sees. Verified no accidental key rename crept in.

## Two things fixed while in there

- The placeholder was `http://192.168.50.215:5100/scrape` — a private LAN address from someone's own network, which reads as a real example to copy. Now the documented `http://scraper:5100/scrape`.
- The add-product error pointed at "Retailer Settings", which is not what that screen is called. It is **Admin -> Retailers**.

## Verification

`tsc`, 207 backend tests, frontend build and tests, route acceptance 13/13, emoji lint, `git diff --check` — all pass. `docs/admin/system.md` updated.

Closes #127