### PR TITLE
release: v2.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0-beta.2] - 2026-08-31
+
 ### Added
 
 - Notification history filters by **All**, **Unread**, **Price** and

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricestalker-backend",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "PriceStalker price tracking API",
   "main": "dist/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pricestalker-frontend",
   "private": true,
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "type": "module",
   "engines": {
     "node": ">=24.18.0 <25",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.12.0"
   },
-  "version": "2.1.0-beta.1"
+  "version": "2.1.0-beta.2"
 }


### PR DESCRIPTION
Four merges since beta.1.

- **#73** unavailable-product lifecycle — now closed. Reasons stored, transient failures separated from definitive ones, auto-pause distinguished from user-pause, retry/resume actions, notify on return.
- **#93** notification event types and server-side filtering.
- **#92** event-aware email defaults.
- **#94** search result ranking.

## Migrations

Two, both safe to roll an image back over:

| | |
|---|---|
| **016** | Adds four nullable/defaulted columns to `products`; backfills `auto_paused` only where a product is already both paused *and* unavailable, since that combination can only have been the system's doing. |
| **017** | Relabels notification rows from three catch-all types to the event each one actually was. Each legacy type had exactly one producer, so the mapping is exact rather than a guess. |

Both tested against PostgreSQL 16, applied and re-applied.

Prerelease — does not advance `stable` or `latest`.