### PR TITLE
feat(products): record why a product is unavailable, and who paused it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Products now record **why** they could not be reached, and the product page
+  shows it alongside whether monitoring is still running. A page that is
+  genuinely gone, a retailer that is temporarily unreachable, and a product you
+  paused yourself are now three visibly different things.
+
+### Fixed
+
+- A retailer being unreachable no longer passes silently. Timeouts, DNS failures
+  and refused connections were producing "unknown", which kept the old status,
+  counted nothing and recorded nothing -- a retailer could be down for a week
+  leaving no trace on the product. They are now counted separately, never mark a
+  product as gone, and notify once if they persist.
+- Unavailable notifications state the real cause instead of always saying
+  "404/410 Page Not Found", and say whether monitoring actually stopped.
+- A product you paused yourself is no longer silently resumed by the system when
+  its page comes back. Only an automatic pause is automatically undone.
+
 ## [2.1.0-beta.1] - 2026-08-31
 
 ### Fixed

--- a/backend/src/migrations/016_unavailable_lifecycle.ts
+++ b/backend/src/migrations/016_unavailable_lifecycle.ts
@@ -1,0 +1,54 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Records why a product is unavailable, and who paused it (issue #73).
+ *
+ * Three gaps this closes:
+ *
+ * 1. **No reason was stored.** A product went to `not_available` and the
+ *    notification history said "404/410" regardless of whether the page had
+ *    actually 404'd, redirected to the home page, or served a soft 404.
+ *
+ * 2. **Site failures were invisible.** A timeout, DNS failure or refused
+ *    connection produced `unknown`, which preserved the previous status,
+ *    incremented nothing and recorded nothing. A retailer could be down for a
+ *    week with no trace on the product.
+ *
+ * 3. **A pause had no author.** `checking_paused` is set both by a user and by
+ *    the system after a page-gone streak, and nothing distinguished them, so the
+ *    UI could not say whether monitoring stopped by choice or by failure.
+ *
+ * All three columns are nullable or defaulted, so existing rows are unaffected
+ * and an image rollback leaves nothing broken.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  await pool.query(`
+    ALTER TABLE public.products
+      ADD COLUMN IF NOT EXISTS unavailable_reason text,
+      ADD COLUMN IF NOT EXISTS auto_paused boolean NOT NULL DEFAULT false,
+      ADD COLUMN IF NOT EXISTS failure_streak integer NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS last_failure_at timestamp with time zone;
+  `);
+
+  // A product already paused and already marked unavailable was paused by the
+  // system, since that is the only way both become true together. Backfilling
+  // this one inference is safe and stops existing unavailable products showing
+  // as though a user had paused them.
+  await pool.query(`
+    UPDATE public.products
+       SET auto_paused = true
+     WHERE checking_paused = true
+       AND stock_status = 'not_available'
+       AND auto_paused = false;
+  `);
+};
+
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  await pool.query(`
+    ALTER TABLE public.products
+      DROP COLUMN IF EXISTS unavailable_reason,
+      DROP COLUMN IF EXISTS auto_paused,
+      DROP COLUMN IF EXISTS failure_streak,
+      DROP COLUMN IF EXISTS last_failure_at;
+  `);
+};

--- a/backend/src/models/types/product.ts
+++ b/backend/src/models/types/product.ts
@@ -11,6 +11,13 @@ export interface Product {
   next_check_at: Date | null;
   stock_status: StockStatus;
   page_gone_streak?: number;
+  /** Why the product is unavailable, when it is. See types/availability. */
+  unavailable_reason?: string | null;
+  /** True when the system paused monitoring, false when a user did. */
+  auto_paused?: boolean;
+  /** Consecutive transport failures; distinct from page_gone_streak. */
+  failure_streak?: number;
+  last_failure_at?: Date | null;
   price_drop_threshold: number | null;
   target_price: number | null;
   notify_back_in_stock: boolean;

--- a/backend/src/services/domain/product/ProductRefreshService.ts
+++ b/backend/src/services/domain/product/ProductRefreshService.ts
@@ -8,10 +8,21 @@ import { ExtractionMethod } from '../../../types/scraper';
 import { logger } from '../../../utils/system/logger';
 import { productNotificationService } from './notifications/index';
 import { productPersistenceService } from './ProductPersistenceService';
+import { isDefinitiveUnavailable, describeUnavailableReason } from '../../../types/availability';
 
-// Consecutive page-gone (404/410) scrapes required before a product is
-// marked not_available, monitoring is paused, and the user is notified.
+// Consecutive page-gone scrapes required before a product is marked
+// not_available, monitoring is paused, and the user is notified.
 const PAGE_GONE_THRESHOLD = 3;
+
+/**
+ * Consecutive transport failures before the user is told the retailer looks
+ * unreachable.
+ *
+ * Higher than the page-gone threshold, and deliberately does not pause: a
+ * timeout is evidence about the network, not about the product, so the right
+ * response is to keep trying and say so once it stops looking like a blip.
+ */
+const SITE_FAILURE_NOTIFY_THRESHOLD = 6;
 
 export class ProductRefreshService {
   /**
@@ -42,37 +53,65 @@ export class ProductRefreshService {
       productId
     );
 
-    // 1.5 Debounce page-gone results: bot walls can serve 404 for a while,
-    // so a product is only flagged not_available (paused + notified) after
-    // several consecutive page-gone scrapes. Until then the previous status
-    // is kept and only the streak advances.
-    if (scrapedData.stockStatus === 'not_available' && product.stock_status !== 'not_available') {
+    // 1.5 Separate two things that used to be conflated.
+    //
+    // A *definitive* result -- 404, 410, a redirect to the home page, a soft 404
+    // -- is evidence about the product, and after a streak it pauses monitoring
+    // and tells the user. Bot walls serve 404 for a while, hence the streak.
+    //
+    // A *transient* failure -- timeout, DNS, refused connection, a bot challenge
+    // -- is evidence about the network or the retailer. It previously produced
+    // `unknown`, which preserved the status, counted nothing and recorded
+    // nothing, so a retailer could be down for a week leaving no trace. It now
+    // counts separately, never pauses, and never marks a product gone.
+    const reason = scrapedData.unavailableReason;
+    const isDefinitive = isDefinitiveUnavailable(reason);
+    const isTransient = !!reason && !isDefinitive;
+
+    if (isTransient) {
+      const failures = await productRepository.recordFailure(productId, reason!);
+      logger.warn(
+        `Product ${productId} | Availability | ${describeUnavailableReason(reason)} (failure ${failures}). Status unchanged.`,
+        'Products',
+        { product_id: productId }
+      );
+      if (failures === SITE_FAILURE_NOTIFY_THRESHOLD) {
+        // Once, on crossing the threshold -- not every scrape thereafter.
+        await productNotificationService.notifyNotAvailable(product, reason!, false);
+      }
+    } else if (isDefinitive && product.stock_status !== 'not_available') {
       const streak = (product.page_gone_streak || 0) + 1;
       await productRepository.setPageGoneStreak(productId, streak);
+      await productRepository.setUnavailableReason(productId, reason!);
       if (streak < PAGE_GONE_THRESHOLD) {
-        logger.warn(`Product ${productId} | Status | Page gone (${streak}/${PAGE_GONE_THRESHOLD} consecutive). Keeping status '${product.stock_status}' until the streak completes.`, 'Products', { product_id: productId });
+        logger.warn(`Product ${productId} | Status | ${describeUnavailableReason(reason)} (${streak}/${PAGE_GONE_THRESHOLD} consecutive). Keeping status '${product.stock_status}' until the streak completes.`, 'Products', { product_id: productId });
         scrapedData.stockStatus = product.stock_status;
       }
-    } else if (product.page_gone_streak) {
-      await productRepository.setPageGoneStreak(productId, 0);
+    } else if (!reason) {
+      // The page was actually read, so any previous failure state is stale.
+      if (product.page_gone_streak) await productRepository.setPageGoneStreak(productId, 0);
+      await productRepository.clearFailureState(productId);
     }
 
     // 2. Persist results (DB State Sync)
     await productPersistenceService.saveScrapeResult(productId, userId, scrapedData, 'refresh');
 
-    // Unpause if the product was previously paused but is now available again
-    if (product.checking_paused && scrapedData.stockStatus !== 'not_available') {
+    // Resume only a pause the system applied. A user who deliberately paused a
+    // product does not want it silently resumed because the page came back --
+    // that decision is theirs, and previously it was overridden.
+    if (product.checking_paused && product.auto_paused && scrapedData.stockStatus !== 'not_available') {
       logger.info(`Product ${productId} | Status | Page is available again. Resuming checks.`, 'Products', { product_id: productId });
-      await productRepository.bulkSetCheckingPaused([productId], userId, false);
+      await productRepository.setPaused(productId, false, false);
+      await productRepository.setUnavailableReason(productId, null);
       product.checking_paused = false;
     }
 
     // 3. Handle Notifications (Side-effects of change)
     if (scrapedData.stockStatus !== product.stock_status) {
       if (scrapedData.stockStatus === 'not_available') {
-        logger.warn(`Product ${productId} | Status | Page is unavailable (404/410). Pausing further checks.`, 'Products', { product_id: productId });
-        await productRepository.bulkSetCheckingPaused([productId], userId, true);
-        await productNotificationService.notifyNotAvailable(product);
+        logger.warn(`Product ${productId} | Status | ${describeUnavailableReason(reason)}. Pausing further checks.`, 'Products', { product_id: productId });
+        await productRepository.setPaused(productId, true, false);
+        await productNotificationService.notifyNotAvailable(product, reason);
       } else if (
         (product.stock_status === 'out_of_stock' || product.stock_status === 'pre_order' || product.stock_status === 'not_available') && 
         scrapedData.stockStatus === 'in_stock' && 

--- a/backend/src/services/domain/product/notifications/alerts.ts
+++ b/backend/src/services/domain/product/notifications/alerts.ts
@@ -1,9 +1,18 @@
 import { Product } from '../../../../models';
 import { ScrapedProductWithVoting } from '../../../../types/scraper';
 import { productNotificationOrchestrator } from './orchestrator';
+import { describeUnavailableReason, type UnavailableReason } from '../../../../types/availability';
 
 export class ProductAlertService {
-  async notifyNotAvailable(product: Product) {
+  /**
+   * Tells the user a product could not be reached.
+   *
+   * `paused` separates the two cases this used to conflate: a page that is gone
+   * and no longer being checked, versus a retailer that is unreachable and still
+   * being retried. Telling someone monitoring has stopped when it has not is
+   * worse than saying nothing.
+   */
+  async notifyNotAvailable(product: Product, reason?: UnavailableReason | null, paused = true) {
     await productNotificationOrchestrator.deliver(
       product,
       'not_available',
@@ -15,14 +24,21 @@ export class ProductAlertService {
       },
       {
         type: 'system_alert',
-        title: `404 | ${product.name || 'Product'}`,
-        message: 'Page not found. Monitoring paused.',
+        // The reason and the action were hardcoded to "404/410 Page Not Found"
+        // and "Monitoring Paused" regardless of what actually happened, so a
+        // redirect, a soft 404 and a week-long retailer outage all read the
+        // same in the notification history (issue #73).
+        title: `Unavailable | ${product.name || 'Product'}`,
+        message: paused
+          ? `${describeUnavailableReason(reason)}. Monitoring paused.`
+          : `${describeUnavailableReason(reason)}. Still retrying.`,
         data: {
           productId: product.id,
           productName: product.name,
           productUrl: product.url,
-          reason: '404/410 Page Not Found',
-          action: 'Monitoring Paused'
+          reason: describeUnavailableReason(reason),
+          reasonCode: reason ?? 'unknown_scrape_failure',
+          action: paused ? 'Monitoring Paused' : 'Still Retrying'
         }
       }
     );

--- a/backend/src/services/domain/product/repositories/product-config.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-config.repository.ts
@@ -4,6 +4,59 @@ import { calculateNextCheckSeconds } from '../../../../utils/system/scheduler-he
 import { asExecutor, type Executor } from './executor';
 
 export const productConfigRepository = {
+  /**
+   * Records a transport failure: the retailer could not be reached, which says
+   * nothing about whether the product still exists.
+   *
+   * Kept separate from the page-gone streak on purpose. Merging them would let
+   * a retailer having a bad afternoon eventually mark products as gone, which is
+   * the opposite of what the evidence supports.
+   */
+  recordFailure: async (id: number, reason: string): Promise<number> => {
+    const result = await pool.query(
+      `UPDATE products
+          SET failure_streak = failure_streak + 1,
+              last_failure_at = CURRENT_TIMESTAMP,
+              unavailable_reason = $2
+        WHERE id = $1
+      RETURNING failure_streak`,
+      [id, reason]
+    );
+    return result.rows[0]?.failure_streak ?? 0;
+  },
+
+  /** Clears failure state after a scrape that actually reached the page. */
+  clearFailureState: async (id: number): Promise<void> => {
+    await pool.query(
+      `UPDATE products
+          SET failure_streak = 0,
+              unavailable_reason = NULL
+        WHERE id = $1
+          AND (failure_streak <> 0 OR unavailable_reason IS NOT NULL)`,
+      [id]
+    );
+  },
+
+  /** Records why a product is unavailable, without touching failure counters. */
+  setUnavailableReason: async (id: number, reason: string | null): Promise<void> => {
+    await pool.query('UPDATE products SET unavailable_reason = $2 WHERE id = $1', [id, reason]);
+  },
+
+  /**
+   * Pauses or resumes monitoring, recording whether the system or a user did it.
+   *
+   * The distinction is what lets the UI say "we stopped checking because the
+   * page is gone" rather than leaving a user wondering why their product went
+   * quiet -- and what stops an automatic resume from overriding a deliberate
+   * user pause.
+   */
+  setPaused: async (id: number, paused: boolean, byUser: boolean): Promise<void> => {
+    await pool.query(
+      'UPDATE products SET checking_paused = $2, auto_paused = $3 WHERE id = $1',
+      [id, paused, paused ? !byUser : false]
+    );
+  },
+
   setPageGoneStreak: async (id: number, streak: number): Promise<void> => {
     await pool.query(
       'UPDATE products SET page_gone_streak = $2 WHERE id = $1',

--- a/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
@@ -86,10 +86,15 @@ export const productLifecycleRepository = {
     return (result.rowCount ?? 0) > 0;
   },
 
+  /**
+   * The user-facing pause. Always recorded as a user pause (auto_paused = false),
+   * which is what stops a later automatic resume from overriding a deliberate
+   * decision -- the system only resumes what the system paused.
+   */
   bulkSetCheckingPaused: async (ids: number[], userId: number, paused: boolean): Promise<number> => {
     if (ids.length === 0) return 0;
     const result = await pool.query(
-      `UPDATE products SET checking_paused = $1 WHERE id = ANY($2) AND user_id = $3`,
+      `UPDATE products SET checking_paused = $1, auto_paused = false WHERE id = ANY($2) AND user_id = $3`,
       [paused, ids, userId]
     );
     return result.rowCount || 0;

--- a/backend/src/services/scraper/acquisition/index.ts
+++ b/backend/src/services/scraper/acquisition/index.ts
@@ -109,7 +109,7 @@ function checkSoft404($: CheerioAPI, html: string, extractionSteps: string[]) {
     for (const pattern of notFoundPatterns) {
       if (title === pattern || (pattern !== 'not found' && title.includes(pattern))) {
         extractionSteps.push(`Soft-404 | Title match: "${title}" contains "${pattern}"`);
-        throw new PageNotAvailableError(`Soft 404: Title matches "${pattern}"`);
+        throw new PageNotAvailableError(`Soft 404: Title matches "${pattern}"`, 'soft_404_title');
       }
     }
   }
@@ -131,7 +131,7 @@ function checkSoft404($: CheerioAPI, html: string, extractionSteps: string[]) {
 
     if (!hasPriceMeta && !hasJsonLdProduct) {
       extractionSteps.push(`Soft-404 | Robots meta tag contains noindex: "${robots}"`);
-      throw new PageNotAvailableError(`Soft 404: Robots meta tag contains noindex (${robots})`);
+      throw new PageNotAvailableError(`Soft 404: Robots meta tag contains noindex (${robots})`, 'soft_404_noindex');
     } else {
       extractionSteps.push(`Soft-404 | Robots meta has noindex but page has valid product/price metadata. Skipping robots check.`);
     }
@@ -148,7 +148,7 @@ function checkSoft404($: CheerioAPI, html: string, extractionSteps: string[]) {
   for (const selector of soft404Selectors) {
     if ($(selector).length > 0) {
       extractionSteps.push(`Soft-404 | Found error selector: "${selector}"`);
-      throw new PageNotAvailableError(`Soft 404: Found error element "${selector}"`);
+      throw new PageNotAvailableError(`Soft 404: Found error element "${selector}"`, 'soft_404_element');
     }
   }
 }

--- a/backend/src/services/scraper/acquisition/standard.ts
+++ b/backend/src/services/scraper/acquisition/standard.ts
@@ -135,7 +135,7 @@ function handleAxiosError(err: any, url: string, extractionSteps: string[], requ
         // fall through to the plain 404 handling.
       }
     }
-    throw new PageNotAvailableError(`Page not found (${status}): ${url}`);
+    throw new PageNotAvailableError(`Page not found (${status}): ${url}`, status === 410 ? 'http_410' : 'http_404');
   }
 
   if (err instanceof AxiosError && status === 403) {
@@ -156,7 +156,7 @@ function validateUrl(originalUrl: string, finalUrl: string, requestId?: string) 
     
     if (isErrorPath || (originalObj.pathname.length > 5 && (finalPath === '/' || finalPath === ''))) {
       logger.warn(`Scraper | Axios | [${requestId || 'N/A'}] | Soft 404 | Redirected from ${originalUrl} to ${finalUrl}`, 'Scraper', { requestId });
-      throw new PageNotAvailableError(`Soft 404: Redirected to error or root page: ${finalUrl}`);
+      throw new PageNotAvailableError(`Soft 404: Redirected to error or root page: ${finalUrl}`, 'redirected_to_error_page');
     }
   } catch (urlErr) {
     if (urlErr instanceof PageNotAvailableError) throw urlErr;

--- a/backend/src/services/scraper/orchestration/index.ts
+++ b/backend/src/services/scraper/orchestration/index.ts
@@ -15,6 +15,7 @@ import { runExtractionPhase } from './extraction';
 import { runConsensusPhase } from './consensus';
 import { runVerificationPhase } from './verification';
 import { handleRetailerMaintenance, handleAutoMapping, handleRestoreStatus } from './maintenance';
+import { classifyTransportError } from '../../../types/availability';
 
 /**
  * High-level scraper entry point.
@@ -223,12 +224,17 @@ export async function scrapeProductWithVoting(
     });
   } catch (error) {
     if (error instanceof PageNotAvailableError) {
-      extractionSteps.push(`Scraper | Block | Page no longer exists (404/410)`);
+      extractionSteps.push(`Scraper | Block | Page no longer exists (${error.reason})`);
       result.stockStatus = 'not_available';
       result.failureReason = 'page_unavailable';
+      result.unavailableReason = error.reason;
       logger.warn(`Product | Scrape Failed | Page Gone | ${url}`, 'Scraper', { product_id: productId, requestId });
     } else {
-      logger.error(`Product | Scrape Failed | ${url}`, 'Scraper', { product_id: productId, error, requestId });
+      // A transport failure is not evidence about the product. Classify it so a
+      // refresh can count it separately and leave the product's status alone,
+      // rather than the previous behaviour of silently returning 'unknown'.
+      result.unavailableReason = classifyTransportError(error);
+      logger.error(`Product | Scrape Failed | ${url} (${result.unavailableReason})`, 'Scraper', { product_id: productId, error, requestId });
     }
     result.extractionSteps = extractionSteps;
   } finally {

--- a/backend/src/services/scraper/transport/errors.ts
+++ b/backend/src/services/scraper/transport/errors.ts
@@ -1,9 +1,19 @@
+import type { UnavailableReason } from '../../../types/availability';
+
 /**
  * Error thrown when a page is explicitly not available (404, 410, or root redirect).
+ *
+ * The reason is carried structurally as well as in the message. The message is
+ * for a human reading a log; the reason is what gets persisted on the product
+ * and rendered back to a user, and parsing it out of prose later was how the
+ * notification history ended up saying "404/410" no matter what happened.
  */
 export class PageNotAvailableError extends Error {
-  constructor(message: string) {
+  readonly reason: UnavailableReason;
+
+  constructor(message: string, reason: UnavailableReason = 'unknown_scrape_failure') {
     super(message);
     this.name = 'PageNotAvailableError';
+    this.reason = reason;
   }
 }

--- a/backend/src/types/availability.ts
+++ b/backend/src/types/availability.ts
@@ -1,0 +1,90 @@
+/**
+ * Why a product could not be reached, recorded on the product itself.
+ *
+ * The distinction that matters is **definitive vs transient**, because the two
+ * deserve opposite treatment: a page that is genuinely gone should stop being
+ * checked and the user told, while a retailer having a bad afternoon should be
+ * retried and nobody woken up.
+ *
+ * Before this existed, a scrape failure was either a `not_available` status with
+ * a hardcoded "404/410" reason in the notification history regardless of the
+ * actual cause, or -- for every network-shaped failure -- silence: the previous
+ * status was kept, nothing was counted, and nothing was recorded.
+ */
+export type UnavailableReason =
+  // --- Definitive: the page itself is gone. Pause and notify after a streak.
+  | 'http_404'
+  | 'http_410'
+  | 'redirected_to_error_page'
+  | 'soft_404_title'
+  | 'soft_404_noindex'
+  | 'soft_404_element'
+  // --- Transient: the page may well be fine; we could not see it.
+  | 'site_timeout'
+  | 'dns_failure'
+  | 'connection_failure'
+  | 'remote_scraper_failure'
+  | 'bot_or_challenge'
+  | 'unknown_scrape_failure';
+
+const DEFINITIVE: ReadonlySet<UnavailableReason> = new Set<UnavailableReason>([
+  'http_404',
+  'http_410',
+  'redirected_to_error_page',
+  'soft_404_title',
+  'soft_404_noindex',
+  'soft_404_element',
+]);
+
+/**
+ * True when the evidence is about the product page rather than about our ability
+ * to fetch it. Only these advance the page-gone streak toward pausing.
+ */
+export function isDefinitiveUnavailable(reason: UnavailableReason | null | undefined): boolean {
+  return !!reason && DEFINITIVE.has(reason);
+}
+
+/** Wording for notifications and the UI. Written for a person, not a log. */
+const DESCRIPTIONS: Record<UnavailableReason, string> = {
+  http_404: 'The product page returned 404 Not Found',
+  http_410: 'The product page returned 410 Gone',
+  redirected_to_error_page: 'The product URL redirected to an error or home page',
+  soft_404_title: 'The page title indicates the product no longer exists',
+  soft_404_noindex: 'The page asks not to be indexed and has no product details',
+  soft_404_element: 'The page shows a "not found" message',
+  site_timeout: 'The retailer did not respond in time',
+  dns_failure: 'The retailer’s domain could not be resolved',
+  connection_failure: 'The connection to the retailer failed',
+  remote_scraper_failure: 'The browser scraper could not fetch the page',
+  bot_or_challenge: 'The retailer served a bot check instead of the product page',
+  unknown_scrape_failure: 'The page could not be read',
+};
+
+export function describeUnavailableReason(reason: UnavailableReason | null | undefined): string {
+  if (!reason) return 'Unknown';
+  return DESCRIPTIONS[reason] ?? 'The page could not be read';
+}
+
+/**
+ * Classifies a transport-layer error.
+ *
+ * Node and axios report these through a mix of `code`, `errno` and message text
+ * depending on which layer failed, so this checks all three rather than trusting
+ * any one of them.
+ */
+export function classifyTransportError(error: unknown): UnavailableReason {
+  const err = error as { code?: string; errno?: string; message?: string };
+  const code = String(err?.code || err?.errno || '').toUpperCase();
+  const message = String(err?.message || '').toLowerCase();
+
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN' || message.includes('getaddrinfo')) {
+    return 'dns_failure';
+  }
+  if (code === 'ECONNABORTED' || code === 'ETIMEDOUT' || message.includes('timeout')) {
+    return 'site_timeout';
+  }
+  if (code === 'ECONNREFUSED' || code === 'ECONNRESET' || code === 'EHOSTUNREACH' || code === 'ENETUNREACH') {
+    return 'connection_failure';
+  }
+  return 'unknown_scrape_failure';
+}

--- a/backend/src/types/scraper.ts
+++ b/backend/src/types/scraper.ts
@@ -1,4 +1,5 @@
 import { ParsedPrice } from '../utils/scraping/priceParser';
+import type { UnavailableReason } from './availability';
 
 export type StockStatus = 'in_stock' | 'out_of_stock' | 'pre_order' | 'not_available' | 'member_only' | 'unknown';
 export type AIStatus = 'verified' | 'corrected' | 'confirmed' | null;
@@ -60,6 +61,12 @@ export interface ScrapedProductWithVoting extends ScrapedProduct {
   failureReason?: ScrapeFailureReason;
   /** Free-text detail for the reason, e.g. which challenge was detected. */
   failureDetail?: string;
+  /**
+   * Why the page could not be read, when it could not be. Distinguishes a page
+   * that is genuinely gone from one we merely failed to fetch -- the two get
+   * opposite treatment during a refresh.
+   */
+  unavailableReason?: UnavailableReason;
 }
 
 export type ExtractionMethod = 'json-ld' | 'site-specific' | 'generic-css' | 'custom-css' | 'custom-regex' | 'ai' | 'generic' | 'deal-price' | 'member-price' | 'pre-order-price' | 'original-price';

--- a/backend/tests/unit/availability-reasons.test.ts
+++ b/backend/tests/unit/availability-reasons.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isDefinitiveUnavailable,
+  describeUnavailableReason,
+  classifyTransportError,
+  type UnavailableReason,
+} from '../../src/types/availability';
+
+/**
+ * The definitive/transient split decides whether a product gets paused and its
+ * owner notified that it is gone. Misclassifying one as the other is the whole
+ * bug this replaces: every network failure used to become a silent `unknown`,
+ * and every definitive failure reported itself as "404/410" whatever it was.
+ */
+
+describe('Unavailable reasons', () => {
+  describe('definitive means the page itself is gone', () => {
+    const definitive: UnavailableReason[] = [
+      'http_404',
+      'http_410',
+      'redirected_to_error_page',
+      'soft_404_title',
+      'soft_404_noindex',
+      'soft_404_element',
+    ];
+
+    it.each(definitive)('%s counts toward pausing', (reason) => {
+      expect(isDefinitiveUnavailable(reason)).toBe(true);
+    });
+  });
+
+  describe('transient means we could not look', () => {
+    const transient: UnavailableReason[] = [
+      'site_timeout',
+      'dns_failure',
+      'connection_failure',
+      'remote_scraper_failure',
+      'bot_or_challenge',
+      'unknown_scrape_failure',
+    ];
+
+    it.each(transient)('%s must never mark a product gone', (reason) => {
+      expect(isDefinitiveUnavailable(reason)).toBe(false);
+    });
+
+    it('treats a bot challenge as transient', () => {
+      // A retailer serving a CAPTCHA is not evidence the product was removed.
+      // Treating it as definitive is how a bot wall silently deletes a user's
+      // tracking, which is the failure mode the streak was added to prevent.
+      expect(isDefinitiveUnavailable('bot_or_challenge')).toBe(false);
+    });
+  });
+
+  it('treats an absent reason as not definitive', () => {
+    expect(isDefinitiveUnavailable(null)).toBe(false);
+    expect(isDefinitiveUnavailable(undefined)).toBe(false);
+  });
+
+  describe('classifying a transport error', () => {
+    it.each([
+      [{ code: 'ENOTFOUND' }, 'dns_failure'],
+      [{ code: 'EAI_AGAIN' }, 'dns_failure'],
+      [{ message: 'getaddrinfo ENOTFOUND shop.example' }, 'dns_failure'],
+      [{ code: 'ECONNABORTED' }, 'site_timeout'],
+      [{ code: 'ETIMEDOUT' }, 'site_timeout'],
+      [{ message: 'timeout of 30000ms exceeded' }, 'site_timeout'],
+      [{ code: 'ECONNREFUSED' }, 'connection_failure'],
+      [{ code: 'ECONNRESET' }, 'connection_failure'],
+      [{ code: 'EHOSTUNREACH' }, 'connection_failure'],
+    ])('%o -> %s', (error, expected) => {
+      expect(classifyTransportError(error)).toBe(expected);
+    });
+
+    it('falls back rather than guessing', () => {
+      expect(classifyTransportError(new Error('something odd'))).toBe('unknown_scrape_failure');
+      expect(classifyTransportError(undefined)).toBe('unknown_scrape_failure');
+    });
+
+    it('never classifies a transport error as definitive', () => {
+      // The safety property: nothing the network does should be able to mark a
+      // product as gone.
+      for (const e of [{ code: 'ENOTFOUND' }, { code: 'ETIMEDOUT' }, new Error('?')]) {
+        expect(isDefinitiveUnavailable(classifyTransportError(e))).toBe(false);
+      }
+    });
+  });
+
+  describe('descriptions are written for a person', () => {
+    it('describes each reason without leaking the code', () => {
+      const reasons: UnavailableReason[] = [
+        'http_404', 'http_410', 'redirected_to_error_page', 'soft_404_title',
+        'soft_404_noindex', 'soft_404_element', 'site_timeout', 'dns_failure',
+        'connection_failure', 'remote_scraper_failure', 'bot_or_challenge',
+        'unknown_scrape_failure',
+      ];
+      for (const r of reasons) {
+        const text = describeUnavailableReason(r);
+        expect(text.length).toBeGreaterThan(10);
+        expect(text).not.toContain('_');
+      }
+    });
+
+    it('distinguishes a redirect from a 404', () => {
+      // These used to be reported identically as "404/410 Page Not Found".
+      expect(describeUnavailableReason('redirected_to_error_page'))
+        .not.toBe(describeUnavailableReason('http_404'));
+    });
+
+    it('handles an absent reason', () => {
+      expect(describeUnavailableReason(null)).toBe('Unknown');
+    });
+  });
+});

--- a/frontend/src/features/products/pages/product-detail/ProductMetadata.tsx
+++ b/frontend/src/features/products/pages/product-detail/ProductMetadata.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useAuth } from '../../../auth';
 import { formatDate } from '../../../../utils/format';
+import { describeUnavailableReason, describeMonitoringState } from '../../../../utils/availability';
 
 interface ProductMetadataProps {
   product: any;
@@ -35,6 +36,11 @@ const ProductMetadata: React.FC<ProductMetadataProps> = ({
   REFRESH_INTERVALS,
 }) => {
   const { user } = useAuth();
+
+  // A stalled product used to give no explanation at all: a user could not tell
+  // whether they had paused it, the system had given up, or the retailer was
+  // simply unreachable (issue #73).
+  const unavailableReason = describeUnavailableReason(product.unavailable_reason);
 
   return (
     <div className="product-detail-meta">
@@ -104,6 +110,18 @@ const ProductMetadata: React.FC<ProductMetadataProps> = ({
         <span className="product-detail-meta-label">Last Checked</span>
         <span className="product-detail-meta-value">{product.last_checked ? formatDate(product.last_checked, user?.locale, true) : 'Never'}</span>
       </div>
+      <div className="product-detail-meta-item">
+        <span className="product-detail-meta-label">Monitoring</span>
+        <span className="product-detail-meta-value">{describeMonitoringState(product)}</span>
+      </div>
+      {unavailableReason && (
+        <div className="product-detail-meta-item">
+          <span className="product-detail-meta-label">Reason</span>
+          <span className="product-detail-meta-value" style={{ color: 'var(--text-muted)' }}>
+            {unavailableReason}
+          </span>
+        </div>
+      )}
       <div className="product-detail-meta-item">
         <span className="product-detail-meta-label">Check Interval</span>
         <select

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -7,6 +7,13 @@ export interface SparklinePoint {
 }
 
 export interface Product {
+  /** Why the product is unavailable, when it is. See utils/availability. */
+  unavailable_reason?: string | null;
+  /** True when the system paused monitoring, false when the user did. */
+  auto_paused?: boolean;
+  /** Consecutive failed fetches; the product is still being retried. */
+  failure_streak?: number;
+  last_failure_at?: string | null;
   id: number;
   user_id: number;
   url: string;

--- a/frontend/src/utils/availability.ts
+++ b/frontend/src/utils/availability.ts
@@ -1,0 +1,67 @@
+/**
+ * Human wording for the availability reason codes the backend stores on a
+ * product. Mirrors backend/src/types/availability.ts.
+ *
+ * Duplicated rather than shared because the two workspaces have no common
+ * package, and a reason the UI cannot name is worse than a slightly duplicated
+ * table: an unrecognised code falls through to a readable default rather than
+ * rendering a raw enum at the user.
+ */
+const DESCRIPTIONS: Record<string, string> = {
+  http_404: 'The product page returned 404 Not Found',
+  http_410: 'The product page returned 410 Gone',
+  redirected_to_error_page: 'The product URL redirected to an error or home page',
+  soft_404_title: 'The page title indicates the product no longer exists',
+  soft_404_noindex: 'The page asks not to be indexed and has no product details',
+  soft_404_element: 'The page shows a "not found" message',
+  site_timeout: 'The retailer did not respond in time',
+  dns_failure: "The retailer's domain could not be resolved",
+  connection_failure: 'The connection to the retailer failed',
+  remote_scraper_failure: 'The browser scraper could not fetch the page',
+  bot_or_challenge: 'The retailer served a bot check instead of the product page',
+  unknown_scrape_failure: 'The page could not be read',
+};
+
+const DEFINITIVE = new Set([
+  'http_404',
+  'http_410',
+  'redirected_to_error_page',
+  'soft_404_title',
+  'soft_404_noindex',
+  'soft_404_element',
+]);
+
+export function describeUnavailableReason(reason?: string | null): string | null {
+  if (!reason) return null;
+  return DESCRIPTIONS[reason] ?? 'The page could not be read';
+}
+
+/** True when the page itself is gone, rather than merely unreachable. */
+export function isDefinitiveUnavailable(reason?: string | null): boolean {
+  return !!reason && DEFINITIVE.has(reason);
+}
+
+/**
+ * What is happening to monitoring, in one line.
+ *
+ * The point of the issue: a user seeing a stalled product could not tell whether
+ * they had paused it, the system had given up, or a retailer was simply down.
+ */
+export function describeMonitoringState(product: {
+  checking_paused?: boolean;
+  auto_paused?: boolean;
+  unavailable_reason?: string | null;
+  failure_streak?: number;
+}): string {
+  if (product.checking_paused) {
+    return product.auto_paused
+      ? 'Paused automatically because the page could not be found'
+      : 'Paused by you';
+  }
+  if (product.failure_streak && product.failure_streak > 0) {
+    return `Still checking; ${product.failure_streak} recent ${
+      product.failure_streak === 1 ? 'attempt' : 'attempts'
+    } failed`;
+  }
+  return 'Active';
+}


### PR DESCRIPTION
First slice of #73. Three gaps, all of which made a stalled product unexplainable to its owner.

## 1. Site failures passed silently

A timeout, DNS failure or refused connection produced `unknown`, which preserved the previous status, incremented nothing and recorded nothing. **A retailer could be down for a week and leave no trace on the product.**

Transport errors are now classified (`site_timeout`, `dns_failure`, `connection_failure`, …), counted on their own streak, and notified once if they persist. They **never** mark a product as gone — the network failing is not evidence about the product.

## 2. No reason was stored

A product went to `not_available` and the notification history read:

```
reason: '404/410 Page Not Found'
action: 'Monitoring Paused'
```

…whatever had actually happened — a real 404, a redirect to the home page, a soft 404, a noindex page. Both strings were hardcoded.

Each throw site now carries a **structured** reason rather than only prose in its message. That is what made the hardcoding necessary in the first place: the cause existed only as free text in an error message, so it could not be persisted or rendered.

## 3. A pause had no author

`checking_paused` is set both by a user and by the system after a page-gone streak, and nothing distinguished them. Two consequences:

- The UI could not say **why** monitoring stopped.
- The automatic resume **overrode a deliberate user pause** when a page came back.

The system now only resumes what the system paused.

## The design decision worth reviewing

**A bot challenge is classified as transient, not definitive.** A retailer serving a CAPTCHA is not evidence a product was removed — and treating it as definitive is exactly how a bot wall silently deletes someone's tracking. That is the failure the page-gone streak was originally added to prevent, and this makes it structural rather than incidental.

## What the user sees

The product page gains **Monitoring** and **Reason**:

```
Monitoring   Paused automatically because the page could not be found
Reason       The product URL redirected to an error or home page
```

versus

```
Monitoring   Still checking; 3 recent attempts failed
Reason       The retailer did not respond in time
```

Those two situations previously looked identical.

## Verification

Against PostgreSQL 16 — migration applies and re-applies; transient failures accumulate **without** pausing; a good scrape clears them; a user pause is correctly distinguished so the resume branch skips it.

28 new unit tests (backend 207 → 235), weighted toward the safety property: **nothing the network does can mark a product as gone.**

Migration 016 adds four columns, all nullable or defaulted, so an image rollback leaves nothing broken. It backfills `auto_paused` only for products already both paused *and* unavailable, since that combination can only have been the system's doing.

## Remaining on #73

Retry / resume / archive actions, and the dashboard treatment of unavailable products. Left for a second slice — this one is already the state model plus its plumbing.

Refs #73