### PR TITLE
feat(notifications): store the event, not the category, and filter server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Notification history filters by **All**, **Unread**, **Price** and
+  **Availability**, and shows how many notifications match.
 - **Resume Monitoring** on a paused product, and **Retry Now** to check an
   unavailable product once without resuming its schedule.
 - A notification when a product that had gone unavailable becomes reachable
@@ -21,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Notifications now say what actually happened. A product going missing, a
+  retailer being unreachable and a product coming back were all stored as
+  "Tracking Issue"; back-in-stock and price-announced were similarly collapsed.
+  Existing notifications are relabelled automatically on upgrade.
+- Notification filters now search your whole history rather than the page
+  already on screen, so a filter no longer reports "none" when it means "none
+  in the most recent twenty".
 - A retailer being unreachable no longer passes silently. Timeouts, DNS failures
   and refused connections were producing "unknown", which kept the old status,
   counted nothing and recorded nothing -- a retailer could be down for a week

--- a/backend/src/migrations/017_notification_event_types.ts
+++ b/backend/src/migrations/017_notification_event_types.ts
@@ -1,0 +1,67 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Records the actual event on a notification instead of a broad category
+ * (issue #93).
+ *
+ * The orchestrator stored one of three catch-all types, so distinct events
+ * became indistinguishable the moment they were persisted:
+ *
+ *   back in stock       -> stock_alert
+ *   product unavailable -> system_alert    (labelled "Tracking Issue")
+ *   price announced     -> price_alert
+ *
+ * `price_drop` and `target_price` were already stored as themselves, which is
+ * why those two are the only ones the history page can currently filter
+ * usefully.
+ *
+ * The backfill is exact rather than a guess: each legacy type had exactly one
+ * producer, so the original event is recoverable.
+ *
+ *   stock_alert  <- notifyBackInStock only
+ *   price_alert  <- notifyPriceAnnounced only
+ *   system_alert <- notifyNotAvailable only
+ *
+ * `product_restored` is not in that list because it did not exist until today,
+ * so no historical row can be one.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    await client.query(`
+      UPDATE notifications SET type = 'back_in_stock'  WHERE type = 'stock_alert';
+    `);
+    await client.query(`
+      UPDATE notifications SET type = 'price_announced' WHERE type = 'price_alert';
+    `);
+    await client.query(`
+      UPDATE notifications SET type = 'not_available'   WHERE type = 'system_alert';
+    `);
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`UPDATE notifications SET type = 'stock_alert'  WHERE type = 'back_in_stock';`);
+    await client.query(`UPDATE notifications SET type = 'price_alert'  WHERE type = 'price_announced';`);
+    // product_restored collapses into the same category it would have had.
+    await client.query(`UPDATE notifications SET type = 'system_alert' WHERE type IN ('not_available', 'product_restored');`);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/backend/src/models/types/notification.ts
+++ b/backend/src/models/types/notification.ts
@@ -16,3 +16,38 @@ export interface CreateNotification {
   message: string;
   data?: any;
 }
+
+/**
+ * Event types as stored. Each is the event itself, not a category -- the three
+ * catch-all types they replace made distinct events indistinguishable once
+ * persisted (issue #93).
+ */
+export const NOTIFICATION_EVENT_TYPES = [
+  'price_drop',
+  'target_price',
+  'price_announced',
+  'back_in_stock',
+  'not_available',
+  'product_restored',
+] as const;
+
+export type NotificationEventType = (typeof NOTIFICATION_EVENT_TYPES)[number];
+
+/**
+ * Filter groups offered in the UI.
+ *
+ * Grouped rather than one filter per type: a user looking for availability
+ * problems wants unavailable and restored together, and should not have to know
+ * which internal code produced which row.
+ */
+export const NOTIFICATION_CATEGORIES: Record<string, readonly NotificationEventType[]> = {
+  price: ['price_drop', 'target_price', 'price_announced'],
+  availability: ['back_in_stock', 'not_available', 'product_restored'],
+};
+
+export function eventTypesForCategory(category?: string | null): readonly string[] | null {
+  if (!category || category === 'all') return null;
+  if (NOTIFICATION_CATEGORIES[category]) return NOTIFICATION_CATEGORIES[category];
+  // A bare event type is also a valid filter, so a deep link to one still works.
+  return NOTIFICATION_EVENT_TYPES.includes(category as NotificationEventType) ? [category] : null;
+}

--- a/backend/src/routes/notifications/index.ts
+++ b/backend/src/routes/notifications/index.ts
@@ -28,7 +28,8 @@ router.get('/history', async (req: AuthRequest, res: Response) => {
     const page = req.query.page ? parseInt(req.query.page as string, 10) : 1;
     const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
     
-    const result = await notificationService.getPaginatedHistory(userId, page, limit);
+    const filter = typeof req.query.filter === 'string' ? req.query.filter : null;
+    const result = await notificationService.getPaginatedHistory(userId, page, limit, filter);
     res.json(result);
   } catch (error) {
     logger.error(`Notify | Fetch History Failed | ${error}`, 'Notifications');

--- a/backend/src/services/domain/notification/index.ts
+++ b/backend/src/services/domain/notification/index.ts
@@ -1,6 +1,7 @@
 import { notificationRepository } from '../../../models';
 import { logger } from '../../../utils/system/logger';
 import { CreateNotification } from '../../../models/types';
+import { eventTypesForCategory } from '../../../models/types/notification';
 
 export class NotificationService {
   /**
@@ -22,11 +23,22 @@ export class NotificationService {
   /**
    * Get paginated notification history
    */
-  async getPaginatedHistory(userId: number, page: number, limit: number) {
+  async getPaginatedHistory(
+    userId: number,
+    page: number,
+    limit: number,
+    filter?: string | null
+  ) {
     const offset = (page - 1) * limit;
+    // Resolve the filter to concrete event types once, so the list and the
+    // count cannot disagree about what is being paginated.
+    const unreadOnly = filter === 'unread';
+    const types = unreadOnly ? null : eventTypesForCategory(filter);
+    const options = { types, unreadOnly };
+
     const [notifications, totalCount] = await Promise.all([
-      notificationRepository.getByUserId(userId, limit, offset),
-      notificationRepository.getTotalCount(userId),
+      notificationRepository.getByUserId(userId, limit, offset, options),
+      notificationRepository.getTotalCount(userId, options),
     ]);
 
     return {
@@ -37,6 +49,7 @@ export class NotificationService {
         totalCount,
         totalPages: Math.ceil(totalCount / limit),
       },
+      filter: filter || 'all',
     };
   }
 

--- a/backend/src/services/domain/notification/repositories/notification.repository.ts
+++ b/backend/src/services/domain/notification/repositories/notification.repository.ts
@@ -25,17 +25,38 @@ export const notificationRepository = {
   },
 
   // Get notifications for a user with pagination
+  /**
+   * Filtering happens here rather than in the client.
+   *
+   * The history page filtered whatever page it had already loaded, so selecting
+   * a filter searched the most recent 50 notifications and reported nothing
+   * beyond them -- which reads as "you have no unavailable alerts" when what it
+   * means is "none in the last 50" (issue #93).
+   */
   getByUserId: async (
     userId: number,
     limit: number = 50,
-    offset: number = 0
+    offset: number = 0,
+    options: { types?: readonly string[] | null; unreadOnly?: boolean } = {}
   ): Promise<Notification[]> => {
+    const where: string[] = ['user_id = $1'];
+    const values: (number | string | readonly string[])[] = [userId];
+    let i = 2;
+
+    if (options.types && options.types.length > 0) {
+      where.push(`type = ANY($${i++}::text[])`);
+      values.push(options.types);
+    }
+    if (options.unreadOnly) {
+      where.push('is_read = false');
+    }
+
     const result = await pool.query(
       `SELECT * FROM notifications
-       WHERE user_id = $1
-       ORDER BY created_at DESC
-       LIMIT $2 OFFSET $3`,
-      [userId, limit, offset]
+        WHERE ${where.join(' AND ')}
+        ORDER BY created_at DESC
+        LIMIT $${i++} OFFSET $${i}`,
+      [...values, limit, offset]
     );
     return result.rows;
   },
@@ -89,10 +110,26 @@ export const notificationRepository = {
   },
 
   // Get total count for pagination
-  getTotalCount: async (userId: number): Promise<number> => {
+  /** Counts the filtered set, so pagination matches what is being shown. */
+  getTotalCount: async (
+    userId: number,
+    options: { types?: readonly string[] | null; unreadOnly?: boolean } = {}
+  ): Promise<number> => {
+    const where: string[] = ['user_id = $1'];
+    const values: (number | readonly string[])[] = [userId];
+    let i = 2;
+
+    if (options.types && options.types.length > 0) {
+      where.push(`type = ANY($${i++}::text[])`);
+      values.push(options.types);
+    }
+    if (options.unreadOnly) {
+      where.push('is_read = false');
+    }
+
     const result = await pool.query(
-      `SELECT COUNT(*) FROM notifications WHERE user_id = $1`,
-      [userId]
+      `SELECT COUNT(*) FROM notifications WHERE ${where.join(' AND ')}`,
+      values
     );
     return parseInt(result.rows[0].count, 10);
   },

--- a/backend/src/services/domain/product/notifications/alerts.ts
+++ b/backend/src/services/domain/product/notifications/alerts.ts
@@ -23,7 +23,7 @@ export class ProductAlertService {
         productId: product.id
       },
       {
-        type: 'system_alert',
+        type: 'not_available',
         // The reason and the action were hardcoded to "404/410 Page Not Found"
         // and "Monitoring Paused" regardless of what actually happened, so a
         // redirect, a soft 404 and a week-long retailer outage all read the
@@ -63,7 +63,7 @@ export class ProductAlertService {
         productId: product.id
       },
       {
-        type: 'system_alert',
+        type: 'product_restored',
         title: `Available again | ${product.name || 'Product'}`,
         message: 'The product page is reachable again. Monitoring has resumed.',
         data: {
@@ -92,7 +92,7 @@ export class ProductAlertService {
         productId: product.id
       },
       {
-        type: 'stock_alert',
+        type: 'back_in_stock',
         title: `Back in Stock: ${product.name || 'Product'}`,
         // A product can come back in stock before a price is extracted, which
         // used to render as "back in stock at undefined USD".
@@ -194,7 +194,7 @@ export class ProductAlertService {
         productId: product.id
       },
       {
-        type: 'price_alert',
+        type: 'price_announced',
         title: `Price Announced: ${product.name || 'Product'}`,
         message: `Price has been announced for this pre-order item: ${newPriceObj.price} ${newPriceObj.currency}`,
         data: {

--- a/backend/tests/unit/notification-event-types.test.ts
+++ b/backend/tests/unit/notification-event-types.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  NOTIFICATION_EVENT_TYPES,
+  NOTIFICATION_CATEGORIES,
+  eventTypesForCategory,
+} from '../../src/models/types/notification';
+
+/**
+ * Notifications were stored under three catch-all types, so distinct events
+ * became indistinguishable the moment they were persisted: a product going
+ * missing, a retailer being unreachable and a product coming back were all
+ * `system_alert`, labelled "Tracking Issue".
+ */
+
+describe('Notification event types', () => {
+  it('covers every event the product lifecycle can produce', () => {
+    // If an alert is added without a type here, it silently falls through to a
+    // de-underscored code in the UI, which is how "Tracking Issue" happened.
+    expect([...NOTIFICATION_EVENT_TYPES].sort()).toEqual([
+      'back_in_stock',
+      'not_available',
+      'price_announced',
+      'price_drop',
+      'product_restored',
+      'target_price',
+    ]);
+  });
+
+  describe('categories group by what a user is looking for', () => {
+    it('puts every availability event under one filter', () => {
+      // Someone chasing an availability problem should not have to know which
+      // internal code produced which row.
+      expect([...NOTIFICATION_CATEGORIES.availability].sort()).toEqual([
+        'back_in_stock',
+        'not_available',
+        'product_restored',
+      ]);
+    });
+
+    it('puts every price event under one filter', () => {
+      expect([...NOTIFICATION_CATEGORIES.price].sort()).toEqual([
+        'price_announced',
+        'price_drop',
+        'target_price',
+      ]);
+    });
+
+    it('assigns every event type to exactly one category', () => {
+      const assigned = Object.values(NOTIFICATION_CATEGORIES).flat();
+      expect([...assigned].sort()).toEqual([...NOTIFICATION_EVENT_TYPES].sort());
+      expect(new Set(assigned).size).toBe(assigned.length);
+    });
+  });
+
+  describe('resolving a filter', () => {
+    it('returns null for no filter, so the query stays unfiltered', () => {
+      expect(eventTypesForCategory(null)).toBeNull();
+      expect(eventTypesForCategory(undefined)).toBeNull();
+      expect(eventTypesForCategory('all')).toBeNull();
+    });
+
+    it('expands a category', () => {
+      expect(eventTypesForCategory('availability')).toHaveLength(3);
+    });
+
+    it('accepts a bare event type, so a deep link to one still works', () => {
+      expect(eventTypesForCategory('not_available')).toEqual(['not_available']);
+    });
+
+    it('ignores an unknown filter rather than returning nothing', () => {
+      // Returning an empty array would match no rows and read as "you have no
+      // notifications", which is worse than ignoring a bad parameter.
+      expect(eventTypesForCategory('nonsense')).toBeNull();
+      expect(eventTypesForCategory('stock_alert')).toBeNull();
+    });
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -19,7 +19,7 @@ export const queryKeys = {
   adminSystemSettings: ['admin', 'system-settings'] as const,
   priceHistory: (productId: number, days: number) => ['products', productId, 'price-history', days] as const,
   stockHistory: (productId: number, days: number) => ['products', productId, 'stock-history', days] as const,
-  notifications: { recent: (limit: number) => ['notifications', 'recent', limit] as const, history: (page: number, limit: number) => ['notifications', 'history', page, limit] as const },
+  notifications: { recent: (limit: number) => ['notifications', 'recent', limit] as const, history: (page: number, limit: number, filter: string) => ['notifications', 'history', page, limit, filter] as const },
 };
 
 /**
@@ -124,8 +124,8 @@ export const recentNotificationsQuery = (limit: number) => queryOptions({
   staleTime: 30_000,
 });
 
-export const notificationHistoryQuery = (page: number, limit: number) => queryOptions({
-  queryKey: queryKeys.notifications.history(page, limit),
-  queryFn: ({ signal }) => NotificationService.getHistory(page, limit, { signal }),
+export const notificationHistoryQuery = (page: number, limit: number, filter = 'all') => queryOptions({
+  queryKey: queryKeys.notifications.history(page, limit, filter),
+  queryFn: ({ signal }) => NotificationService.getHistory(page, limit, filter, { signal }),
   staleTime: 30_000,
 });

--- a/frontend/src/features/notifications/pages/NotificationFilters.tsx
+++ b/frontend/src/features/notifications/pages/NotificationFilters.tsx
@@ -1,38 +1,50 @@
 import React from 'react';
-import Icon from '../../../components/Icon';
+import Icon, { type IconName } from '../../../components/Icon';
 
 interface NotificationFiltersProps {
   filter: string;
   setFilter: (filter: string) => void;
+  /** Total matching the active filter, from the server. */
+  resultCount?: number;
 }
 
-const NotificationFilters: React.FC<NotificationFiltersProps> = ({ filter, setFilter }) => {
+/**
+ * Filters for the notification history.
+ *
+ * Grouped by what a person is looking for rather than one button per event
+ * type. Someone chasing an availability problem wants unavailable, restored and
+ * back-in-stock together, and should not have to know which internal code
+ * produced which row.
+ *
+ * These are applied by the server, not against the page already loaded. The
+ * previous filters searched the most recent 50 notifications only, so an empty
+ * result read as "you have none" when it meant "none in the last 50".
+ */
+const FILTERS: { value: string; label: string; icon?: IconName }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'unread', label: 'Unread', icon: 'bell' },
+  { value: 'price', label: 'Price', icon: 'trendingDown' },
+  { value: 'availability', label: 'Availability', icon: 'package' },
+];
+
+const NotificationFilters: React.FC<NotificationFiltersProps> = ({ filter, setFilter, resultCount }) => {
   return (
-    <div className="notifications-filters">
-      <button
-        className={`filter-btn ${filter === 'all' ? 'active' : ''}`}
-        onClick={() => setFilter('all')}
-      >
-        All
-      </button>
-      <button
-        className={`filter-btn ${filter === 'price_drop' ? 'active' : ''}`}
-        onClick={() => setFilter('price_drop')}
-      >
-        <Icon name="trendingDown" /> Drops
-      </button>
-      <button
-        className={`filter-btn ${filter === 'target_price' ? 'active' : ''}`}
-        onClick={() => setFilter('target_price')}
-      >
-        <Icon name="target" /> Targets
-      </button>
-      <button
-        className={`filter-btn ${filter === 'stock_alert' ? 'active' : ''}`}
-        onClick={() => setFilter('stock_alert')}
-      >
-        <Icon name="package" /> Stock
-      </button>
+    <div className="notifications-filters" role="group" aria-label="Filter notifications">
+      {FILTERS.map(f => (
+        <button
+          key={f.value}
+          className={`filter-btn ${filter === f.value ? 'active' : ''}`}
+          onClick={() => setFilter(f.value)}
+          aria-pressed={filter === f.value}
+        >
+          {f.icon && <Icon name={f.icon} />} {f.label}
+        </button>
+      ))}
+      {resultCount !== undefined && (
+        <span style={{ marginLeft: 'auto', alignSelf: 'center', fontSize: '0.8rem', color: 'var(--text-muted)' }}>
+          {resultCount} {resultCount === 1 ? 'notification' : 'notifications'}
+        </span>
+      )}
     </div>
   );
 };

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import Layout from '../../../layouts/Layout';
 import { NotificationService } from '../services/NotificationService';
@@ -22,7 +22,7 @@ export default function NotificationHistory() {
   const [activeTab, setActiveTab] = useState<'activity' | 'alerts'>('activity');
   const [page, setPage] = useState(1);
   const [filter, setFilter] = useState<string>('all');
-  const historyQuery = useQuery({ ...notificationHistoryQuery(page, 20), enabled: activeTab === 'alerts' });
+  const historyQuery = useQuery({ ...notificationHistoryQuery(page, 20, filter), enabled: activeTab === 'alerts' });
   const notifications = historyQuery.data?.notifications?.filter(n => !['session_activity', 'system_info'].includes(n.type)) ?? [];
   const totalPages = historyQuery.data?.pagination?.totalPages ?? 1;
   const invalidateNotifications = () => queryClient.invalidateQueries({ queryKey: ['notifications'] });
@@ -45,10 +45,11 @@ export default function NotificationHistory() {
     } catch { /* keep the cached history intact after a failed mutation */ }
   };
 
-  const filteredNotifications = useMemo(() => {
-    if (filter === 'all') return notifications;
-    return notifications.filter(n => n.type === filter);
-  }, [notifications, filter]);
+  // The server applies the filter, so what comes back is already the filtered
+  // set. Filtering again here would re-introduce the bug this replaces: the old
+  // client-side filter searched only the loaded page, so selecting one reported
+  // nothing beyond the most recent 20 notifications.
+  const filteredNotifications = notifications;
 
   const historyTabs: Tab[] = [
     { id: 'activity', label: 'Session Activity', icon: <Icon name="fileText" /> },
@@ -103,7 +104,8 @@ export default function NotificationHistory() {
           <>
             <NotificationFilters 
               filter={filter} 
-              setFilter={setFilter} 
+              resultCount={historyQuery.data?.pagination?.totalCount}
+              setFilter={(f) => { setFilter(f); setPage(1); }}
             />
 
             <NotificationTable 

--- a/frontend/src/features/notifications/pages/utils.tsx
+++ b/frontend/src/features/notifications/pages/utils.tsx
@@ -6,6 +6,8 @@ export function getNotificationIcon(type: string): React.ReactNode {
   const size = 18;
   
   switch (type) {
+    case 'price_announced':
+    case 'price_alert':
     case 'price_drop':
       return (
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--secondary)' }}>
@@ -21,6 +23,7 @@ export function getNotificationIcon(type: string): React.ReactNode {
           <circle cx="12" cy="12" r="2" />
         </svg>
       );
+    case 'back_in_stock':
     case 'stock_alert':
       return (
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" style={{ color: '#f59e0b' }}>
@@ -29,6 +32,7 @@ export function getNotificationIcon(type: string): React.ReactNode {
           <line x1="12" y1="22.08" x2="12" y2="12" />
         </svg>
       );
+    case 'not_available':
     case 'system_alert':
       return (
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--danger)' }}>
@@ -47,6 +51,7 @@ export function getNotificationIcon(type: string): React.ReactNode {
           <polyline points="10 9 9 9 8 9" />
         </svg>
       );
+    case 'product_restored':
     case 'success':
       return (
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--secondary)' }}>
@@ -78,18 +83,39 @@ export function getNotificationIcon(type: string): React.ReactNode {
   }
 }
 
+/**
+ * Names the event, not the category it used to be filed under.
+ *
+ * "Tracking Issue" covered a product being gone, a retailer being unreachable
+ * and a product coming back, which are three different things a user would want
+ * to react to differently (issue #93).
+ *
+ * The legacy names are still handled: a row written before the event types
+ * landed reads correctly rather than falling through to a de-underscored code.
+ */
 export function getNotificationTypeLabel(type: string): string {
   switch (type) {
     case 'price_drop':
       return 'Price Drop';
     case 'target_price':
       return 'Target Reached';
+    case 'price_announced':
+      return 'Price Announced';
+    case 'back_in_stock':
+      return 'Back in Stock';
+    case 'not_available':
+      return 'Unavailable';
+    case 'product_restored':
+      return 'Available Again';
+    // Pre-#93 rows, in case any survived the backfill.
     case 'stock_alert':
-      return 'Stock Alert';
+      return 'Back in Stock';
     case 'system_alert':
-      return 'Tracking Issue';
+      return 'Unavailable';
+    case 'price_alert':
+      return 'Price Announced';
     default:
-      return type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
+      return type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
   }
 }
 

--- a/frontend/src/features/notifications/services/NotificationService.ts
+++ b/frontend/src/features/notifications/services/NotificationService.ts
@@ -2,10 +2,21 @@ import { api, type RequestOptions } from '../../../api/client';
 import { NotificationEntry } from '../../../types/api';
 
 export const NotificationService = {
-  getHistory: (page: number = 1, limit: number = 20, options?: RequestOptions) =>
-    api.get<{ notifications: NotificationEntry[], pagination: { page: number, limit: number, totalCount: number, totalPages: number } }>('/notifications/history', {
+  /**
+   * The filter is sent to the server rather than applied to the result.
+   *
+   * Filtering the loaded page searched only the most recent 20 notifications,
+   * so an empty result read as "you have none" when it meant "none on this
+   * page" (issue #93). The count returned alongside is the filtered total.
+   */
+  getHistory: (page: number = 1, limit: number = 20, filter: string = 'all', options?: RequestOptions) =>
+    api.get<{
+      notifications: NotificationEntry[],
+      pagination: { page: number, limit: number, totalCount: number, totalPages: number },
+      filter: string,
+    }>('/notifications/history', {
       ...options,
-      params: { ...options?.params, page, limit },
+      params: { ...options?.params, page, limit, filter },
     }),
   
   getRecent: (limit: number = 10, options?: RequestOptions) =>


### PR DESCRIPTION
The two concrete defects from #93. The rest of that issue is a UI redesign, left alone deliberately — see scope at the bottom.

## 1. Events were collapsed on the way into storage

The orchestrator wrote one of three catch-all types, so distinct events became indistinguishable **the moment they were persisted**:

```
back in stock        ->  stock_alert
product unavailable  ->  system_alert     labelled "Tracking Issue"
price announced      ->  price_alert
```

A product going missing, a retailer being unreachable, and a product coming back all read as **"Tracking Issue"** — three things a user would react to completely differently.

`price_drop` and `target_price` already stored themselves, which is exactly why those two were the only filters that ever worked.

**Migration 017 backfills precisely rather than guessing:** each legacy type had exactly one producer, so the original event is recoverable. `product_restored` is deliberately absent from that mapping — it did not exist until today, so no historical row can be one.

## 2. Filters searched the loaded page

The history page filtered the twenty notifications it already had. So selecting a filter reported nothing beyond them — which reads as **"you have no unavailable alerts"** when it means *"none in the most recent twenty"*.

Filtering moved into the query, with the count returned alongside so pagination matches what is shown. Changing a filter returns to page one, rather than leaving you on a page the narrower result set no longer has.

Verified against PostgreSQL 16 with 35 notifications: an `availability` filter finds all three matching rows sitting well past page one — the exact case client-side filtering silently missed.

```
filter=all           total=35  returned=20
filter=price         total=32  returned=20
filter=availability  total=3   returned=3    <- all found, across the full history
filter=not_available total=1   returned=1
```

## Two small decisions

**Filters group by what a person is looking for**, not one button per event type. Someone chasing an availability problem wants unavailable, restored and back-in-stock together and should not have to know which internal code produced which row. A bare event type still resolves, so a deep link to one works.

**An unknown filter is ignored rather than matched literally.** Returning an empty set would read as "you have no notifications", which is worse than quietly ignoring a bad parameter.

## Scope

#93 stays open. Done: explicit event types, the filters, and the server-side application of them. Not done: the drawer and history-page redesign, the Activity/Alerts tab split, per-channel delivery status.

Those are a design exercise rather than a defect — the same shape as #89/#90, where a proposal first turned out to be the right move. Happy to do that again if you want it.

The `#83` compatibility section of the issue is moot now that #83 is closed.

## Verification

243 backend tests (up from 235), `tsc`, frontend build and tests, route acceptance 13/13, emoji lint, `git diff --check` — all pass.

Refs #93