### PR TITLE
fix(notifications,search): event-aware emails, and rank search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Email alerts now describe the event that happened. Every email used the same
+  price-shaped default, so a back-in-stock alert arrived as a bare price line
+  saying nothing about stock, and an unavailable alert reported a price for a
+  product that could not be reached. A template you have configured yourself is
+  still used exactly as written.
+- Product search results are ordered by how likely each is to be a trackable
+  product page, so retailer listings come before videos, forum threads and
+  buying guides. Nothing is removed from the results.
 - Notifications now say what actually happened. A product going missing, a
   retailer being unreachable and a product coming back were all stored as
   "Tracking Issue"; back-in-stock and price-announced were similarly collapsed.

--- a/backend/src/services/domain/product/SearchService.ts
+++ b/backend/src/services/domain/product/SearchService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { settingsCache } from '../../../utils/cache';
 import { RetailerQueryService } from '../retailer/RetailerQueryService';
 import { logger } from '../../../utils/system/logger';
+import { rankSearchResults } from './utils/search-ranking';
 
 export interface SearchResult {
   title: string;
@@ -65,7 +66,9 @@ export class SearchService {
         }
       }
 
-      return processedResults;
+      // Reordered, not filtered: a retailer whose URLs do not match any
+      // heuristic still appears, just lower down (issue #94).
+      return rankSearchResults(processedResults);
     } catch (error: any) {
       logger.error('SearchService | SearXNG query failed', 'Product', error);
       

--- a/backend/src/services/domain/product/utils/search-ranking.ts
+++ b/backend/src/services/domain/product/utils/search-ranking.ts
@@ -1,0 +1,95 @@
+/**
+ * Ranks search results by how likely each is to be a trackable product page
+ * (issue #94).
+ *
+ * Deliberately **reorders rather than filters**. Two reasons:
+ *
+ * 1. The issue warns against assuming every retailer uses the same URL pattern,
+ *    and it is right -- any rule confident enough to exclude on would also
+ *    exclude working results from retailers that do not follow it.
+ * 2. Filtering can return nothing. A search that finds no results reads as "we
+ *    could not find that product" when it may mean "our heuristic was wrong",
+ *    and the user has no way to tell which.
+ *
+ * Switching SearXNG to `categories=shopping` was the other option considered. It
+ * is rejected here because which engines back that category depends entirely on
+ * the operator's own SearXNG configuration -- on an instance with none enabled
+ * it returns nothing at all, which is a worse failure than poor ordering.
+ */
+
+/** Hosts that are never a product page worth tracking. */
+const NON_PRODUCT_HOSTS = [
+  'youtube.com', 'youtu.be', 'vimeo.com',
+  'reddit.com', 'quora.com', 'stackexchange.com', 'stackoverflow.com',
+  'wikipedia.org', 'fandom.com',
+  'facebook.com', 'twitter.com', 'x.com', 'instagram.com', 'tiktok.com',
+  'pinterest.com', 'linkedin.com',
+];
+
+/** Path segments that indicate a listing or article rather than one product. */
+const NON_PRODUCT_SEGMENTS = [
+  '/blog/', '/news/', '/article/', '/articles/', '/review/', '/reviews/',
+  '/forum/', '/community/', '/support/', '/help/', '/guide/', '/guides/',
+  '/compare/', '/vs/', '/best-', '/how-to',
+];
+
+/** A price-looking string in the snippet is decent evidence of a product page. */
+const PRICE_PATTERN = /(?:[$£€¥]\s?\d|(?:\d[\d.,]*)\s?(?:USD|EUR|GBP|AUD|CHF|CAD|NZD)\b)/i;
+
+export interface RankableResult {
+  title: string;
+  url: string;
+  content: string;
+  domain: string;
+  isSupported: boolean;
+}
+
+/**
+ * Higher is more likely to be a product page. Scores are relative, not absolute
+ * -- only the ordering they produce is meaningful.
+ */
+export function scoreResult(result: RankableResult): number {
+  let score = 0;
+
+  // The strongest signal available, and the one that does not assume a URL
+  // shape: this domain already has a retailer configuration, so the scraper is
+  // known to work on it.
+  if (result.isSupported) score += 10;
+
+  let path = '';
+  try {
+    path = new URL(result.url).pathname.toLowerCase();
+  } catch {
+    return score - 5;
+  }
+
+  const host = result.domain.toLowerCase();
+  if (NON_PRODUCT_HOSTS.some(h => host === h || host.endsWith(`.${h}`))) score -= 8;
+  if (NON_PRODUCT_SEGMENTS.some(seg => path.includes(seg))) score -= 4;
+
+  // A price in the snippet suggests the page is selling something.
+  if (PRICE_PATTERN.test(result.content) || PRICE_PATTERN.test(result.title)) score += 3;
+
+  // A product page usually sits deeper than a category page. Weak on purpose,
+  // and capped, because plenty of retailers put products at the root.
+  const depth = path.split('/').filter(Boolean).length;
+  score += Math.min(depth, 3) * 0.5;
+
+  // A bare domain is a home page, not a product.
+  if (depth === 0) score -= 3;
+
+  return score;
+}
+
+/**
+ * Sorts by score, preserving the engine's own order within equal scores.
+ *
+ * The stability matters: where the heuristic has nothing to say, the search
+ * engine's relevance ranking is better than anything invented here.
+ */
+export function rankSearchResults<T extends RankableResult>(results: T[]): T[] {
+  return results
+    .map((result, index) => ({ result, index, score: scoreResult(result) }))
+    .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+    .map(entry => entry.result);
+}

--- a/backend/src/services/notifications/providers/email.ts
+++ b/backend/src/services/notifications/providers/email.ts
@@ -1,7 +1,7 @@
 import nodemailer from 'nodemailer';
 import { NotificationProvider, NotificationPayload } from '../types';
 import { logger } from '../../../utils/system/logger';
-import { interpolateTemplate } from '../utils';
+import { interpolateTemplate, defaultEmailTemplate } from '../utils';
 
 export class EmailProvider implements NotificationProvider {
   constructor(
@@ -9,14 +9,19 @@ export class EmailProvider implements NotificationProvider {
     private smtpPort: number,
     private from: string,
     private to: string,
-    private subjectTemplate: string,
-    private bodyTemplate: string
+    private subjectTemplate: string | null | undefined,
+    private bodyTemplate: string | null | undefined
   ) {}
 
   async send(payload: NotificationPayload): Promise<boolean> {
     try {
-      const subject = interpolateTemplate(this.subjectTemplate, payload);
-      const body = interpolateTemplate(this.bodyTemplate, payload);
+      // A configured template wins, whatever the event -- it is the user's
+      // choice, and the variables to make one event-aware now exist. Only the
+      // fallback is chosen per event, because a single default cannot describe
+      // a price drop and a product going missing at the same time.
+      const defaults = defaultEmailTemplate(payload.type);
+      const subject = interpolateTemplate(this.subjectTemplate || defaults.subject, payload);
+      const body = interpolateTemplate(this.bodyTemplate || defaults.body, payload);
 
       const transporter = nodemailer.createTransport({
         host: this.smtpHost,

--- a/backend/src/services/notifications/registry.ts
+++ b/backend/src/services/notifications/registry.ts
@@ -48,8 +48,11 @@ export const PROVIDER_REGISTRY: Record<string, ProviderInitializer> = {
       s.smtp_port,
       s.email_from,
       s.email_to,
-      s.email_subject_template || 'PriceStalker Alert: {{product_name}}',
-      s.email_body_template || 'Product: {{product_name}}\nPrice: {{current_price}}'
+      // Passed through unset so the provider can choose a default that matches
+      // the event. Substituting a generic one here is what made every email
+      // look like a price alert.
+      s.email_subject_template,
+      s.email_body_template
     );
   }
 };

--- a/backend/src/services/notifications/utils.ts
+++ b/backend/src/services/notifications/utils.ts
@@ -158,3 +158,56 @@ export function getNotificationContent(payload: NotificationPayload, template?: 
 
   return { title, message };
 }
+
+/**
+ * Default email wording per event, used only when the user has not configured
+ * their own template.
+ *
+ * The single default was `Product: {{product_name}} / Price: {{current_price}}`
+ * for every event, so a back-in-stock alert arrived as a bare price line saying
+ * nothing about stock, and an unavailable alert reported a price for a product
+ * that could not be reached (issue #92).
+ *
+ * A user's own template is never overridden -- it is their choice, and the
+ * variables to make one event-aware (`{{type}}`, `{{new_stock_status}}`) now
+ * exist for exactly that.
+ */
+export function defaultEmailTemplate(type: NotificationPayload['type']): { subject: string; body: string } {
+  switch (type) {
+    case 'price_drop':
+      return {
+        subject: 'Price drop: {{product_name}}',
+        body: '{{product_name}} dropped from {{old_price}} to {{current_price}} {{currency}}.\n\n{{product_url}}',
+      };
+    case 'target_price':
+      return {
+        subject: 'Target price reached: {{product_name}}',
+        body: '{{product_name}} is now {{current_price}} {{currency}}, at or below your target.\n\n{{product_url}}',
+      };
+    case 'price_announced':
+      return {
+        subject: 'Price announced: {{product_name}}',
+        body: '{{product_name}} now has a price: {{current_price}} {{currency}}.\n\n{{product_url}}',
+      };
+    case 'back_in_stock':
+      return {
+        subject: 'Back in stock: {{product_name}}',
+        body: '{{product_name}} is available again.\n\nCurrent price: {{current_price}} {{currency}}\n\n{{product_url}}',
+      };
+    case 'not_available':
+      return {
+        subject: 'Unavailable: {{product_name}}',
+        body: '{{product_name}} could not be reached.\n\n{{product_url}}',
+      };
+    case 'product_restored':
+      return {
+        subject: 'Available again: {{product_name}}',
+        body: '{{product_name}} is reachable again and monitoring has resumed.\n\n{{product_url}}',
+      };
+    default:
+      return {
+        subject: 'PriceStalker alert: {{product_name}}',
+        body: '{{product_name}}\n\n{{product_url}}',
+      };
+  }
+}

--- a/backend/tests/unit/search-ranking.test.ts
+++ b/backend/tests/unit/search-ranking.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { rankSearchResults, scoreResult, type RankableResult } from '../../src/services/domain/product/utils/search-ranking';
+
+const result = (over: Partial<RankableResult>): RankableResult => ({
+  title: 'Widget',
+  url: 'https://shop.example.com/p/widget',
+  content: '',
+  domain: 'shop.example.com',
+  isSupported: false,
+  ...over,
+});
+
+describe('Search result ranking', () => {
+  describe('it reorders, it never removes', () => {
+    it('keeps every result', () => {
+      // The issue warns against assuming a URL pattern. Anything confident
+      // enough to exclude on would also exclude working retailers that do not
+      // follow it, and an empty result reads as "no such product" rather than
+      // "our heuristic was wrong".
+      const input = [
+        result({ url: 'https://youtube.com/watch?v=1', domain: 'youtube.com' }),
+        result({ url: 'https://shop.example.com/p/widget', isSupported: true }),
+        result({ url: 'https://blog.example.com/blog/widget-review', domain: 'blog.example.com' }),
+      ];
+      expect(rankSearchResults(input)).toHaveLength(3);
+    });
+
+    it('still returns an unusual retailer, just lower down', () => {
+      const odd = result({ url: 'https://tiny-shop.example', domain: 'tiny-shop.example' });
+      const ranked = rankSearchResults([
+        result({ url: 'https://shop.example.com/p/widget', isSupported: true }),
+        odd,
+      ]);
+      expect(ranked).toContain(odd);
+    });
+  });
+
+  describe('ordering', () => {
+    it('puts a configured retailer first', () => {
+      // The strongest signal that does not assume a URL shape: the scraper is
+      // already known to work on this domain.
+      const ranked = rankSearchResults([
+        result({ url: 'https://unknown.example/p/widget', domain: 'unknown.example' }),
+        result({ url: 'https://known.example/p/widget', domain: 'known.example', isSupported: true }),
+      ]);
+      expect(ranked[0].domain).toBe('known.example');
+    });
+
+    it('demotes video, forum and encyclopedia hosts', () => {
+      const ranked = rankSearchResults([
+        result({ url: 'https://www.youtube.com/watch?v=abc', domain: 'youtube.com' }),
+        result({ url: 'https://old.reddit.com/r/deals/x', domain: 'reddit.com' }),
+        result({ url: 'https://shop.example.com/p/widget' }),
+      ]);
+      expect(ranked[0].domain).toBe('shop.example.com');
+    });
+
+    it('demotes articles and buying guides', () => {
+      const ranked = rankSearchResults([
+        result({ url: 'https://shop.example.com/blog/best-widgets-2026' }),
+        result({ url: 'https://shop.example.com/p/widget' }),
+      ]);
+      expect(ranked[0].url).toContain('/p/widget');
+    });
+
+    it('promotes a result whose snippet contains a price', () => {
+      const ranked = rankSearchResults([
+        result({ url: 'https://shop.example.com/a', content: 'Everything about widgets' }),
+        result({ url: 'https://shop.example.com/b', content: 'Buy now for $49.99' }),
+      ]);
+      expect(ranked[0].url).toContain('/b');
+    });
+
+    it('demotes a bare home page', () => {
+      const ranked = rankSearchResults([
+        result({ url: 'https://shop.example.com/', domain: 'shop.example.com' }),
+        result({ url: 'https://shop.example.com/p/widget' }),
+      ]);
+      expect(ranked[0].url).toContain('/p/widget');
+    });
+  });
+
+  describe('where the heuristic has nothing to say', () => {
+    it('preserves the search engine order', () => {
+      // The engine's own relevance ranking beats anything invented here, so
+      // equal scores must not be reshuffled.
+      const input = [
+        result({ url: 'https://shop.example.com/p/one', title: 'one' }),
+        result({ url: 'https://shop.example.com/p/two', title: 'two' }),
+        result({ url: 'https://shop.example.com/p/three', title: 'three' }),
+      ];
+      expect(rankSearchResults(input).map(r => r.title)).toEqual(['one', 'two', 'three']);
+    });
+  });
+
+  it('does not throw on a malformed URL', () => {
+    expect(() => scoreResult(result({ url: 'not a url' }))).not.toThrow();
+    expect(rankSearchResults([result({ url: 'not a url' })])).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
The two remaining issues that needed no decision from you, only work.

## Email was event-blind (#92)

Every alert fell back to one template:

```
Product: {{product_name}}
Price: {{current_price}}
```

So a **back-in-stock** alert arrived as a bare price line saying nothing about stock, and an **unavailable** alert reported a price for a product that could not be reached.

The fallback is now chosen per event. A template **you** have configured is still used exactly as written, whatever the event — that distinction matters: it is your choice, and the variables to make one event-aware (`{{type}}`, `{{new_stock_status}}`) exist for precisely that. Only the *default* had to stop pretending every notification was about a price.

The registry was substituting a generic default before the provider ever saw the payload, which is what made an event-aware fallback impossible in the first place.

Rendered check across every event:

```
price_drop        Price drop: Widget          / dropped from 49.99 to 39.99 AUD
back_in_stock     Back in stock: Widget       / is available again
not_available     Unavailable: Widget         / could not be reached
product_restored  Available again: Widget     / reachable again, monitoring resumed
```

## Search results are ranked, not filtered (#94)

Ordered by how likely each is to be a trackable product page: a domain with an existing retailer config ranks highest, a price in the snippet helps, and videos, forums, encyclopedias, blogs and buying guides are demoted.

**Nothing is removed.** Two reasons, both in the issue:

1. It warns against assuming every retailer uses the same URL pattern — and any rule confident enough to *exclude* on would also exclude working results from retailers that do not follow it.
2. Filtering can return nothing, which reads as *"no such product"* rather than *"the heuristic was wrong"*, and the user cannot tell which.

Equal scores keep the search engine's own order, since its relevance ranking beats anything invented here.

### Why not `categories=shopping`

I raised this on the issue as the cheap first thing to try, and I am not shipping it. Which engines back that category depends entirely on the operator's own SearXNG configuration — on an instance with none enabled it returns **nothing at all**, which is a worse failure than poor ordering.

Still worth testing on your own instance, just not as a shipped default. If it works well there, it could become an opt-in setting.

## Scope

Both issues stay open for their remaining parts:
- **#92** — per-provider consistency across Telegram, Pushover, Gotify, Discord and webhooks, and the notification-history reason.
- **#94** — nothing outstanding beyond confirming the ranking helps in practice; close it if you are happy.

## Verification

252 backend tests (up from 243), `tsc`, frontend build, emoji lint, `git diff --check` — all pass.

Refs #92
Refs #94