### PR TITLE
release: v2.0.0, and default deployments to stable

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,6 +54,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=beta,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # `stable` is what deploy/swarm-stack.yml tracks by default. It moves
+            # only on a versioned release, so an operator who does not pin a
+            # version never gets an unreviewed migration from main.
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build Docker image
         uses: docker/build-push-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-31
+
 ### Changed
 
+- **The Docker Compose / Swarm deployment now tracks `stable` instead of
+  `beta`.** `beta` follows every merge to `main`, and because schema migrations
+  run automatically when the backend starts and are not reversible, tracking it
+  meant an unreviewed migration could run against your database on any restart.
+  `stable` moves only on a versioned release. Set `PRICESTALKER_TAG=beta` to
+  keep the old behaviour, or pin an exact version such as `v2.0.0`.
 - The **Remote Scraper URL** system setting is now labelled **Browser Scraper
   URL**, matching the per-retailer "Use Browser Scraper" toggle it feeds, and its
   placeholder shows the documented `http://scraper:5100/scrape` rather than a

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricestalker-backend",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "description": "PriceStalker price tracking API",
   "main": "dist/index.js",
   "scripts": {

--- a/deploy/swarm-stack.yml
+++ b/deploy/swarm-stack.yml
@@ -34,11 +34,18 @@
 #   docker exec $(docker ps -q -f name=pricestalker_postgres) \
 #     pg_dump -U postgres --no-owner --no-privileges priceghost | gzip > backup.sql.gz
 #
-# The tag below defaults to `beta`, which currently contains the ongoing v2
-# overhaul from main. The stable `latest` tag is published only for versioned
-# releases and may still represent the previous stable line. Pin
-# PRICESTALKER_TAG to a specific version if you want to choose your upgrade
-# moment.
+# The tag below defaults to `stable`, which moves only on a versioned release.
+#
+# This matters more than a normal image tag would, because schema migrations run
+# automatically when the backend container starts and are not reversible. On
+# `beta` -- which tracks every merge to main -- that means an unreviewed
+# migration can run against your database the next time the container restarts.
+#
+#   stable   versioned releases only (default, recommended)
+#   beta     every merge to main; expect schema changes without notice
+#   v2.0.0   pin an exact version and choose your own upgrade moment
+#
+# Whichever you track, take the backup above before upgrading.
 
 services:
   postgres:
@@ -64,7 +71,7 @@ services:
         condition: on-failure
 
   backend:
-    image: ghcr.io/mikeknight85/pricestalker-backend:${PRICESTALKER_TAG:-beta}
+    image: ghcr.io/mikeknight85/pricestalker-backend:${PRICESTALKER_TAG:-stable}
     environment:
       NODE_ENV: production
       PORT: "3001"
@@ -93,7 +100,7 @@ services:
         condition: on-failure
 
   frontend:
-    image: ghcr.io/mikeknight85/pricestalker-frontend:${PRICESTALKER_TAG:-beta}
+    image: ghcr.io/mikeknight85/pricestalker-frontend:${PRICESTALKER_TAG:-stable}
     networks:
       - pricestalker-internal
       - traefik-public
@@ -118,7 +125,7 @@ services:
   # http://scraper:5100/scrape once deployed. Remove this service if
   # unused; the backend scrapes in-process without it.
   scraper:
-    image: ghcr.io/mikeknight85/pricestalker-scraper:${PRICESTALKER_TAG:-beta}
+    image: ghcr.io/mikeknight85/pricestalker-scraper:${PRICESTALKER_TAG:-stable}
     environment:
       PORT: "5100"
     # Chromium needs more than the default 64MB of shared memory or it crashes

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pricestalker-frontend",
   "private": true,
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.12.0"
   },
-  "version": "2.0.0-beta.1"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
Two changes, and the second is why the first matters now.

## Default the deployment to `stable`

`deploy/swarm-stack.yml` defaulted to **`beta`**, which tracks every merge to `main`.

Migrations run automatically when the backend container starts (`server.ts:55` -> `runMigrationsOnBoot`), block startup until they succeed, and are **never reversed** — nothing calls `umzug.down()` outside the manual CLI. So anyone who followed the deploy instructions without pinning `PRICESTALKER_TAG` could have an unreviewed schema migration run against their database on any container restart.

This is self-hosted software. The person that lands on is the end user, restoring from a backup they may not have.

### `stable` did not exist

Worth flagging, because I nearly changed the default to a 404. The workflow's `channel:` input is a **Docker build arg**, not an image tag. The tags actually published were `beta` on main, and `latest` + semver on a release tag. I probed the registry to confirm:

```
stable -> 404
latest -> 200
beta   -> 200
1.4.0  -> 200
```

So `docker-image.yml` now publishes `stable` on versioned releases, and this release creates it for the first time. The comment block in the compose file now spells out the three choices and what each exposes you to.

## Cut v2.0.0

The last stable line was **v1.4.0 in June**. Everything since has been sitting on beta. The changelog's `Unreleased` section held **81 entries including two breaking changes**, so the major bump is warranted on its own terms — and getting beta onto stable is the point of the exercise.

- `2.0.0-beta.1` -> `2.0.0` across root, backend and frontend.
- `Unreleased` sealed as `[2.0.0] - 2026-08-31`, fresh empty `Unreleased` above it.
- The scraper keeps its own independent version (`1.0.36`); I did not invent a bump for it.

## Upgrade safety for this release

Migrations 010 through 015 are all **additive or value-only** — new nullable columns and a repair of corrupt setting values. An operator moving v1.4.0 -> v2.0.0 is not exposed to a destructive schema change, and old code would tolerate the new columns if they rolled the image back.

The migration that *would* be destructive — the many-to-many refactor in #83, which moves columns out of `products` and merges rows across users — is deliberately **not** in this release.

## After merging

Tagging `v2.0.0` publishes `2.0.0`, `2.0`, `latest` and the new `stable`, at which point the compose default resolves. I will confirm the tag exists in the registry before calling it done.

## Verification

`tsc`, backend tests, frontend build, emoji lint, `git diff --check` — all pass. The lockfile does not record workspace versions, so `--frozen-lockfile` is unaffected by the bump.