### PR TITLE
fix(scheduler): honour the check frequency the user chose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Changing a product's check frequency now takes effect immediately. The new
+  interval was saved but the next check was not rescheduled, so shortening
+  24 hours to 6 left the product quiet for up to another 24 hours while the
+  card counted down to the old time.
+- A product's countdown no longer runs far past the interval you chose. Three
+  independent timing randomisers compounded, so a product set to check every
+  6 hours could be scheduled more than 20 hours out. The randomness is kept --
+  it is what stops requests forming a detectable rhythm -- but the total is now
+  capped at 1.5x your setting.
+
 ## [2.1.0-beta.2] - 2026-08-31
 
 ### Added

--- a/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
@@ -65,6 +65,23 @@ export const productLifecycleRepository = {
       }
     }
 
+    // Changing the frequency has to move the next check with it (issue #138).
+    // refresh_interval is written here, but next_check_at is only ever set by
+    // updateLastChecked after a scrape -- so a user shortening 24h to 6h waited
+    // up to a further 24 hours, watching a countdown to the old target.
+    //
+    // Anchored on last_checked rather than now, so time already elapsed counts
+    // toward the new interval and an already-overdue product is picked up on the
+    // next tick. GREATEST clamps a resulting past timestamp to now.
+    //
+    // Deliberately not calculateNextCheckSeconds(): its randomisers are for
+    // spreading scheduled load, and applying them here would show a user a
+    // countdown that disagrees with the interval they just picked.
+    if ((updates as any).refresh_interval !== undefined) {
+      fields.push(`next_check_at = GREATEST(CURRENT_TIMESTAMP, COALESCE(last_checked, CURRENT_TIMESTAMP) + ($${paramIndex++} || ' seconds')::interval)`);
+      values.push(String((updates as any).refresh_interval));
+    }
+
     // checking_paused and auto_paused are a pair: a pause set through this
     // update is a user's decision, so the automatic flag must clear with it.
     // Leaving it set would produce auto_paused = true with checking_paused =

--- a/backend/src/utils/system/scheduler-helpers.ts
+++ b/backend/src/utils/system/scheduler-helpers.ts
@@ -17,6 +17,22 @@ export function isQuietHours(): boolean {
 }
 
 /**
+ * How far past the configured interval a check may ever be pushed.
+ *
+ * The three randomisers below compound: ±15% jitter, ×1.5 during quiet hours,
+ * and a 10% chance to double. Stacked, a product set to check every 6 hours
+ * could be scheduled 20.7 hours out -- and the dashboard renders a live
+ * countdown straight from next_check_at, so it reads as "this is not being
+ * checked", which is exactly how this was reported.
+ *
+ * The cap keeps the user's setting meaningful without removing the
+ * unpredictability, which is what actually defeats rhythm detection: a request
+ * arriving at an unpredictable point within a bounded window is just as
+ * irregular as one that might arrive three times later.
+ */
+const MAX_INTERVAL_MULTIPLIER = 1.5;
+
+/**
  * Calculates the next check time for a product with jitter and quiet hours adjustment.
  */
 export function calculateNextCheckSeconds(refreshInterval: number): number {
@@ -33,6 +49,10 @@ export function calculateNextCheckSeconds(refreshInterval: number): number {
   if (Math.random() < 0.1) {
     nextCheckSeconds *= 2;
   }
+
+  // Bound the total. Without this the three randomisers compound into a delay
+  // several times the interval the user chose.
+  nextCheckSeconds = Math.min(nextCheckSeconds, Math.floor(refreshInterval * MAX_INTERVAL_MULTIPLIER));
 
   // Ensure we don't schedule something in the past or too soon
   return Math.max(60, nextCheckSeconds);

--- a/backend/tests/unit/scheduler-interval.test.ts
+++ b/backend/tests/unit/scheduler-interval.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { calculateNextCheckSeconds, getSmartJitter, isQuietHours } from '../../src/utils/system/scheduler-helpers';
+
+/**
+ * The scheduler applies three independent randomisers to every interval:
+ * ±15% jitter, ×1.5 during quiet hours, and a 10% chance to double. Each is
+ * defensible alone; stacked they produced a delay several times the interval a
+ * user had chosen, and the dashboard renders a live countdown straight from
+ * next_check_at -- so it reads as "this product is not being checked".
+ */
+
+const SIX_HOURS = 21600;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('calculateNextCheckSeconds', () => {
+  it('never exceeds 1.5x the configured interval, however the dice fall', () => {
+    // Force the worst case: maximum jitter, quiet hours, and the oversleep.
+    vi.spyOn(Math, 'random').mockReturnValue(0.0001);
+    vi.spyOn(Date.prototype, 'getHours').mockReturnValue(3);
+
+    // Unbounded this was 6h x 1.15 x 1.5 x 2 = 20.7 hours on a 6-hour setting.
+    expect(calculateNextCheckSeconds(SIX_HOURS)).toBeLessThanOrEqual(SIX_HOURS * 1.5);
+  });
+
+  it('holds the bound across the whole random range', () => {
+    vi.spyOn(Date.prototype, 'getHours').mockReturnValue(3);
+    for (let i = 0; i < 500; i++) {
+      const next = calculateNextCheckSeconds(SIX_HOURS);
+      expect(next).toBeLessThanOrEqual(SIX_HOURS * 1.5);
+      expect(next).toBeGreaterThanOrEqual(60);
+    }
+  });
+
+  it('holds the bound for every interval the UI offers', () => {
+    // 1h, 6h, 12h, 24h, 48h
+    for (const interval of [3600, 21600, 43200, 86400, 172800]) {
+      for (let i = 0; i < 100; i++) {
+        expect(calculateNextCheckSeconds(interval)).toBeLessThanOrEqual(interval * 1.5);
+      }
+    }
+  });
+
+  it('still varies, so the bound has not flattened the jitter', () => {
+    // Bounding must not turn every product into the same fixed cadence, which
+    // is the rhythm the randomisers exist to break.
+    vi.spyOn(Date.prototype, 'getHours').mockReturnValue(12);
+    const seen = new Set(Array.from({ length: 200 }, () => calculateNextCheckSeconds(SIX_HOURS)));
+    expect(seen.size).toBeGreaterThan(20);
+  });
+
+  it('never schedules sooner than a minute', () => {
+    expect(calculateNextCheckSeconds(1)).toBeGreaterThanOrEqual(60);
+    expect(calculateNextCheckSeconds(0)).toBeGreaterThanOrEqual(60);
+  });
+
+  it('stays close to the interval in the ordinary case', () => {
+    // No oversleep, not quiet hours: the result should be recognisably the
+    // interval the user picked.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    vi.spyOn(Date.prototype, 'getHours').mockReturnValue(12);
+    const next = calculateNextCheckSeconds(SIX_HOURS);
+    expect(next).toBeGreaterThan(SIX_HOURS * 0.8);
+    expect(next).toBeLessThan(SIX_HOURS * 1.2);
+  });
+});
+
+describe('the pieces it is built from', () => {
+  it('keeps jitter within ±15%', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(Math.abs(getSmartJitter(SIX_HOURS))).toBeLessThanOrEqual(SIX_HOURS * 0.15);
+    }
+  });
+
+  it('treats 1am to 6am as quiet', () => {
+    for (const [hour, quiet] of [[0, false], [1, true], [3, true], [6, true], [7, false], [23, false]] as const) {
+      vi.spyOn(Date.prototype, 'getHours').mockReturnValue(hour);
+      expect(isQuietHours()).toBe(quiet);
+      vi.restoreAllMocks();
+    }
+  });
+});


### PR DESCRIPTION
From the report that a product set to check every 6 hours was not being checked.

**It was being checked** — roughly every six hours, successfully, all day. Two separate things made it look otherwise, and one is a real bug.

## 1. Changing the frequency did not reschedule (#138)

`refresh_interval` is written by `productLifecycleRepository.update`, but `next_check_at` is only ever set by `updateLastChecked` **after a scrape**. So shortening 24h to 6h left the product quiet for up to another 24 hours, with the dashboard counting down to the old target.

Production shows it plainly: two products at `refresh_interval=86400` with scheduled gaps of ~6h — which only fit the *previous* 21600 value.

The reschedule anchors on `last_checked` rather than now, so elapsed time counts toward the new interval and an already-overdue product is picked up on the next tick. It deliberately does **not** use `calculateNextCheckSeconds` — those randomisers exist to spread scheduled load, and applying them here would show a countdown that disagrees with the interval just selected.

## 2. The countdown could run far past the configured interval

Three randomisers compound:

```
±15% jitter  ×  1.5 quiet hours  ×  2 (10% oversleep)
```

Each is defensible alone. Together they put a **6-hour product up to 20.7 hours out**. One product in production was scheduled **13h 22m** ahead on a 6-hour setting — which is what prompted the report.

Now capped at **1.5× the configured interval**. The unpredictability is what defeats rhythm detection, not the magnitude: a request arriving at an unpredictable point inside a bounded window is just as irregular as one that might arrive three times later. A test asserts the spread survives the cap, so this has not quietly flattened every product onto one cadence.

## Not a bug, worth knowing

`price_history` only records **changes**. Several of these products last changed price weeks ago (one on 4 August), so the chart looks frozen while checks run every six hours. That is correct behaviour, but it compounds the impression that nothing is happening.

## Verification

Against PostgreSQL 16:

| case | result |
|---|---|
| shorten 24h → 6h, last checked 1h ago | next check in 18000s — 21600 from last check, elapsed time counted |
| shorten while already 10h overdue | due immediately |
| never checked ( NULL) | schedules 21600s from now |
| unrelated update (rename) | schedule untouched |

260 backend tests (up from 252), `tsc`, emoji lint, `git diff --check` — all pass.

Closes #138