### PR TITLE
fix(build): baseline generator JSON, and the remaining logging gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ JWT_SECRET=replace-with-a-long-random-string
 # FILE_LOG_LEVEL=info          # overrides LOG_LEVEL for logs/backend.log
 # DB_LOG_LEVEL=info            # overrides LOG_LEVEL for the Admin System Event Log
 # SLOW_QUERY_MS=500            # SQL slower than this is logged at WARN instead of DEBUG
+# AI_TRACE_CHARS=2000          # how much of an AI prompt/response to log at DEBUG
 # BACKEND_MEM_LIMIT=1g
 # REDACT_API_KEYS=false         # Set to "true" to mask AI API keys in the Admin UI and disable the reveal (eye icon) button for added security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The baseline schema generator no longer corrupts JSON seed values. Seed SQL is
+  now escaped for the TypeScript template literal it gets embedded in, and the
+  generator warns if any settings value would not survive as valid JSON.
+
 ## [2.0.0] - 2026-08-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AI extraction can now be diagnosed: at debug level each provider records the
+  prompt it sent and the raw text it returned, capped by `AI_TRACE_CHARS`.
+  Previously only token counts were logged, so there was no way to tell whether
+  the model was asked the wrong question or answered the right one badly.
+- The price extraction cascade writes its progress to the log as it runs, rather
+  than only into the trace attached to a finished scrape -- so a scrape that
+  hangs or dies partway no longer takes its progress with it.
+- Failed OIDC sign-ins record why. An expired token, a clock skew and a bad
+  signature previously all produced the same empty log.
 - The baseline schema generator no longer corrupts JSON seed values. Seed SQL is
   now escaped for the TypeScript template literal it gets embedded in, and the
   generator warns if any settings value would not survive as valid JSON.

--- a/backend/src/routes/auth/oidc.ts
+++ b/backend/src/routes/auth/oidc.ts
@@ -135,6 +135,22 @@ router.get('/callback', async (req: Request, res: Response) => {
     // The fragment keeps the JWT out of server access logs and Referer headers.
     res.redirect(302, `${completeUrl}#token=${encodeURIComponent(token)}`);
   } catch (error) {
+    // The user gets a short message in the redirect; the reason belongs in the
+    // log (logging audit L-05). Previously a failed sign-in left nothing to
+    // diagnose from -- no reason, no issuer, no error code -- so an expired
+    // token, a clock skew and a bad signature were indistinguishable.
+    const err = error as { name?: string; message?: string; code?: string; claim?: string };
+    logger.warn(
+      `Auth | OIDC | Callback failed | ${err?.name || 'Error'}: ${err?.message || 'Unknown error'}`,
+      'Auth',
+      {
+        errorName: err?.name,
+        errorCode: err?.code,
+        // jose names the offending claim on validation failures, which is what
+        // separates "expired" from "wrong audience" from "wrong issuer".
+        claim: err?.claim,
+      }
+    );
     redirectWithError(error instanceof Error ? error.message : 'Unknown error');
   }
 });

--- a/backend/src/services/ai/providers/anthropic.ts
+++ b/backend/src/services/ai/providers/anthropic.ts
@@ -3,6 +3,7 @@ import { AISettings } from '../../../models';
 import { logger } from '../../../utils/system/logger';
 import { withRetry } from '../../../utils/system/retry';
 import { AIProvider, AIRequestOptions, AIResponse } from './types';
+import { traceAiRequest, traceAiResponse } from '../trace';
 
 const DEFAULT_ANTHROPIC_MODEL = 'claude-3-haiku-20240307';
 
@@ -21,6 +22,7 @@ export class AnthropicProvider implements AIProvider {
   }
 
   async generate(prompt: string, options?: AIRequestOptions): Promise<AIResponse> {
+    traceAiRequest(prompt, { provider: 'Anthropic', productId: options?.productId, label: options?.retryLabel });
     const response = await withRetry(() => this.client.messages.create({
       model: this.model,
       max_tokens: options?.maxTokens || 1024,
@@ -40,8 +42,11 @@ export class AnthropicProvider implements AIProvider {
     }
 
     const content = response.content[0];
+    const rawText = content.type === 'text' ? content.text : '';
+    traceAiResponse(rawText, { provider: 'Anthropic', productId: options?.productId, label: options?.retryLabel });
+
     return {
-      text: content.type === 'text' ? content.text : '',
+      text: rawText,
       usage: response.usage ? {
         promptTokens: response.usage.input_tokens,
         completionTokens: response.usage.output_tokens,

--- a/backend/src/services/ai/providers/gemini.ts
+++ b/backend/src/services/ai/providers/gemini.ts
@@ -3,6 +3,7 @@ import { AISettings } from '../../../models';
 import { logger } from '../../../utils/system/logger';
 import { withRetry } from '../../../utils/system/retry';
 import { AIProvider, AIRequestOptions, AIResponse } from './types';
+import { traceAiRequest, traceAiResponse } from '../trace';
 
 const DEFAULT_GEMINI_MODEL = 'gemini-1.5-flash';
 
@@ -20,6 +21,7 @@ export class GeminiProvider implements AIProvider {
   }
 
   async generate(prompt: string, options?: AIRequestOptions): Promise<AIResponse> {
+    traceAiRequest(prompt, { provider: 'Gemini', productId: options?.productId, label: options?.retryLabel });
     const result: any = await withRetry(() => this.model.generateContent(prompt),
       { maxRetries: this.settings.ai_max_retries ?? 2 },
       options?.retryLabel || 'Gemini'
@@ -38,8 +40,11 @@ export class GeminiProvider implements AIProvider {
       });
     }
 
+    const rawText = response.text();
+    traceAiResponse(rawText, { provider: 'Gemini', productId: options?.productId, label: options?.retryLabel });
+
     return {
-      text: response.text(),
+      text: rawText,
       usage: response.usageMetadata ? {
         promptTokens: response.usageMetadata.promptTokenCount,
         completionTokens: response.usageMetadata.candidatesTokenCount,

--- a/backend/src/services/ai/providers/ollama.ts
+++ b/backend/src/services/ai/providers/ollama.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { AISettings } from '../../../models';
 import { withRetry } from '../../../utils/system/retry';
 import { AIProvider, AIRequestOptions, AIResponse } from './types';
+import { traceAiRequest, traceAiResponse } from '../trace';
 
 export class OllamaProvider implements AIProvider {
   private baseUrl: string;
@@ -15,6 +16,7 @@ export class OllamaProvider implements AIProvider {
   }
 
   async generate(prompt: string, options?: AIRequestOptions): Promise<AIResponse> {
+    traceAiRequest(prompt, { provider: 'Ollama', productId: options?.productId, label: options?.retryLabel });
     const response = await withRetry(() => axios.post(
       `${this.baseUrl}/api/chat`,
       {
@@ -35,6 +37,8 @@ export class OllamaProvider implements AIProvider {
     ), { maxRetries: this.settings.ai_max_retries ?? 1 }, options?.retryLabel || 'Ollama');
 
     const content = response.data?.message?.content || '';
+    traceAiResponse(content, { provider: 'Ollama', productId: options?.productId, label: options?.retryLabel });
+
     return { text: content };
   }
 }

--- a/backend/src/services/ai/providers/openai.ts
+++ b/backend/src/services/ai/providers/openai.ts
@@ -3,6 +3,7 @@ import { AISettings } from '../../../models';
 import { logger } from '../../../utils/system/logger';
 import { withRetry } from '../../../utils/system/retry';
 import { AIProvider, AIRequestOptions, AIResponse } from './types';
+import { traceAiRequest, traceAiResponse } from '../trace';
 
 const DEFAULT_OPENAI_MODEL = 'gpt-3.5-turbo-0125';
 const DEFAULT_DEEPSEEK_MODEL = 'deepseek-chat';
@@ -55,6 +56,7 @@ export class OpenAIProvider implements AIProvider {
   }
 
   async generate(prompt: string, options?: AIRequestOptions): Promise<AIResponse> {
+    traceAiRequest(prompt, { provider: this.providerName, productId: options?.productId, label: options?.retryLabel });
     const response = await withRetry(() => this.client.chat.completions.create({
       model: this.model,
       max_tokens: options?.maxTokens || 1024,
@@ -74,8 +76,11 @@ export class OpenAIProvider implements AIProvider {
       });
     }
 
+    const rawText = response.choices[0]?.message?.content || '';
+    traceAiResponse(rawText, { provider: this.providerName, productId: options?.productId, label: options?.retryLabel });
+
     return {
-      text: response.choices[0]?.message?.content || '',
+      text: rawText,
       usage: response.usage ? {
         promptTokens: response.usage.prompt_tokens,
         completionTokens: response.usage.completion_tokens,

--- a/backend/src/services/ai/providers/vertex.ts
+++ b/backend/src/services/ai/providers/vertex.ts
@@ -3,6 +3,7 @@ import { AISettings } from '../../../models';
 import { logger } from '../../../utils/system/logger';
 import { withRetry } from '../../../utils/system/retry';
 import { AIProvider, AIRequestOptions, AIResponse } from './types';
+import { traceAiRequest, traceAiResponse } from '../trace';
 
 const DEFAULT_VERTEX_MODEL = 'gemini-1.5-pro-002';
 
@@ -14,6 +15,7 @@ export class VertexProvider implements AIProvider {
   }
 
   async generate(prompt: string, options?: AIRequestOptions): Promise<AIResponse> {
+    traceAiRequest(prompt, { provider: 'Vertex', productId: options?.productId, label: options?.retryLabel });
     const projectId = this.settings.vertex_project_id;
     const location = this.settings.vertex_location || 'us-central1';
     const apiKey = this.settings.vertex_api_key;
@@ -67,6 +69,8 @@ export class VertexProvider implements AIProvider {
         product_id: options?.productId
       });
     }
+
+    traceAiResponse(text, { provider: 'Vertex', productId: options?.productId, label: options?.retryLabel });
 
     return {
       text,

--- a/backend/src/services/ai/trace.ts
+++ b/backend/src/services/ai/trace.ts
@@ -1,0 +1,64 @@
+import { logger } from '../../utils/system/logger';
+
+/**
+ * Debug tracing for AI provider exchanges (logging audit L-02).
+ *
+ * Only token counts were logged, so a wrong extraction gave no way to tell
+ * whether the model was asked the wrong question or answered the right one
+ * badly. The prompt and the raw response are the two things you need, and
+ * neither was recorded anywhere.
+ *
+ * Both are capped rather than logged whole. A prompt carries the denoised
+ * product page, so an uncapped trace would put a page of HTML into the console,
+ * the log file and -- if DB_LOG_LEVEL is set to debug -- a system_logs row, for
+ * every scrape. The audit's suggested `substring(0, 500)` is the right instinct;
+ * this makes the limit configurable because 500 characters frequently cuts off
+ * before the part you are looking at.
+ *
+ * Nothing here bypasses the scrubber: these go through logger.debug like any
+ * other line, so URL credentials are redacted on the way out.
+ */
+
+const DEFAULT_TRACE_CHARS = 2000;
+
+function traceLimit(): number {
+  const configured = Number(process.env.AI_TRACE_CHARS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_TRACE_CHARS;
+}
+
+function clip(value: string): string {
+  const limit = traceLimit();
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit)}... [${value.length - limit} more chars]`;
+}
+
+export interface AiTraceMeta {
+  provider: string;
+  productId?: number;
+  label?: string;
+}
+
+/** Records the prompt sent to a model. Costs nothing unless DEBUG is enabled. */
+export function traceAiRequest(prompt: string, meta: AiTraceMeta): void {
+  logger.debug(
+    `AI | ${meta.provider} | Request${meta.label ? ` | ${meta.label}` : ''} | ${clip(prompt)}`,
+    'AI',
+    { provider: meta.provider, product_id: meta.productId, promptChars: prompt.length }
+  );
+}
+
+/**
+ * Records what the model actually returned, before any parsing.
+ *
+ * The raw form matters: most AI extraction failures are a model wrapping JSON in
+ * prose or a code fence, which is invisible once parsing has already failed.
+ */
+export function traceAiResponse(raw: string | null | undefined, meta: AiTraceMeta): void {
+  logger.debug(
+    `AI | ${meta.provider} | Response${meta.label ? ` | ${meta.label}` : ''} | ${
+      raw ? clip(raw) : '(empty)'
+    }`,
+    'AI',
+    { provider: meta.provider, product_id: meta.productId, responseChars: raw?.length ?? 0 }
+  );
+}

--- a/backend/src/services/scraper/prices.ts
+++ b/backend/src/services/scraper/prices.ts
@@ -6,6 +6,7 @@ import {
 import { RetailerConfig } from '../../models';
 import { settingsCache } from '../../utils/cache';
 import { extractCustomCandidates, extractGenericPriceCandidates, extractJsonLdCandidates } from './extractors/prices';
+import { logger } from '../../utils/system/logger';
 
 /**
  * Definition of an extraction pass for a specific price type.
@@ -49,6 +50,19 @@ const EXTRACTION_PASSES: ExtractionPass[] = [
   }
 ];
 
+/**
+ * Records a cascade step to the trace and, at debug level, to the log stream
+ * (logging audit L-04).
+ *
+ * extractionSteps is attached to the final result, so it only becomes visible
+ * once a scrape has finished. When a scrape hangs or dies partway, the steps it
+ * had reached died with it -- which is precisely when you want them.
+ */
+function traceStep(extractionSteps: string[], message: string): void {
+  extractionSteps.push(message);
+  logger.debug(message, 'Extraction');
+}
+
 export async function extractAllPriceCandidates(
   $: CheerioAPI,
   html: string,
@@ -65,7 +79,7 @@ export async function extractAllPriceCandidates(
   const jsonLd = extractJsonLdCandidates($, currencyHint || undefined, jsonLdPriceKey);
   if (jsonLd.length > 0) {
     allCandidates.push(...jsonLd);
-    extractionSteps.push(`Extract | JSON-LD | Found ${jsonLd.length} candidates`);
+    traceStep(extractionSteps, `Extract | JSON-LD | Found ${jsonLd.length} candidates`);
   }
 
   // 2. Main Iterative Passes (Deals, Member, Pre-order, Original)
@@ -76,11 +90,11 @@ export async function extractAllPriceCandidates(
     const uniqueSelectors = Array.from(new Set([...custom, ...generic].map(s => s.trim()))).filter(Boolean);
     
     if (uniqueSelectors.length > 0) {
-      extractionSteps.push(`Extract | ${pass.name} | Selectors: ${JSON.stringify(uniqueSelectors)}`);
+      traceStep(extractionSteps, `Extract | ${pass.name} | Selectors: ${JSON.stringify(uniqueSelectors)}`);
       const candidates = extractCustomCandidates($, uniqueSelectors, html, currencyHint || undefined, localeHint);
       
       if (candidates.length > 0) {
-        extractionSteps.push(`Extract | ${pass.name} | Found ${candidates.length} candidates`);
+        traceStep(extractionSteps, `Extract | ${pass.name} | Found ${candidates.length} candidates`);
         for (const c of candidates) {
           c.method = pass.method;
           c.confidence = pass.confidence;
@@ -93,11 +107,11 @@ export async function extractAllPriceCandidates(
   // 3. Site-Specific (Standard)
   const customSelectors = domainConfig?.price_selectors || [];
   if (customSelectors.length > 0) {
-    extractionSteps.push(`Extract | Custom | Selectors: ${JSON.stringify(customSelectors)}`);
+    traceStep(extractionSteps, `Extract | Custom | Selectors: ${JSON.stringify(customSelectors)}`);
     const custom = extractCustomCandidates($, customSelectors, html, currencyHint || undefined, localeHint);
     if (custom.length > 0) {
       allCandidates.push(...custom);
-      extractionSteps.push(`Extract | Custom | Found ${custom.length} candidates`);
+      traceStep(extractionSteps, `Extract | Custom | Found ${custom.length} candidates`);
     }
   }
 
@@ -107,11 +121,11 @@ export async function extractAllPriceCandidates(
     .filter(s => !normalizedCustom.has(s.trim().toLowerCase()));
     
   if (genericSelectors.length > 0) {
-    extractionSteps.push(`Extract | Generic | Selectors: ${JSON.stringify(genericSelectors)}`);
+    traceStep(extractionSteps, `Extract | Generic | Selectors: ${JSON.stringify(genericSelectors)}`);
     const generic = await extractGenericPriceCandidates($, currencyHint || undefined, localeHint, genericSelectors, html);
     if (generic.length > 0) {
       allCandidates.push(...generic);
-      extractionSteps.push(`Extract | Generic | Found ${generic.length} candidates`);
+      traceStep(extractionSteps, `Extract | Generic | Found ${generic.length} candidates`);
     }
   }
 

--- a/database/v2-migration/generate-baseline.py
+++ b/database/v2-migration/generate-baseline.py
@@ -28,6 +28,7 @@ Usage:
     ./generate-baseline.py canonical-schema.sql <seeds.sql> > 001_baseline.ts
 """
 import re
+import json
 import sys
 
 
@@ -209,9 +210,64 @@ export const down = async ({{ context: pool }}: {{ context: MigrationContext }})
 '''
 
 
+
+def escape_for_ts_template(sql: str) -> str:
+    """Escape SQL so it survives being embedded in a TypeScript template literal.
+
+    The seed SQL is written into a `client.query(\`...\`)` call. A template
+    literal consumes one level of backslash escaping, which silently defeats the
+    escaping that pg_dump's E'' strings depend on:
+
+        in the .ts file        E'["a[rel=\\"b\\"]"]'
+        Postgres receives      E'["a[rel=\"b\"]"]'
+        Postgres stores        ["a[rel="b"]"]        <- invalid JSON
+
+    Postgres drops the backslash from \" because it is not a recognised E''
+    escape, so the JSON escaping is gone by the time it lands in the column.
+    That is how generic_stock_selectors, generic_ai_price_selectors and
+    generic_ai_image_selectors came to be stored unparseable, which in turn made
+    SettingsCache fall back to its smaller built-in defaults without saying so.
+
+    Escaping backticks and ${ as well, because seed content is arbitrary text and
+    either would otherwise terminate the literal or start an interpolation.
+    """
+    return (
+        sql.replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("${", "\\${")
+    )
+
+
+def check_json_settings(sql: str) -> None:
+    """Warn if any system_settings array value would not survive as JSON.
+
+    This is the assertion that would have caught the escaping bug at generation
+    time rather than months later in a running database.
+    """
+    for match in re.finditer(r"\('(generic_[a-z_]+)',\s*(E?)'((?:[^']|'')*)'\)", sql):
+        key, is_e, raw = match.group(1), match.group(2), match.group(3)
+        value = raw.replace("''", "'")
+        if is_e:
+            # Mirror Postgres: a backslash before an unrecognised character is
+            # dropped, and \\ collapses to one backslash.
+            value = re.sub(r"\\(.)", lambda m: "\\" if m.group(1) == "\\" else m.group(1), value)
+        if not value.lstrip().startswith("["):
+            continue
+        try:
+            json.loads(value)
+        except json.JSONDecodeError as err:
+            print(
+                f"warning: seed value for {key} is not valid JSON as Postgres would store it: {err}",
+                file=sys.stderr,
+            )
+
+
 def main():
     schema = open(sys.argv[1]).read()
     seeds = open(sys.argv[2]).read().strip() if len(sys.argv) > 2 else ""
+    if seeds:
+        check_json_settings(seeds)
+        seeds = escape_for_ts_template(seeds)
     parts = transform(split_statements(schema))
     tables, columns, seqs, seqs_owned, defaults, constraints, indexes, functions, triggers = parts
 

--- a/docs/audit/LOGGING.md
+++ b/docs/audit/LOGGING.md
@@ -54,10 +54,10 @@ We identified **five major monitoring and tracing gaps** that degrade debugging 
 | Gap ID | Area | Severity | Technical Impact | Actionable Mitigation |
 | :--- | :--- | :--- | :--- | :--- |
 | **L-01** | Database Layer | **High** | No visibility into SQL queries, database latency, or parameter maps during transaction failures. | **Fixed.** Every pooled and transaction-client statement is traced under the `Database` context with its SQL, latency and parameter count; slow queries warn at `SLOW_QUERY_MS`. Parameter values are deliberately excluded. |
-| **L-02** | AI / LLM Integrations | **Medium** | Prompt structure, system parameters, and raw JSON returns are invisible; only token usage is logged. | Add `logger.debug` statements inside `providers/*.ts` printing the raw prompt request and response payloads. |
+| **L-02** | AI / LLM Integrations | **Medium** | Prompt structure, system parameters, and raw JSON returns are invisible; only token usage is logged. | **Fixed.** Prompts and raw responses are traced at `DEBUG` for all five providers, capped by `AI_TRACE_CHARS`. |
 | **L-03** | Configuration Filtering | **Low** | Global `LOG_LEVEL` limits are bypassed by database writes, causing disk bloat on errors even when debugging is off. | **Fixed.** Database writes now honour `DB_LOG_LEVEL`, falling back to `LOG_LEVEL`, like the console and file sinks. |
-| **L-04** | Scraper Selectors | **Low** | Selector evaluation sequence (JSON-LD, custom-regex, generic parsing) lacks real-time streaming console logs. | Log each selector execution and matching candidate in real-time under `DEBUG` level. |
-| **L-05** | Auth token errors | **Low** | Verification checks for tokens don't log the reason for expiration or decryption failure. | Log token validation failures (e.g., token expired, signature mismatch) at `WARN` level. |
+| **L-04** | Scraper Selectors | **Low** | Selector evaluation sequence (JSON-LD, custom-regex, generic parsing) lacks real-time streaming console logs. | **Fixed.** The price cascade streams each step to the log as it runs, not only into the post-hoc trace. |
+| **L-05** | Auth token errors | **Low** | Verification checks for tokens don't log the reason for expiration or decryption failure. | **Fixed.** OIDC callback failures log the error name, code and offending claim. |
 
 ---
 

--- a/docs/developer/LOGGING.md
+++ b/docs/developer/LOGGING.md
@@ -24,6 +24,7 @@ Logging behavior is controlled via environment variables in your `.env` file or 
 | `FILE_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for Disk Log files. |
 | `DB_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `LOG_LEVEL` | Overrides the log level threshold specifically for the `system_logs` table behind Admin -> System Event Log. Raise it to `warn` to keep the table small, or lower it to `debug` to capture traces without flooding the console. |
 | `SLOW_QUERY_MS` | Any positive integer | `500` | A SQL statement taking at least this long is logged at `WARN` instead of `DEBUG`. |
+| `AI_TRACE_CHARS` | Any positive integer | `2000` | How much of an AI prompt and response to record at `DEBUG`. Both are capped: a prompt carries the denoised product page. |
 | `LOG_DIR_PATH` | Any valid absolute/relative directory | `./logs` | Directory path where log files are written. |
 | `TZ` | e.g. `Australia/Perth`, `UTC` | `UTC` | Controls the timezone prefix format for both services. |
 
@@ -149,3 +150,30 @@ recorded instead.
 Because `Database` is a high-volume context, `DEBUG` and `INFO` lines are printed
 and written to disk but not persisted to `system_logs`. Slow-query warnings and
 query failures are persisted, so they show up in **Admin -> System Event Log**.
+
+---
+
+## 7. AI Request Tracing
+
+At `DEBUG`, every AI provider records the prompt it sent and the raw text it got
+back, under the `AI` context:
+
+```text
+DEBUG [AI]: AI | Gemini | Request  | Extract the price from... [3021 more chars]
+DEBUG [AI]: AI | Gemini | Response | {"price": 49.99, "currency": "AUD"}
+```
+
+The raw response matters more than the parsed one: most AI extraction failures
+are a model wrapping its JSON in prose or a code fence, which is invisible by the
+time parsing has already failed.
+
+Both are capped at `AI_TRACE_CHARS` (default 2000). Uncapped, a single scrape
+would put a page of HTML into the console, the log file, and -- if
+`DB_LOG_LEVEL=debug` -- a `system_logs` row.
+
+## 8. Extraction Progress
+
+The price cascade writes each step to the log as it runs, as well as into the
+scrape trace attached to the result. The trace alone only becomes visible once a
+scrape finishes, so a scrape that hangs or dies partway took its progress with
+it -- which is exactly when it is wanted.


### PR DESCRIPTION
Closes #113 and #79 — the two issues that needed no decision from you.

---

## #113 — the cause is not the `E''` dialect

The issue assumes the generator emits bad escape strings. It does not construct them at all: it reads a `pg_dump` and embeds the seed SQL **verbatim into a TypeScript template literal**.

A template literal consumes one level of backslash escaping — which is exactly what `pg_dump`'s `E''` strings depend on:

```
in the .ts file      E'["a[rel=\\\\"b\\\\"]"]'
Postgres receives    E'["a[rel=\\"b\\"]"]'
Postgres stores      ["a[rel="b"]"]          <- invalid JSON
```

Postgres drops the backslash from `\\"` because it is not a recognised `E''` escape. That is how `generic_stock_selectors`, `generic_ai_price_selectors` and `generic_ai_image_selectors` came to be stored unparseable — and why stock detection was running on 5 generic selectors instead of the seeded 12.

**Fix:** escape the seeds for the template literal. Backticks and `${` too — seed content is arbitrary text, and either would otherwise terminate the literal or start an interpolation.

**Plus the check that would have caught it originally:** every `system_settings` array value is now parsed *as Postgres would store it*, and a failure warns on stderr. Verified it fires on the original bug shape and stays quiet on correct input.

`001_baseline.ts` is **not** regenerated. It has shipped, migration 013 already repairs the result on fresh and existing installs, and regenerating a migration that has run in production buys nothing.

**Verified end to end:** generator output evaluated the way the migration evaluates it, executed against PostgreSQL 16, stored value parses as JSON with selectors intact.

---

## #79 — L-02, L-04, L-05

**L-02, AI tracing.** Only token counts were logged, so a wrong extraction gave no way to tell whether the model was asked the wrong question or answered the right one badly. All five providers now trace the prompt and the **raw** response through one shared helper.

The raw form is the point: most AI extraction failures are a model wrapping JSON in prose or a code fence, which is invisible once parsing has failed.

Capped by `AI_TRACE_CHARS` (default 2000). The audit suggested `substring(0, 500)` — right instinct, too short to see the part you are looking at. Uncapped would be worse: a prompt carries the denoised product page, so every scrape would write a page of HTML to the console, the log file, and a `system_logs` row under `DB_LOG_LEVEL=debug`.

**L-04, cascade progress.** Steps went into `extractionSteps`, which is attached to the result and only visible once a scrape *finishes*. A scrape that hangs or dies partway took its progress with it — exactly when you want it. Now streamed to the log as well, through one helper so the trace and the log cannot disagree.

**L-05, OIDC failures.** The callback caught its error, put the message in a redirect, and logged nothing. An expired token, a clock skew and a bad signature were indistinguishable afterwards. Now logs the error name, code and offending claim.

---

## Verification

`tsc`, 207 backend tests, emoji lint, `git diff --check` — all pass. `docs/developer/LOGGING.md` and `.env.example` document the new knob; `docs/audit/LOGGING.md` marks L-02, L-04 and L-05 fixed, which closes out that register.

Closes #113
Closes #79