### PR TITLE
ci: keep prereleases out of stable and latest

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,11 +53,16 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=beta,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            # `stable` is what deploy/swarm-stack.yml tracks by default. It moves
-            # only on a versioned release, so an operator who does not pin a
-            # version never gets an unreviewed migration from main.
-            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # `stable` is what deploy/swarm-stack.yml tracks by default, and
+            # `latest` is what a bare `docker pull` gets. Both must move only on a
+            # final release.
+            #
+            # The hyphen test excludes prereleases: `v2.1.0-beta.1` is a valid tag
+            # to cut for testing, and without this it would advance `stable` for
+            # every self-hoster who never opted into a prerelease. A final version
+            # has no hyphen, a prerelease always does (semver requires it).
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
 
       - name: Build Docker image
         uses: docker/build-push-action@v7

--- a/deploy/swarm-stack.yml
+++ b/deploy/swarm-stack.yml
@@ -41,9 +41,10 @@
 # `beta` -- which tracks every merge to main -- that means an unreviewed
 # migration can run against your database the next time the container restarts.
 #
-#   stable   versioned releases only (default, recommended)
-#   beta     every merge to main; expect schema changes without notice
-#   v2.0.0   pin an exact version and choose your own upgrade moment
+#   stable          final releases only (default, recommended)
+#   beta            every merge to main; expect schema changes without notice
+#   v2.0.0          pin an exact version and choose your own upgrade moment
+#   v2.1.0-beta.1   a prerelease; these never advance stable
 #
 # Whichever you track, take the backup above before upgrading.
 


### PR DESCRIPTION
A gap in the `stable` tag I added in v2.0.0, found before it caused damage.

## The problem

```yaml
type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
```

`refs/tags/v2.1.0-beta.1` satisfies that. So cutting a prerelease to test something would have advanced **`stable`** — the tag every self-hoster now tracks by default — defeating the entire point of adding the channel.

`latest` had the same gap.

## The fix

Gate both on the tag containing no hyphen. Semver **requires** a hyphen before a prerelease identifier and forbids one in a final version, so this is an exact test rather than a heuristic:

```yaml
enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
```

The semver tags are unaffected — `v2.1.0-beta.1` still publishes `2.1.0-beta.1`, which is what you pin to when testing one. The compose file's channel list now documents that.

## Why it matters now

You asked to keep working on beta before merging to stable. Without this, the first prerelease tag would have pushed that work straight to everyone on the default channel.