### PR TITLE
release: v2.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0-beta.1] - 2026-08-31
+
 ### Fixed
 
 - AI extraction can now be diagnosed: at debug level each provider records the

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricestalker-backend",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.1",
   "description": "PriceStalker price tracking API",
   "main": "dist/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pricestalker-frontend",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0-beta.1",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.12.0"
   },
-  "version": "2.0.0"
+  "version": "2.1.0-beta.1"
 }


### PR DESCRIPTION
Opens the 2.1 line on the beta channel.

Contains the two issues that needed no decision from you:
- **#113** — the baseline generator's JSON escaping.
- **#79** — the remaining logging audit gaps (L-02, L-04, L-05), which closes that register out.

Version tags carry a prerelease identifier so this is pinnable as `PRICESTALKER_TAG=v2.1.0-beta.1` without advancing `stable` or `latest` — both now require a tag with no hyphen (#131).

No migrations in this release.