### PR TITLE
fix(notifications): describe the event that happened, on every channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Notifications now describe the event that actually happened on every channel.
+  A product becoming reachable again was announced as "Back in Stock!" on
+  Discord, Pushover, Gotify and ntfy, and was never delivered to Telegram at
+  all -- the message came out empty and the API rejected it. Every channel now
+  renders from one shared description, so all six event types are covered
+  everywhere.
+- An "unavailable" alert says why the product could not be read, and no longer
+  claims monitoring has been paused when it has not. Every channel reported
+  "Page no longer exists (404/410). Monitoring has been paused" regardless of
+  the real cause, including on the retry path that deliberately keeps checking.
+- Telegram alerts arrive for products whose names contain `&`, `<` or `>`.
+  These were sent in HTML mode without escaping and were rejected outright.
+- Prices in notifications no longer render an unresolved currency as dollars,
+  and a price of zero is shown as a price rather than treated as missing.
+- The email templates in Notification Channels are no longer prefilled with a
+  price-drop sentence. Saving that page without editing them stored
+  "{{product_name}} has dropped to {{current_price}}!" for every event; the
+  prefilled text is now a placeholder, and a template that was stored without
+  being chosen is cleared on upgrade. Templates you wrote are untouched.
+- A product moving from members-only to in stock now sends a back-in-stock
+  alert.
+- Notification history records every alert, whether or not a channel delivered
+  it. Previously nothing was recorded unless an external channel succeeded, so
+  an install with no channels configured had no history at all, and a total
+  delivery failure erased the one record that would have explained the silence.
+  Channels that failed are now shown struck through beside those that worked.
+- Concurrent refreshes of the same product can no longer send two back-in-stock
+  alerts for one event.
+
+### Added
+
+- `{{price}}` (amount with its currency) and `{{reason}}` template variables
+  for notification templates.
+- Webhook payloads carry the stock transition, target price, product id and
+  failure reason, and report an unresolved currency as `null` instead of `USD`.
+
+### Fixed
+
 - Changing a product's check frequency now takes effect immediately. The new
   interval was saved but the next check was not rescheduled, so shortening
   24 hours to 6 left the product quiet for up to another 24 hours while the

--- a/backend/src/migrations/018_clear_prefilled_email_template.ts
+++ b/backend/src/migrations/018_clear_prefilled_email_template.ts
@@ -1,0 +1,75 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Clears the email template nobody chose (issue #92).
+ *
+ * The settings form prefilled both email template fields with a price-drop
+ * sentence:
+ *
+ *   Subject: PriceStalker Alert: {{product_name}}
+ *   Body:    Hi,
+ *
+ *            {{product_name}} has dropped to {{current_price}}!
+ *
+ *            View it here: {{product_url}}
+ *
+ * A user who opened Notification Channels to set up any *other* channel and
+ * pressed Save stored that template without ever intending to write one. A
+ * configured template wins over the per-event defaults -- correctly, it is the
+ * user's choice -- so from then on every alert claimed a price drop, including
+ * a product coming back in stock and a product going missing.
+ *
+ * Only the exact prefilled string is cleared. Anything the user typed, edited,
+ * or even changed the whitespace of is theirs and is left alone. Cleared to
+ * NULL, the backend picks wording that matches each event.
+ *
+ * Idempotent: re-running matches nothing, because the rows it would match have
+ * already been set to NULL.
+ */
+
+const PREFILLED_SUBJECT = 'PriceStalker Alert: {{product_name}}';
+const PREFILLED_BODY = 'Hi,\n\n{{product_name}} has dropped to {{current_price}}!\n\nView it here: {{product_url}}';
+
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    // The two fields are cleared independently: a user may well have rewritten
+    // the body while leaving the prefilled subject in place.
+    const subject = await client.query(
+      `UPDATE users SET email_subject_template = NULL WHERE email_subject_template = $1`,
+      [PREFILLED_SUBJECT]
+    );
+    const body = await client.query(
+      `UPDATE users SET email_body_template = NULL WHERE email_body_template = $1`,
+      [PREFILLED_BODY]
+    );
+
+    if (subject.rowCount || body.rowCount) {
+      console.log(
+        `[018] Cleared prefilled email templates: ${subject.rowCount} subject, ${body.rowCount} body. ` +
+        `These users now get wording that matches each event.`
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+/**
+ * Intentionally does nothing.
+ *
+ * Restoring the template would mean writing it back for users who never chose
+ * it, and there is no record of which NULLs were cleared by this migration
+ * versus which were already NULL. Reversing it would put the wrong wording back
+ * on more accounts than it took it off.
+ */
+export const down = async () => {
+  // No-op. See above.
+};

--- a/backend/src/services/domain/product/ProductPersistenceService.ts
+++ b/backend/src/services/domain/product/ProductPersistenceService.ts
@@ -10,11 +10,25 @@ import pool from '../../../config/database';
 import { PoolClient } from 'pg';
 import { configCache, regionalMappingCache } from '../../../utils/cache';
 import { Product } from '../../../models/types';
+import { StockStatus } from '../../../models/types/base';
+
+/** A stock change that was actually written, as observed under the lock. */
+export interface StockTransition {
+  from: StockStatus | null;
+  to: StockStatus;
+}
 
 export class ProductPersistenceService {
   /**
    * Saves metadata, price history, and stock history for a product.
    * Handles Standard, Member, and Original prices.
+   *
+   * Returns the stock transition it actually applied, or null if the status did
+   * not change. Callers must decide whether to notify from this rather than
+   * from their own pre-scrape snapshot: the snapshot is read outside the
+   * advisory lock, so two concurrent refreshes both saw the old status and both
+   * fired a back-in-stock alert for the same event (issue #92). The transition
+   * returned here is observed under the lock, so exactly one of them sees it.
    */
   async saveScrapeResult(
     productId: number, 
@@ -22,7 +36,7 @@ export class ProductPersistenceService {
     scrapedData: ScrapedProductWithVoting,
     source: 'manual-add' | 'refresh' | 'manual-confirm' | 'auto-track',
     manualSelector?: string
-  ) {
+  ): Promise<StockTransition | null> {
     const client = await pool.connect();
     
     try {
@@ -36,7 +50,7 @@ export class ProductPersistenceService {
       const product = await productRepository.findById(productId, userId, { executor: client });
       if (!product) {
         await client.query('ROLLBACK');
-        return;
+        return null;
       }
 
       // Resolve domain early — needed for cache invalidation post-commit
@@ -46,7 +60,7 @@ export class ProductPersistenceService {
       await this.updateMetadata(client, productId, userId, product, scrapedData, source);
 
       // 3. Update stock status and history
-      await this.updateStockState(client, productId, product, scrapedData);
+      const transition = await this.updateStockState(client, productId, product, scrapedData);
 
       // 4. Record Prices
       await this.recordPrices(client, productId, scrapedData, source);
@@ -80,6 +94,8 @@ export class ProductPersistenceService {
       // Flush the in-memory retailer config cache AFTER commit so the next scrape
       // immediately picks up any selector changes confirmed by this save operation.
       configCache.invalidate(configDomain);
+
+      return transition;
     } catch (error) {
       await client.query('ROLLBACK');
       logger.error(`Product ${productId} | Persistence | Failed: ${error}`, 'Products', { product_id: productId, error });
@@ -128,20 +144,23 @@ export class ProductPersistenceService {
     productId: number,
     product: Product,
     scrapedData: ScrapedProductWithVoting
-  ) {
+  ): Promise<StockTransition | null> {
     // 'unknown' means the scrape could not determine anything (blocked page,
     // failed extraction) — it is not an observation, so never let it
     // overwrite a real previously-known status.
     if (scrapedData.stockStatus === 'unknown' && product.stock_status && product.stock_status !== 'unknown') {
       logger.debug(`Product ${productId} | Stock | Scrape returned unknown; keeping '${product.stock_status}'`, 'Products', { product_id: productId });
-      return;
+      return null;
     }
 
     if (scrapedData.stockStatus !== product.stock_status) {
       await productRepository.updateStockStatus(productId, scrapedData.stockStatus, scrapedData.aiStatus, client);
       await stockHistoryRepository.recordChange(productId, scrapedData.stockStatus, client);
       logger.info(`Product ${productId} | Stock | Changed: ${product.stock_status} -> ${scrapedData.stockStatus}`, 'Products', { product_id: productId });
+      return { from: product.stock_status, to: scrapedData.stockStatus };
     }
+
+    return null;
   }
 
   /**

--- a/backend/src/services/domain/product/ProductRefreshService.ts
+++ b/backend/src/services/domain/product/ProductRefreshService.ts
@@ -9,6 +9,7 @@ import { logger } from '../../../utils/system/logger';
 import { productNotificationService } from './notifications/index';
 import { productPersistenceService } from './ProductPersistenceService';
 import { isDefinitiveUnavailable, describeUnavailableReason } from '../../../types/availability';
+import { StockStatus } from '../../../models/types/base';
 
 // Consecutive page-gone scrapes required before a product is marked
 // not_available, monitoring is paused, and the user is notified.
@@ -23,6 +24,27 @@ const PAGE_GONE_THRESHOLD = 3;
  * response is to keep trying and say so once it stops looking like a blip.
  */
 const SITE_FAILURE_NOTIFY_THRESHOLD = 6;
+
+/**
+ * Which previous statuses make a move to `in_stock` worth announcing.
+ *
+ * `member_only` is included, and was not before (issue #92). From the user's
+ * side it is the same event as any other on this list: the item exists, they
+ * could not buy it, and now they can. Leaving it out meant a members-only
+ * product opening to everyone passed silently.
+ *
+ * `unknown` stays out deliberately. It does not mean the item was unavailable,
+ * it means the last scrape could not tell -- so treating it as a transition
+ * would fire "back in stock" on the first successful scrape after any parse
+ * failure, for a product that had been in stock the whole time. `null` is out
+ * for the same reason: a product that has never had a status is not a product
+ * that has come back.
+ */
+const BACK_IN_STOCK_FROM: readonly StockStatus[] = ['out_of_stock', 'pre_order', 'not_available', 'member_only'];
+
+export function isBackInStockFrom(previous: StockStatus | null): boolean {
+  return previous !== null && BACK_IN_STOCK_FROM.includes(previous);
+}
 
 export class ProductRefreshService {
   /**
@@ -94,7 +116,13 @@ export class ProductRefreshService {
     }
 
     // 2. Persist results (DB State Sync)
-    await productPersistenceService.saveScrapeResult(productId, userId, scrapedData, 'refresh');
+    //
+    // The transition comes back from inside the advisory lock. The check below
+    // used to compare against `product.stock_status`, read before the scrape
+    // and outside any lock, so two concurrent refreshes of the same product
+    // both saw `out_of_stock` and both sent a back-in-stock alert for one
+    // event. Only the refresh that actually wrote the change sees it here.
+    const transition = await productPersistenceService.saveScrapeResult(productId, userId, scrapedData, 'refresh');
 
     // Resume only a pause the system applied. A user who deliberately paused a
     // product does not want it silently resumed because the page came back --
@@ -110,17 +138,13 @@ export class ProductRefreshService {
     }
 
     // 3. Handle Notifications (Side-effects of change)
-    if (scrapedData.stockStatus !== product.stock_status) {
-      if (scrapedData.stockStatus === 'not_available') {
+    if (transition) {
+      if (transition.to === 'not_available') {
         logger.warn(`Product ${productId} | Status | ${describeUnavailableReason(reason)}. Pausing further checks.`, 'Products', { product_id: productId });
         await productRepository.setPaused(productId, true, false);
         await productNotificationService.notifyNotAvailable(product, reason);
-      } else if (
-        (product.stock_status === 'out_of_stock' || product.stock_status === 'pre_order' || product.stock_status === 'not_available') && 
-        scrapedData.stockStatus === 'in_stock' && 
-        product.notify_back_in_stock
-      ) {
-        await productNotificationService.notifyBackInStock(product, scrapedData);
+      } else if (transition.to === 'in_stock' && isBackInStockFrom(transition.from) && product.notify_back_in_stock) {
+        await productNotificationService.notifyBackInStock(product, scrapedData, transition.from);
       }
     }
 

--- a/backend/src/services/domain/product/notifications/alerts.ts
+++ b/backend/src/services/domain/product/notifications/alerts.ts
@@ -20,7 +20,13 @@ export class ProductAlertService {
         productName: product.name || 'Unknown Product',
         productUrl: product.url,
         type: 'not_available',
-        productId: product.id
+        productId: product.id,
+        // Both of these used to stop at the in-app history. Every external
+        // channel hardcoded "Page no longer exists (404/410). Monitoring has
+        // been paused", so a timeout read as a dead page, and the transient
+        // path -- which does not pause -- said monitoring had stopped.
+        reason: describeUnavailableReason(reason),
+        paused
       },
       {
         type: 'not_available',
@@ -60,7 +66,8 @@ export class ProductAlertService {
         productName: product.name || 'Unknown Product',
         productUrl: product.url,
         type: 'product_restored',
-        productId: product.id
+        productId: product.id,
+        oldStockStatus: product.stock_status || undefined
       },
       {
         type: 'product_restored',
@@ -77,7 +84,13 @@ export class ProductAlertService {
     );
   }
 
-  async notifyBackInStock(product: Product, scrapedData: ScrapedProductWithVoting) {
+  /**
+   * `previousStatus` is the status observed under the persistence lock, not the
+   * caller's pre-scrape snapshot -- so "Previously out of stock" in the message
+   * describes what actually changed rather than what the caller happened to
+   * have loaded.
+   */
+  async notifyBackInStock(product: Product, scrapedData: ScrapedProductWithVoting, previousStatus?: string | null) {
     await productNotificationOrchestrator.deliver(
       product,
       'back_in_stock',
@@ -87,7 +100,7 @@ export class ProductAlertService {
         type: 'back_in_stock',
         newPrice: scrapedData.price?.price,
         currency: scrapedData.price?.currency || undefined,
-        oldStockStatus: product.stock_status || undefined,
+        oldStockStatus: previousStatus || product.stock_status || undefined,
         newStockStatus: scrapedData.stockStatus,
         productId: product.id
       },
@@ -103,7 +116,7 @@ export class ProductAlertService {
           productId: product.id,
           productName: product.name,
           productUrl: product.url,
-          oldStockStatus: product.stock_status,
+          oldStockStatus: previousStatus || product.stock_status,
           newStockStatus: scrapedData.stockStatus,
           newPrice: scrapedData.price?.price,
           currency: scrapedData.price?.currency || undefined

--- a/backend/src/services/domain/product/notifications/orchestrator.ts
+++ b/backend/src/services/domain/product/notifications/orchestrator.ts
@@ -26,19 +26,43 @@ export class ProductNotificationOrchestrator {
       if (!userSettings) return;
 
       const result = await sendNotifications(userSettings, payload);
-      logger.info(`Product ${product.id} | Notify | Sent ${type} alert`, 'Products', { product_id: product.id });
 
-      if (result.channelsNotified.length > 0) {
-        await notificationRepository.create({
-          user_id: product.user_id,
-          type: historyEntry.type as any,
-          title: historyEntry.title,
-          message: historyEntry.message,
-          data: {
-            ...historyEntry.data,
-            channelsNotified: result.channelsNotified
-          }
-        });
+      // The in-app history records what happened to the product, not whether a
+      // message left the building (issue #92). It used to be written only when
+      // at least one external channel succeeded, which meant:
+      //
+      //   - a user with no channels configured -- the state every install
+      //     starts in -- got no notification history at all, and
+      //   - when every channel failed, the one record that would have explained
+      //     the silence was the record that was skipped.
+      //
+      // The delivery outcome is kept alongside it, both channels and failures,
+      // so "the alert fired but Telegram was down" stays distinguishable from
+      // "the alert never fired".
+      await notificationRepository.create({
+        user_id: product.user_id,
+        type: historyEntry.type as any,
+        title: historyEntry.title,
+        message: historyEntry.message,
+        data: {
+          ...historyEntry.data,
+          channelsNotified: result.channelsNotified,
+          channelsFailed: result.channelsFailed
+        }
+      });
+
+      if (result.channelsFailed.length > 0) {
+        logger.warn(
+          `Product ${product.id} | Notify | ${type} alert recorded; delivery failed on ${result.channelsFailed.join(', ')}`,
+          'Products',
+          { product_id: product.id }
+        );
+      } else {
+        logger.info(
+          `Product ${product.id} | Notify | Sent ${type} alert to ${result.channelsNotified.join(', ') || 'no external channels'}`,
+          'Products',
+          { product_id: product.id }
+        );
       }
     } catch (err) {
       logger.error(`Product ${product.id} | Notify | Failed ${type} alert`, 'Products', { product_id: product.id, error: err });

--- a/backend/src/services/notifications/events.ts
+++ b/backend/src/services/notifications/events.ts
@@ -1,0 +1,211 @@
+import { NotificationPayload } from './types';
+
+/**
+ * One description of each event, rendered by every provider (issue #92).
+ *
+ * Each of the seven providers used to carry its own if/else chain over the
+ * event type, and every one of them ended in an `else` that meant "back in
+ * stock". That was fine while three events existed. Six exist now, so the
+ * chains had quietly become wrong in the same way in six places:
+ *
+ *   - Telegram sent an empty message for `product_restored` and
+ *     `price_announced` -- `formatDefaultMessage` returned '', and the Telegram
+ *     API rejects an empty `text`, so the notification was never delivered.
+ *   - Discord, Pushover, Gotify and ntfy announced `product_restored` as
+ *     "Back in Stock!", which is a different claim about a different thing.
+ *   - The unavailable wording said "Monitoring has been paused" unconditionally,
+ *     including on the transient-failure path that explicitly does not pause.
+ *
+ * The fix is structural rather than seven parallel patches: the wording lives
+ * here once, and `describeEvent` is exhaustive over the union, so adding a
+ * seventh event type is a compile error until it has wording. A provider now
+ * chooses presentation -- an embed, a header, a priority -- never meaning.
+ */
+
+/** Symbols for currencies that have one people actually recognise. */
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: '$', EUR: '€', GBP: '£', JPY: '¥', CNY: '¥',
+  INR: '₹', KRW: '₩', THB: '฿', ZAR: 'R', BRL: 'R$',
+  SEK: 'kr', NOK: 'kr', DKK: 'kr',
+  AUD: '$', NZD: '$', CAD: '$', SGD: '$', HKD: '$',
+};
+
+/**
+ * Formats an amount, or returns null when there is no amount to format.
+ *
+ * Returning null rather than a string is deliberate: the caller decides what
+ * absence reads as, which differs per event. "Back in stock" with no price
+ * should not say "back in stock at N/A" -- it should not mention price at all.
+ *
+ * Zero is a real price. The previous `price ? ... : 'N/A'` guards reported a
+ * free item as having no price.
+ */
+export function formatMoney(amount?: number | null, currency?: string | null): string | null {
+  if (amount === undefined || amount === null || Number.isNaN(amount)) return null;
+
+  const value = amount.toFixed(2);
+  if (!currency) return value;
+
+  // An unknown currency is shown by its ISO code, never dressed as dollars.
+  // The template path stopped inventing USD when unresolved currencies moved to
+  // manual confirmation; the default-message path was still doing it.
+  const symbol = CURRENCY_SYMBOLS[currency.toUpperCase()];
+  return symbol ? `${symbol}${value}` : `${currency} ${value}`;
+}
+
+/** "out_of_stock" reads badly in a sentence; "out of stock" does not. */
+export function humaniseStockStatus(status?: string | null): string | null {
+  if (!status || status === 'unknown') return null;
+  return status.replace(/_/g, ' ');
+}
+
+export interface EventField {
+  name: string;
+  value: string;
+  inline: boolean;
+}
+
+export interface EventPresentation {
+  /** Heading: in-app title, Discord embed title, ntfy Title header. */
+  title: string;
+  /** Prefix for the channels that already carry one. Never the whole meaning. */
+  emoji: string;
+  /** One line saying what happened. */
+  headline: string;
+  /** Optional second line: the consequence, or what happens next. */
+  detail?: string;
+  /** ntfy tag names. */
+  tags: string[];
+  /** Discord embed colour. */
+  color: number;
+  /** Structured summary, for Discord embeds and the webhook payload. */
+  fields: EventField[];
+}
+
+export function describeEvent(payload: NotificationPayload): EventPresentation {
+  const price = formatMoney(payload.newPrice, payload.currency);
+  const previous = humaniseStockStatus(payload.oldStockStatus);
+
+  switch (payload.type) {
+    case 'price_drop': {
+      const oldPrice = formatMoney(payload.oldPrice, payload.currency);
+      const drop = payload.oldPrice !== undefined && payload.newPrice !== undefined
+        ? formatMoney(payload.oldPrice - payload.newPrice, payload.currency)
+        : null;
+
+      return {
+        title: 'Price Drop Alert!',
+        emoji: '🔔',
+        headline: oldPrice && price
+          ? `Price dropped from ${oldPrice} to ${price}${drop ? ` (-${drop})` : ''}`
+          : 'The price has dropped',
+        tags: ['moneybag', 'chart_with_downwards_trend'],
+        color: 0x10b981,
+        fields: [
+          { name: 'Old Price', value: oldPrice ?? 'unknown', inline: true },
+          { name: 'New Price', value: price ?? 'unknown', inline: true },
+        ],
+      };
+    }
+
+    case 'target_price': {
+      const target = formatMoney(payload.targetPrice, payload.currency);
+      return {
+        title: 'Target Price Reached!',
+        emoji: '🎯',
+        headline: price && target
+          ? `Price is now ${price}, at or below your target of ${target}`
+          : 'The price reached your target',
+        tags: ['dart', 'white_check_mark'],
+        color: 0xf59e0b,
+        fields: [
+          { name: 'Current Price', value: price ?? 'unknown', inline: true },
+          { name: 'Your Target', value: target ?? 'unknown', inline: true },
+        ],
+      };
+    }
+
+    case 'back_in_stock':
+      return {
+        title: 'Back in Stock!',
+        emoji: '🎉',
+        // A product can come back in stock before a price is extracted. Saying
+        // "available at N/A" is worse than not mentioning price.
+        headline: price ? `This item is now available at ${price}` : 'This item is now available',
+        detail: previous ? `Previously ${previous}.` : undefined,
+        tags: ['package', 'tada'],
+        color: 0x6366f1,
+        fields: [
+          { name: 'Price', value: price ?? 'not listed', inline: true },
+          { name: 'Status', value: 'Available', inline: true },
+        ],
+      };
+
+    case 'price_announced':
+      return {
+        title: 'Price Announced',
+        emoji: '🏷️',
+        headline: price
+          ? `A price has been announced: ${price}`
+          : 'A price has been announced',
+        tags: ['label'],
+        color: 0x3b82f6,
+        fields: [{ name: 'Price', value: price ?? 'unknown', inline: true }],
+      };
+
+    case 'not_available': {
+      // The reason and the consequence both travel on the payload now. They
+      // were hardcoded to "404/410" and "Monitoring has been paused", so a
+      // timeout was reported as a dead page, and the transient-failure path --
+      // which deliberately keeps retrying -- told the user monitoring had
+      // stopped when it had not.
+      const reason = payload.reason || 'The product page could not be read';
+      const paused = payload.paused !== false;
+      return {
+        title: 'Product Unavailable',
+        emoji: '⚠️',
+        headline: reason,
+        detail: paused
+          ? 'Monitoring has been paused. You can resume it from the dashboard.'
+          : 'Still retrying.',
+        tags: ['warning'],
+        color: 0x6b7280,
+        fields: [
+          { name: 'Reason', value: reason, inline: true },
+          { name: 'Action', value: paused ? 'Monitoring paused' : 'Still retrying', inline: true },
+        ],
+      };
+    }
+
+    case 'product_restored':
+      return {
+        title: 'Available Again',
+        emoji: '✅',
+        headline: 'The product page is reachable again',
+        detail: 'Monitoring has resumed.',
+        tags: ['white_check_mark'],
+        color: 0x10b981,
+        fields: [{ name: 'Action', value: 'Monitoring resumed', inline: true }],
+      };
+
+    default: {
+      // Exhaustiveness. Adding an event type without wording for it fails the
+      // build here rather than shipping as a silent "Back in Stock!".
+      const unhandled: never = payload.type;
+      throw new Error(`Notification event type has no wording: ${String(unhandled)}`);
+    }
+  }
+}
+
+/**
+ * The plain-text body every channel that sends prose starts from.
+ *
+ * Providers add their own furniture -- a URL line, an emoji prefix, an embed --
+ * but the sentences describing the event are the same everywhere.
+ */
+export function eventBody(payload: NotificationPayload): string {
+  const event = describeEvent(payload);
+  return [payload.productName, '', event.headline, event.detail]
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
+}

--- a/backend/src/services/notifications/index.ts
+++ b/backend/src/services/notifications/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
+export * from './events';
 export * from './utils';
 export * from './orchestrator';
 export * from './legacy';

--- a/backend/src/services/notifications/providers/discord.ts
+++ b/backend/src/services/notifications/providers/discord.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { NotificationProvider, NotificationPayload } from '../types';
-import { executeProviderRequest, interpolateTemplate, getCurrencySymbol } from '../utils';
+import { executeProviderRequest, interpolateTemplate } from '../utils';
+import { describeEvent } from '../events';
 
 export class DiscordProvider implements NotificationProvider {
   constructor(
@@ -16,69 +17,24 @@ export class DiscordProvider implements NotificationProvider {
         return;
       }
 
-      const currencySymbol = getCurrencySymbol(payload.currency);
-      let embed;
+      // Wording, colour and fields all come from the shared descriptor. The
+      // if/else chain this replaces had no branch for `product_restored` or
+      // `price_announced`, so both arrived as a green "Back in Stock!" embed
+      // claiming the item was available.
+      const event = describeEvent(payload);
 
-      if (payload.type === 'price_drop') {
-        const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
-        const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-
-        embed = {
-          title: '🔔 Price Drop Alert!',
-          description: payload.productName,
-          color: 0x10b981,
-          fields: [
-            { name: 'Old Price', value: oldPriceStr, inline: true },
-            { name: 'New Price', value: newPriceStr, inline: true },
-          ],
+      await axios.post(this.webhookUrl, {
+        embeds: [{
+          title: `${event.emoji} ${event.title}`,
+          description: event.detail
+            ? `${payload.productName}\n\n${event.headline}\n${event.detail}`
+            : `${payload.productName}\n\n${event.headline}`,
+          color: event.color,
+          fields: event.fields,
           url: payload.productUrl,
           timestamp: new Date().toISOString(),
-        };
-      } else if (payload.type === 'target_price') {
-        const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-        const targetPriceStr = payload.targetPrice ? `${currencySymbol}${payload.targetPrice.toFixed(2)}` : 'N/A';
-
-        embed = {
-          title: '🎯 Target Price Reached!',
-          description: payload.productName,
-          color: 0xf59e0b,
-          fields: [
-            { name: 'Current Price', value: newPriceStr, inline: true },
-            { name: 'Your Target', value: targetPriceStr, inline: true },
-          ],
-          url: payload.productUrl,
-          timestamp: new Date().toISOString(),
-        };
-      } else if (payload.type === 'not_available') {
-        embed = {
-          title: '⚠️ Product Unavailable',
-          description: payload.productName,
-          color: 0x6b7280,
-          fields: [
-            { name: 'Status', value: '❌ Page Not Found (404/410)', inline: true },
-            { name: 'Action', value: '⏸️ Monitoring Paused', inline: true },
-          ],
-          footer: { text: 'You can unpause this product in the dashboard if the link is restored.' },
-          url: payload.productUrl,
-          timestamp: new Date().toISOString(),
-        };
-      } else {
-        const priceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'Check link';
-
-        embed = {
-          title: '🎉 Back in Stock!',
-          description: payload.productName,
-          color: 0x6366f1,
-          fields: [
-            { name: 'Price', value: priceStr, inline: true },
-            { name: 'Status', value: '✅ Available', inline: true },
-          ],
-          url: payload.productUrl,
-          timestamp: new Date().toISOString(),
-        };
-      }
-
-      await axios.post(this.webhookUrl, { embeds: [embed] });
+        }],
+      });
     });
   }
 }

--- a/backend/src/services/notifications/providers/ntfy.ts
+++ b/backend/src/services/notifications/providers/ntfy.ts
@@ -1,30 +1,8 @@
 import axios from 'axios';
 import { NotificationProvider, NotificationPayload } from '../types';
 import { logger } from '../../../utils/system/logger';
-import { interpolateTemplate, getCurrencySymbol } from '../utils';
-
-/**
- * Heading and tags per event type, for the custom-template path.
- *
- * The template branch used a two-way ternary that treated everything which was
- * not a price drop or a target price as "Back in Stock!", so an unavailable
- * product was announced as back in stock.
- */
-function headingFor(type: NotificationPayload['type']): { title: string; tags: string[] } {
-  switch (type) {
-    case 'price_drop':
-      return { title: 'Price Drop Alert!', tags: ['moneybag'] };
-    case 'target_price':
-      return { title: 'Target Price Reached!', tags: ['dart'] };
-    case 'not_available':
-      return { title: 'Product Unavailable', tags: ['warning'] };
-    case 'price_announced':
-      return { title: 'Price Announced', tags: ['label'] };
-    case 'back_in_stock':
-    default:
-      return { title: 'Back in Stock!', tags: ['tada'] };
-  }
-}
+import { interpolateTemplate } from '../utils';
+import { describeEvent, eventBody } from '../events';
 
 export class NtfyProvider implements NotificationProvider {
   constructor(
@@ -37,50 +15,18 @@ export class NtfyProvider implements NotificationProvider {
 
   async send(payload: NotificationPayload): Promise<boolean> {
     try {
-      const currencySymbol = getCurrencySymbol(payload.currency);
-      let title: string;
-      let message: string;
-      let tags: string[];
-
-      if (this.template) {
-        ({ title, tags } = headingFor(payload.type));
-        message = interpolateTemplate(this.template, payload);
-      } else if (payload.type === 'price_drop') {
-        const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
-        const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-        title = 'Price Drop Alert!';
-        message = `${payload.productName}\n\nPrice dropped from ${oldPriceStr} to ${newPriceStr}`;
-        tags = ['moneybag', 'chart_with_downwards_trend'];
-      } else if (payload.type === 'target_price') {
-        const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-        const targetPriceStr = payload.targetPrice ? `${currencySymbol}${payload.targetPrice.toFixed(2)}` : 'N/A';
-        title = 'Target Price Reached!';
-        message = `${payload.productName}\n\nPrice is now ${newPriceStr} (your target: ${targetPriceStr})`;
-        tags = ['dart', 'white_check_mark'];
-      } else if (payload.type === 'not_available') {
-        // This used to fall through to the back-in-stock branch, so a product
-        // that had just become unavailable was announced as back in stock.
-        title = 'Product Unavailable';
-        message = `${payload.productName}\n\nThis product is no longer available. Monitoring has been paused.`;
-        tags = ['warning'];
-      } else if (payload.type === 'price_announced') {
-        const priceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'unavailable';
-        title = 'Price Announced';
-        message = `${payload.productName}\n\nA price is now listed: ${priceStr}`;
-        tags = ['label'];
-      } else {
-        const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
-        title = 'Back in Stock!';
-        message = `${payload.productName}\n\nThis item is now available${priceStr}`;
-        tags = ['package', 'tada'];
-      }
+      // Title and tags apply to both paths: a custom template replaces the body
+      // the user writes, not the heading the client shows in its notification
+      // tray, so the heading must still name the right event.
+      const event = describeEvent(payload);
+      const message = this.template ? interpolateTemplate(this.template, payload) : eventBody(payload);
 
       const baseUrl = this.serverUrl ? this.serverUrl.replace(/\/$/, '') : 'https://ntfy.sh';
       const url = `${baseUrl}/${this.topic}`;
 
       const headers: Record<string, string> = {
-        'Title': title,
-        'Tags': tags.join(','),
+        'Title': event.title,
+        'Tags': event.tags.join(','),
         'Click': payload.productUrl,
       };
 

--- a/backend/src/services/notifications/providers/pushover.ts
+++ b/backend/src/services/notifications/providers/pushover.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { NotificationProvider, NotificationPayload } from '../types';
 import { getNotificationContent, executeProviderRequest } from '../utils';
+import { describeEvent } from '../events';
 
 export class PushoverProvider implements NotificationProvider {
   constructor(
@@ -12,11 +13,11 @@ export class PushoverProvider implements NotificationProvider {
   async send(payload: NotificationPayload): Promise<boolean> {
     return executeProviderRequest('Pushover', async () => {
       const { title, message } = getNotificationContent(payload, this.template);
-      
-      const pushTitle = payload.type === 'price_drop' && !this.template ? `🔔 ${title}` 
-                      : payload.type === 'target_price' && !this.template ? `🎯 ${title}`
-                      : payload.type === 'back_in_stock' && !this.template ? `🎉 ${title}`
-                      : title;
+
+      // The prefix used to come from a ternary listing three event types by
+      // name, so half the events arrived without one -- and the title they
+      // arrived under was 'Back in Stock!' whatever had happened.
+      const pushTitle = this.template ? title : `${describeEvent(payload).emoji} ${title}`;
 
       await axios.post('https://api.pushover.net/1/messages.json', {
         token: this.appToken,

--- a/backend/src/services/notifications/providers/telegram.ts
+++ b/backend/src/services/notifications/providers/telegram.ts
@@ -12,16 +12,21 @@ export class TelegramProvider implements NotificationProvider {
 
   async send(payload: NotificationPayload): Promise<boolean> {
     try {
-      const message = this.template 
-        ? interpolateTemplate(this.template, payload) 
+      const message = this.template
+        ? interpolateTemplate(this.template, payload)
         : formatDefaultMessage(payload);
-        
+
       const url = `https://api.telegram.org/bot${this.botToken}/sendMessage`;
 
       await axios.post(url, {
         chat_id: this.chatId,
         text: message,
-        parse_mode: 'HTML',
+        // HTML parse mode only for a custom template, where the user may
+        // actually be using tags. The default message contains no markup, and
+        // sending it as HTML meant any product name containing &, < or > was
+        // rejected by the API with a 400 -- a whole class of products whose
+        // alerts silently never arrived.
+        ...(this.template ? { parse_mode: 'HTML' as const } : {}),
         disable_web_page_preview: false,
       });
 

--- a/backend/src/services/notifications/providers/webhook.ts
+++ b/backend/src/services/notifications/providers/webhook.ts
@@ -31,13 +31,24 @@ export class WebhookProvider implements NotificationProvider {
           body = interpolateTemplate(this.payloadTemplate, payload);
         }
       } else {
+        // The default payload carried `event: back_in_stock` with nothing else
+        // about stock, so a receiver could not tell what the item had come back
+        // *from*, and it reported `currency: 'USD'` for products whose currency
+        // was never resolved -- a wrong value is worse than an absent one for a
+        // consumer parsing this.
         body = {
           event: payload.type,
           product: payload.productName,
+          productId: payload.productId,
           url: payload.productUrl,
-          price: payload.newPrice,
-          oldPrice: payload.oldPrice,
-          currency: payload.currency || 'USD',
+          price: payload.newPrice ?? null,
+          oldPrice: payload.oldPrice ?? null,
+          targetPrice: payload.targetPrice ?? null,
+          currency: payload.currency ?? null,
+          oldStockStatus: payload.oldStockStatus ?? null,
+          newStockStatus: payload.newStockStatus ?? null,
+          reason: payload.reason ?? null,
+          paused: payload.paused ?? null,
           timestamp: new Date().toISOString()
         };
       }

--- a/backend/src/services/notifications/types.ts
+++ b/backend/src/services/notifications/types.ts
@@ -15,6 +15,20 @@ export interface NotificationPayload {
    */
   oldStockStatus?: string;
   newStockStatus?: string;
+  /**
+   * Why the product could not be read, already phrased for a person.
+   *
+   * Every channel hardcoded "Page no longer exists (404/410)", so a timeout, a
+   * redirect and a soft 404 were all reported as a dead page -- while the
+   * in-app history, which does receive the reason, said something different.
+   */
+  reason?: string;
+  /**
+   * Whether monitoring actually stopped. Defaults to true when absent, matching
+   * the definitive-unavailable path. The transient-failure path passes false:
+   * it keeps retrying, and saying otherwise is simply untrue.
+   */
+  paused?: boolean;
 }
 
 export interface NotificationResult {

--- a/backend/src/services/notifications/utils.ts
+++ b/backend/src/services/notifications/utils.ts
@@ -1,11 +1,18 @@
 import { NotificationPayload } from './types';
 import { logger } from '../../utils/system/logger';
+import { describeEvent, eventBody, formatMoney, humaniseStockStatus } from './events';
 
 /**
- * Helper to get currency symbol for display.
+ * Kept for callers that want a bare symbol.
+ *
+ * It no longer falls back to '$'. Defaulting an unresolved currency to dollars
+ * is how a CHF price arrived in a notification reading "$49.90"; the rest of
+ * the app stopped guessing when unresolved currencies moved to manual
+ * confirmation, and `formatMoney` shows the ISO code instead.
  */
 export function getCurrencySymbol(currency?: string): string {
   switch (currency) {
+    case 'USD': case 'AUD': case 'NZD': case 'CAD': case 'SGD': case 'HKD': return '$';
     case 'EUR': return '€';
     case 'GBP': return '£';
     case 'CHF': return 'CHF ';
@@ -16,15 +23,14 @@ export function getCurrencySymbol(currency?: string): string {
     case 'ZAR': return 'R';
     case 'BRL': return 'R$';
     case 'SEK': case 'NOK': case 'DKK': return 'kr';
-    case 'SGD': case 'HKD': case 'NZD': case 'CAD': return '$';
-    default: return '$';
+    default: return '';
   }
 }
 
 /** "out_of_stock" reads badly in a notification; "Out of stock" does not. */
 function formatStockStatus(status?: string): string {
-  if (!status) return 'unknown';
-  const words = status.replace(/_/g, ' ');
+  const words = humaniseStockStatus(status);
+  if (!words) return 'unknown';
   return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
@@ -52,6 +58,10 @@ export function interpolateTemplate(template: string, payload: NotificationPaylo
     'type': payload.type.replace(/_/g, ' '),
     'old_stock_status': formatStockStatus(payload.oldStockStatus),
     'new_stock_status': formatStockStatus(payload.newStockStatus),
+    // A price with its currency attached, so a template does not have to
+    // assemble one and get the unknown-currency case wrong.
+    'price': formatMoney(payload.newPrice, payload.currency) ?? 'unavailable',
+    'reason': payload.reason || '',
   };
 
   let result = template;
@@ -65,52 +75,20 @@ export function interpolateTemplate(template: string, payload: NotificationPaylo
 }
 
 /**
- * Default formatter for notification messages.
+ * The default message for channels that send plain prose (Telegram).
+ *
+ * This used to be an if/else chain over the event type with no branch for
+ * `product_restored` or `price_announced`, falling through to `return ''`.
+ * Telegram's API rejects an empty `text`, so those two events were never
+ * delivered to Telegram at all -- they were logged as a send failure with no
+ * indication that the message itself was the problem.
  */
 export function formatDefaultMessage(payload: NotificationPayload): string {
-  const currencySymbol = getCurrencySymbol(payload.currency);
-
-  if (payload.type === 'price_drop') {
-    const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
-    const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-    const dropAmount = payload.oldPrice && payload.newPrice
-      ? `${currencySymbol}${(payload.oldPrice - payload.newPrice).toFixed(2)}`
-      : '';
-
-    return `🔔 Price Drop Alert!\n\n` +
-      `📦 ${payload.productName}\n\n` +
-      `💰 Price dropped from ${oldPriceStr} to ${newPriceStr}` +
-      (dropAmount ? ` (-${dropAmount})` : '') + `\n\n` +
-      `🔗 ${payload.productUrl}`;
-  }
-
-  if (payload.type === 'target_price') {
-    const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-    const targetPriceStr = payload.targetPrice ? `${currencySymbol}${payload.targetPrice.toFixed(2)}` : 'N/A';
-
-    return `🎯 Target Price Reached!\n\n` +
-      `📦 ${payload.productName}\n\n` +
-      `💰 Price is now ${newPriceStr} (your target: ${targetPriceStr})\n\n` +
-      `🔗 ${payload.productUrl}`;
-  }
-
-  if (payload.type === 'back_in_stock') {
-    const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
-    return `🎉 Back in Stock!\n\n` +
-      `📦 ${payload.productName}\n\n` +
-      `✅ This item is now available${priceStr}\n\n` +
-      `🔗 ${payload.productUrl}`;
-  }
-
-  if (payload.type === 'not_available') {
-    return `⚠️ Product Unavailable\n\n` +
-      `📦 ${payload.productName}\n\n` +
-      `❌ Page no longer exists (404/410).\n` +
-      `⏸️ Monitoring has been paused.\n\n` +
-      `🔗 ${payload.productUrl}`;
-  }
-
-  return '';
+  const event = describeEvent(payload);
+  return `${event.emoji} ${event.title}\n\n` +
+    `📦 ${payload.productName}\n\n` +
+    `${event.headline}` + (event.detail ? `\n${event.detail}` : '') + `\n\n` +
+    `🔗 ${payload.productUrl}`;
 }
 
 export async function executeProviderRequest(providerName: string, requestFn: () => Promise<void>): Promise<boolean> {
@@ -124,39 +102,21 @@ export async function executeProviderRequest(providerName: string, requestFn: ()
   }
 }
 
+/**
+ * Title and body for the channels that send a title/message pair (Pushover,
+ * Gotify).
+ *
+ * The title used to come from a ternary chain whose final branch was
+ * 'Back in Stock!', so a restored product and an announced price were both
+ * announced as back in stock -- on the custom-template path too, where the
+ * user's own wording arrived under a title contradicting it.
+ */
 export function getNotificationContent(payload: NotificationPayload, template?: string | null): { title: string, message: string } {
-  if (template) {
-    const title = payload.type === 'price_drop' ? 'Price Drop Alert!' : 
-                  payload.type === 'target_price' ? 'Target Price Reached!' : 
-                  payload.type === 'not_available' ? 'Product Unavailable' : 'Back in Stock!';
-    const message = interpolateTemplate(template, payload);
-    return { title, message };
-  }
-
-  const currencySymbol = getCurrencySymbol(payload.currency);
-  let title = '';
-  let message = '';
-
-  if (payload.type === 'price_drop') {
-    const oldPriceStr = payload.oldPrice ? `${currencySymbol}${payload.oldPrice.toFixed(2)}` : 'N/A';
-    const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-    title = 'Price Drop Alert!';
-    message = `${payload.productName}\n\nPrice dropped from ${oldPriceStr} to ${newPriceStr}`;
-  } else if (payload.type === 'target_price') {
-    const newPriceStr = payload.newPrice ? `${currencySymbol}${payload.newPrice.toFixed(2)}` : 'N/A';
-    const targetPriceStr = payload.targetPrice ? `${currencySymbol}${payload.targetPrice.toFixed(2)}` : 'N/A';
-    title = 'Target Price Reached!';
-    message = `${payload.productName}\n\nPrice is now ${newPriceStr} (your target: ${targetPriceStr})`;
-  } else if (payload.type === 'not_available') {
-    title = 'Product Unavailable';
-    message = `${payload.productName}\n\nThis product is no longer available (404/410) and monitoring has been paused.`;
-  } else {
-    const priceStr = payload.newPrice ? ` at ${currencySymbol}${payload.newPrice.toFixed(2)}` : '';
-    title = 'Back in Stock!';
-    message = `${payload.productName}\n\nThis item is now available${priceStr}`;
-  }
-
-  return { title, message };
+  const event = describeEvent(payload);
+  return {
+    title: event.title,
+    message: template ? interpolateTemplate(template, payload) : eventBody(payload),
+  };
 }
 
 /**
@@ -192,12 +152,12 @@ export function defaultEmailTemplate(type: NotificationPayload['type']): { subje
     case 'back_in_stock':
       return {
         subject: 'Back in stock: {{product_name}}',
-        body: '{{product_name}} is available again.\n\nCurrent price: {{current_price}} {{currency}}\n\n{{product_url}}',
+        body: '{{product_name}} is available again.\n\nCurrent price: {{price}}\n\n{{product_url}}',
       };
     case 'not_available':
       return {
         subject: 'Unavailable: {{product_name}}',
-        body: '{{product_name}} could not be reached.\n\n{{product_url}}',
+        body: '{{product_name}} could not be read.\n\n{{reason}}\n\n{{product_url}}',
       };
     case 'product_restored':
       return {

--- a/backend/tests/unit/notification-providers.test.ts
+++ b/backend/tests/unit/notification-providers.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('axios', () => ({
+  default: { post: vi.fn().mockResolvedValue({ status: 200, data: {} }) },
+}));
+
+const sentMail: any[] = [];
+vi.mock('nodemailer', () => ({
+  default: {
+    createTransport: () => ({
+      sendMail: async (mail: any) => { sentMail.push(mail); return {}; },
+    }),
+  },
+}));
+
+import axios from 'axios';
+import type { NotificationPayload } from '../../src/services/notifications/types';
+import { NOTIFICATION_EVENT_TYPES } from '../../src/models/types/notification';
+import { describeEvent, formatMoney } from '../../src/services/notifications/events';
+import { DiscordProvider } from '../../src/services/notifications/providers/discord';
+import { TelegramProvider } from '../../src/services/notifications/providers/telegram';
+import { PushoverProvider } from '../../src/services/notifications/providers/pushover';
+import { NtfyProvider } from '../../src/services/notifications/providers/ntfy';
+import { GotifyProvider } from '../../src/services/notifications/providers/gotify';
+import { WebhookProvider } from '../../src/services/notifications/providers/webhook';
+import { EmailProvider } from '../../src/services/notifications/providers/email';
+
+/**
+ * Every provider carried its own if/else over the event type, and every chain
+ * ended in an `else` meaning "back in stock". Six event types exist, so the
+ * chains were wrong in the same way in seven places (issue #92).
+ *
+ * These tests run the whole matrix -- each provider against each event -- so a
+ * provider that stops covering an event fails here rather than announcing a
+ * dead product as back in stock in someone's Telegram.
+ */
+
+const post = axios.post as unknown as ReturnType<typeof vi.fn>;
+
+const base: NotificationPayload = {
+  productName: 'Lockere Jersey Boxershorts (3er Pack)',
+  productUrl: 'https://shop.example.com/p/1',
+  type: 'back_in_stock',
+  productId: 409,
+};
+
+/** Every provider, driven through one uniform call. */
+const PROVIDERS: { name: string; send: (p: NotificationPayload, tpl?: string | null) => Promise<boolean> }[] = [
+  { name: 'telegram', send: (p, t) => new TelegramProvider('tok', 'chat', t).send(p) },
+  { name: 'discord', send: (p, t) => new DiscordProvider('https://discord.example/hook', t).send(p) },
+  { name: 'pushover', send: (p, t) => new PushoverProvider('user', 'app', t).send(p) },
+  { name: 'ntfy', send: (p, t) => new NtfyProvider('topic', null, null, null, t).send(p) },
+  { name: 'gotify', send: (p, t) => new GotifyProvider('https://gotify.example', 'tok', t).send(p) },
+  { name: 'webhook', send: (p, t) => new WebhookProvider('https://hook.example', null, t).send(p) },
+];
+
+/** Everything a provider put on the wire, as one searchable string. */
+function wireText(): string {
+  const bodies = post.mock.calls.map(call => JSON.stringify(call[1] ?? ''));
+  const headers = post.mock.calls.map(call => JSON.stringify(call[2]?.headers ?? {}));
+  return [...bodies, ...headers, ...sentMail.map(m => JSON.stringify(m))].join('\n');
+}
+
+beforeEach(() => {
+  post.mockClear();
+  sentMail.length = 0;
+});
+
+describe('every provider covers every event', () => {
+  for (const type of NOTIFICATION_EVENT_TYPES) {
+    describe(type, () => {
+      const payload: NotificationPayload = { ...base, type, newPrice: 19.99, currency: 'CHF' };
+
+      for (const provider of PROVIDERS) {
+        it(`${provider.name} sends something non-empty`, async () => {
+          // Telegram rejects an empty `text` with a 400. formatDefaultMessage
+          // returned '' for product_restored and price_announced, so those two
+          // events were never delivered to Telegram at all.
+          await expect(provider.send(payload)).resolves.toBe(true);
+          expect(post).toHaveBeenCalledTimes(1);
+
+          const body = JSON.stringify(post.mock.calls[0][1] ?? '');
+          expect(body.length).toBeGreaterThan(2);
+          expect(body).toContain('Boxershorts');
+        });
+
+        if (type !== 'back_in_stock') {
+          it(`${provider.name} does not call it back in stock`, async () => {
+            await provider.send(payload);
+            expect(wireText().toLowerCase()).not.toContain('back in stock');
+          });
+        }
+      }
+
+      it('email sends a subject and body that name the event', async () => {
+        await new EmailProvider('smtp.example', 25, 'a@example.com', 'b@example.com', null, null).send(payload);
+        expect(sentMail).toHaveLength(1);
+        expect(sentMail[0].subject).toBeTruthy();
+        expect(sentMail[0].text).toBeTruthy();
+        if (type !== 'back_in_stock') {
+          expect(`${sentMail[0].subject} ${sentMail[0].text}`.toLowerCase()).not.toContain('back in stock');
+        }
+      });
+    });
+  }
+});
+
+describe('back in stock, across the cases the issue lists', () => {
+  const cases: { label: string; payload: NotificationPayload }[] = [
+    { label: 'a valid price', payload: { ...base, newPrice: 49.99, currency: 'AUD' } },
+    { label: 'no price at all', payload: { ...base } },
+    { label: 'a price of zero', payload: { ...base, newPrice: 0, currency: 'EUR' } },
+    { label: 'a currency with no symbol', payload: { ...base, newPrice: 49.99, currency: 'CHF' } },
+    { label: 'a price but no currency', payload: { ...base, newPrice: 49.99 } },
+    { label: 'previously out_of_stock', payload: { ...base, newPrice: 5, currency: 'EUR', oldStockStatus: 'out_of_stock' } },
+    { label: 'previously pre_order', payload: { ...base, newPrice: 5, currency: 'EUR', oldStockStatus: 'pre_order' } },
+    { label: 'previously not_available', payload: { ...base, newPrice: 5, currency: 'EUR', oldStockStatus: 'not_available' } },
+    { label: 'previously member_only', payload: { ...base, newPrice: 5, currency: 'EUR', oldStockStatus: 'member_only' } },
+  ];
+
+  for (const { label, payload } of cases) {
+    for (const provider of PROVIDERS) {
+      it(`${provider.name} with ${label} contains no undefined and invents no currency`, async () => {
+        await provider.send(payload);
+        const wire = wireText();
+
+        // "Product is back in stock at undefined USD" -- the report that
+        // opened the issue.
+        expect(wire).not.toContain('undefined');
+        expect(wire).not.toContain('NaN');
+
+        // An unknown or non-dollar currency must never render as dollars.
+        if (payload.currency && payload.currency !== 'AUD') {
+          expect(wire).not.toMatch(/\$\d/);
+        }
+        if (!payload.currency && payload.newPrice !== undefined) {
+          expect(wire).not.toMatch(/[$€£]\s?\d/);
+        }
+      });
+    }
+  }
+});
+
+describe('an unavailable alert says what actually happened', () => {
+  const payload: NotificationPayload = {
+    ...base,
+    type: 'not_available',
+    reason: 'The request timed out',
+    paused: false,
+  };
+
+  for (const provider of PROVIDERS) {
+    it(`${provider.name} does not claim monitoring stopped when it has not`, async () => {
+      // The transient-failure path notifies with paused=false and keeps
+      // retrying. Every channel used to say "Monitoring has been paused"
+      // regardless, and reported the cause as a 404 whatever it was.
+      await provider.send(payload);
+      const wire = wireText();
+      expect(wire.toLowerCase()).not.toContain('monitoring has been paused');
+      expect(wire).not.toContain('404');
+    });
+  }
+
+  it('carries the real reason rather than a hardcoded one', async () => {
+    await new NtfyProvider('topic', null, null, null, null).send(payload);
+    expect(wireText()).toContain('The request timed out');
+  });
+
+  it('does say monitoring stopped when it has', async () => {
+    await new NtfyProvider('topic', null, null, null, null).send({ ...payload, paused: true });
+    expect(wireText().toLowerCase()).toContain('monitoring has been paused');
+  });
+});
+
+describe('a custom template still gets the right heading', () => {
+  // A template replaces the body the user writes, not the heading their client
+  // shows in the notification tray -- which was 'Back in Stock!' for every
+  // event that was not a price drop or a target price.
+  for (const provider of PROVIDERS) {
+    it(`${provider.name} does not head a restored product with "Back in Stock"`, async () => {
+      await provider.send({ ...base, type: 'product_restored' }, '{{product_name}} update');
+      expect(wireText().toLowerCase()).not.toContain('back in stock');
+    });
+  }
+});
+
+describe('the webhook payload is machine-readable', () => {
+  it('carries the stock transition, not just the event name', async () => {
+    await new WebhookProvider('https://hook.example').send({
+      ...base, newPrice: 49.99, currency: 'AUD', oldStockStatus: 'out_of_stock', newStockStatus: 'in_stock',
+    });
+    expect(post.mock.calls[0][1]).toMatchObject({
+      event: 'back_in_stock',
+      price: 49.99,
+      currency: 'AUD',
+      oldStockStatus: 'out_of_stock',
+      newStockStatus: 'in_stock',
+    });
+  });
+
+  it('reports an unresolved currency as null rather than USD', async () => {
+    // A wrong value is worse than an absent one for something being parsed.
+    await new WebhookProvider('https://hook.example').send({ ...base, newPrice: 49.99 });
+    expect((post.mock.calls[0][1] as any).currency).toBeNull();
+  });
+});
+
+describe('formatMoney', () => {
+  it('uses a symbol where one is recognised', () => {
+    expect(formatMoney(19.9, 'EUR')).toBe('€19.90');
+    expect(formatMoney(19.9, 'GBP')).toBe('£19.90');
+  });
+
+  it('uses the ISO code where none is', () => {
+    expect(formatMoney(19.9, 'CHF')).toBe('CHF 19.90');
+    expect(formatMoney(19.9, 'PLN')).toBe('PLN 19.90');
+  });
+
+  it('returns null for a missing amount, so callers can omit price entirely', () => {
+    expect(formatMoney(undefined, 'EUR')).toBeNull();
+    expect(formatMoney(null, 'EUR')).toBeNull();
+  });
+
+  it('treats zero as a real price', () => {
+    expect(formatMoney(0, 'EUR')).toBe('€0.00');
+  });
+
+  it('omits the currency rather than guessing one', () => {
+    expect(formatMoney(19.9)).toBe('19.90');
+  });
+});
+
+describe('describeEvent', () => {
+  it('gives every event its own title', () => {
+    const titles = NOTIFICATION_EVENT_TYPES.map(type => describeEvent({ ...base, type }).title);
+    expect(new Set(titles).size).toBe(NOTIFICATION_EVENT_TYPES.length);
+  });
+
+  it('does not mention price when there is none', () => {
+    const event = describeEvent({ ...base, type: 'back_in_stock' });
+    expect(event.headline).toBe('This item is now available');
+  });
+
+  it('names the previous status when one is known', () => {
+    const event = describeEvent({ ...base, oldStockStatus: 'member_only' });
+    expect(event.detail).toBe('Previously member only.');
+  });
+
+  it('says nothing about a previous status of unknown', () => {
+    expect(describeEvent({ ...base, oldStockStatus: 'unknown' }).detail).toBeUndefined();
+  });
+});
+
+describe('Telegram and product names containing markup characters', () => {
+  it('does not send the default message as HTML', async () => {
+    // Telegram rejects unescaped &, < and > in HTML parse mode with a 400, so
+    // every alert for a product named like this silently failed to arrive.
+    await new TelegramProvider('tok', 'chat').send({
+      ...base, productName: 'Sony WH-1000XM5 <Black> & Case',
+    });
+    const body = post.mock.calls[0][1] as any;
+    expect(body.parse_mode).toBeUndefined();
+    expect(body.text).toContain('Sony WH-1000XM5 <Black> & Case');
+  });
+
+  it('still honours HTML in a custom template, which is the user’s choice', async () => {
+    await new TelegramProvider('tok', 'chat', '<b>{{product_name}}</b>').send(base);
+    expect((post.mock.calls[0][1] as any).parse_mode).toBe('HTML');
+  });
+});

--- a/backend/tests/unit/stock-notifications.test.ts
+++ b/backend/tests/unit/stock-notifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { interpolateTemplate } from '../../src/services/notifications/utils';
 import type { NotificationPayload } from '../../src/services/notifications/types';
+import { isBackInStockFrom } from '../../src/services/domain/product/ProductRefreshService';
 
 const base: NotificationPayload = {
   productName: 'WaveShare POE USB-C Splitter',
@@ -58,5 +59,31 @@ describe('Notification templates', () => {
     expect(
       interpolateTemplate('{{product_name}} fell from {{old_price}} to {{current_price}} {{currency}}', payload)
     ).toBe('WaveShare POE USB-C Splitter fell from 49.99 to 39.99 AUD');
+  });
+});
+
+describe('what counts as coming back in stock', () => {
+  it('includes every status where the item existed but could not be bought', () => {
+    // member_only was missing (issue #92). From the user's side it is the same
+    // event as the rest of this list: the item was there, they could not buy
+    // it, and now they can.
+    expect(isBackInStockFrom('out_of_stock')).toBe(true);
+    expect(isBackInStockFrom('pre_order')).toBe(true);
+    expect(isBackInStockFrom('not_available')).toBe(true);
+    expect(isBackInStockFrom('member_only')).toBe(true);
+  });
+
+  it('excludes unknown, which is an absence of information rather than a state', () => {
+    // Otherwise the first successful scrape after any parse failure announces
+    // "back in stock" for a product that was in stock the whole time.
+    expect(isBackInStockFrom('unknown')).toBe(false);
+  });
+
+  it('excludes a product that has never had a status', () => {
+    expect(isBackInStockFrom(null)).toBe(false);
+  });
+
+  it('does not fire on a product that was already in stock', () => {
+    expect(isBackInStockFrom('in_stock')).toBe(false);
   });
 });

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.css
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.css
@@ -252,6 +252,27 @@
   cursor: help;
 }
 
+/*
+ * A channel that was tried and failed. Colour alone would not carry this --
+ * the strikethrough is what makes "we tried and could not reach it" readable
+ * without hovering for the tooltip.
+ */
+.channel-badge-failed {
+  color: var(--danger, #ef4444);
+  opacity: 0.7;
+  position: relative;
+}
+
+.channel-badge-failed::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  border-top: 1.5px solid currentColor;
+  transform: rotate(-20deg);
+}
+
 .notification-date {
   font-size: 0.8125rem;
   color: var(--text-muted);

--- a/frontend/src/features/notifications/pages/NotificationTable.tsx
+++ b/frontend/src/features/notifications/pages/NotificationTable.tsx
@@ -50,6 +50,10 @@ const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, lo
         const currency = notification.data?.currency;
         const priceChangePercent = notification.data?.priceChangePercent || notification.data?.price_change_percent;
         const channelsNotified = notification.data?.channelsNotified || notification.data?.channels_notified || [];
+        // A notification is now recorded whether or not it was delivered, so
+        // "no channels" and "every channel failed" are different rows and must
+        // not both read as "Internal Only" (issue #92).
+        const channelsFailed = notification.data?.channelsFailed || notification.data?.channels_failed || [];
 
         return (
           <div key={notification.id} className={`notification-row ${!notification.is_read ? 'unread' : ''}`}>
@@ -113,13 +117,21 @@ const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, lo
             </div>
 
             <div className="notification-channels">
-              {channelsNotified.length > 0 ? (
-                channelsNotified.map((channel: string) => (
-                  <span key={channel} className="channel-badge" title={channel}>
-                    <Icon name={getChannelIcon(channel)} />
-                  </span>
-                ))
-              ) : (
+              {channelsNotified.map((channel: string) => (
+                <span key={channel} className="channel-badge" title={channel}>
+                  <Icon name={getChannelIcon(channel)} />
+                </span>
+              ))}
+              {channelsFailed.map((channel: string) => (
+                <span
+                  key={`failed-${channel}`}
+                  className="channel-badge channel-badge-failed"
+                  title={`${channel} delivery failed`}
+                >
+                  <Icon name={getChannelIcon(channel)} />
+                </span>
+              ))}
+              {channelsNotified.length === 0 && channelsFailed.length === 0 && (
                 <span className="text-muted" style={{ fontSize: '0.75rem' }}>Internal Only</span>
               )}
             </div>

--- a/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
+++ b/frontend/src/features/settings/pages/NotificationChannelsSection.tsx
@@ -8,8 +8,21 @@ import { queryClient } from '../../../api/queryClient';
 import { notificationSettingsQuery, queryKeys } from '../../../api/queries';
 import { NotificationSettings } from '../../../types/api';
 
-const DEFAULT_EMAIL_SUBJECT = 'PriceStalker Alert: {{product_name}}';
-const DEFAULT_EMAIL_BODY = 'Hi,\n\n{{product_name}} has dropped to {{current_price}}!\n\nView it here: {{product_url}}';
+/*
+ * Shown as placeholder text, not prefilled into the fields (issue #92).
+ *
+ * These used to be the fields' initial values, so a user who opened this page
+ * and pressed Save -- without ever intending to write a template -- stored
+ * "{{product_name}} has dropped to {{current_price}}!" and received that
+ * sentence for every event thereafter, including a product coming back in
+ * stock and a product going missing.
+ *
+ * Left empty, the backend picks wording that matches the event. A template the
+ * user actually types still wins, always: the variables to make one
+ * event-aware are listed under the field.
+ */
+const EMAIL_SUBJECT_PLACEHOLDER = 'Leave empty for wording that matches each event';
+const EMAIL_BODY_PLACEHOLDER = 'Leave empty for wording that matches each event, or write your own:\n\n{{product_name}}\n{{type}}: {{price}}\n{{product_url}}';
 
 interface ChannelSettings {
   telegram_bot_token: string;
@@ -52,7 +65,7 @@ export default function NotificationChannelsSection() {
     pushover_user_key: '', pushover_app_token: '', pushover_enabled: false, pushover_message_template: '',
     ntfy_server_url: '', ntfy_topic: '', ntfy_password: '', ntfy_enabled: false, ntfy_message_template: '',
     gotify_url: '', gotify_app_token: '', gotify_enabled: false, gotify_message_template: '',
-    email_enabled: false, email_to: '', email_subject_template: DEFAULT_EMAIL_SUBJECT, email_body_template: DEFAULT_EMAIL_BODY,
+    email_enabled: false, email_to: '', email_subject_template: '', email_body_template: '',
     webhook_url: '', webhook_enabled: false
   });
 
@@ -93,8 +106,8 @@ export default function NotificationChannelsSection() {
         gotify_message_template: s.gotify_message_template || '',
         email_enabled: !!s.email_enabled,
         email_to: s.email_to || '',
-        email_subject_template: s.email_subject_template || DEFAULT_EMAIL_SUBJECT,
-        email_body_template: s.email_body_template || DEFAULT_EMAIL_BODY,
+        email_subject_template: s.email_subject_template || '',
+        email_body_template: s.email_body_template || '',
         webhook_url: s.webhook_url || '',
         webhook_enabled: !!s.webhook_enabled
       });
@@ -142,7 +155,13 @@ export default function NotificationChannelsSection() {
 
   const renderTemplateHelp = () => (
     <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginTop: '0.5rem', padding: '0.5rem', background: 'var(--background)', borderRadius: '0.25rem' }}>
-      <strong>Available Tags:</strong> <code>{"{{product_name}}"}</code>, <code>{"{{product_url}}"}</code>, <code>{"{{old_price}}"}</code>, <code>{"{{current_price}}"}</code>, <code>{"{{currency}}"}</code>, <code>{"{{product_id}}"}</code>, <code>{"{{type}}"}</code>, <code>{"{{old_stock_status}}"}</code>, <code>{"{{new_stock_status}}"}</code>
+      <strong>Available Tags:</strong> <code>{"{{product_name}}"}</code>, <code>{"{{product_url}}"}</code>, <code>{"{{old_price}}"}</code>, <code>{"{{current_price}}"}</code>, <code>{"{{price}}"}</code>, <code>{"{{currency}}"}</code>, <code>{"{{product_id}}"}</code>, <code>{"{{type}}"}</code>, <code>{"{{old_stock_status}}"}</code>, <code>{"{{new_stock_status}}"}</code>, <code>{"{{reason}}"}</code>
+      <div style={{ marginTop: '0.375rem' }}>
+        One template covers every event, so wording it around a price drop will read
+        oddly on a back-in-stock or unavailable alert. Use <code>{"{{type}}"}</code> and{' '}
+        <code>{"{{new_stock_status}}"}</code> to describe what happened, or leave the field
+        empty to get wording chosen per event.
+      </div>
     </div>
   );
 
@@ -299,11 +318,11 @@ export default function NotificationChannelsSection() {
           </div>
           <div className="form-group">
             <label>Subject Template</label>
-            <input type="text" className="form-control" value={draftSettings.email_subject_template} onChange={e => handleUpdateField('email_subject_template', e.target.value)} />
+            <input type="text" className="form-control" value={draftSettings.email_subject_template} onChange={e => handleUpdateField('email_subject_template', e.target.value)} placeholder={EMAIL_SUBJECT_PLACEHOLDER} />
           </div>
           <div className="form-group">
             <label>Body Template</label>
-            <textarea className="form-control" style={{ height: '120px', fontSize: '0.8rem' }} value={draftSettings.email_body_template} onChange={e => handleUpdateField('email_body_template', e.target.value)} />
+            <textarea className="form-control" style={{ height: '120px', fontSize: '0.8rem' }} value={draftSettings.email_body_template} onChange={e => handleUpdateField('email_body_template', e.target.value)} placeholder={EMAIL_BODY_PLACEHOLDER} />
             {renderTemplateHelp()}
           </div>
         </NotificationChannelCard>

--- a/frontend/src/utils/availability.ts
+++ b/frontend/src/utils/availability.ts
@@ -54,8 +54,13 @@ export function describeMonitoringState(product: {
   failure_streak?: number;
 }): string {
   if (product.checking_paused) {
+    // A paused product is excluded from scheduled refreshes, so nothing is
+    // watching for it to come back. The system resumes an auto-pause the moment
+    // a scrape succeeds -- but only a manual refresh can produce that scrape,
+    // so saying only "paused" leaves the user waiting for a recovery that will
+    // never arrive on its own (issue #92).
     return product.auto_paused
-      ? 'Paused automatically because the page could not be found'
+      ? 'Paused automatically because the page could not be found. Refresh it manually to check whether it is back'
       : 'Paused by you';
   }
   if (product.failure_streak && product.failure_streak > 0) {


### PR DESCRIPTION
Audits back-in-stock delivery as #92 asks. The transition itself fires correctly; what happens after it is wrong in seven places for one reason.

## The shared cause

Each of the seven providers carried its own `if/else` over the event type, and **every chain ended in an `else` meaning "back in stock"**. Fine when three events existed. Six exist now, so the same bug appeared independently in all seven:

| what happened | what the user got |
|---|---|
| product reachable again | **Telegram: nothing.** `formatDefaultMessage` returned `""`, the API rejects an empty `text` |
| product reachable again | Discord / Pushover / Gotify / ntfy: **"Back in Stock!"** — a different claim about a different thing |
| price announced on a pre-order | same, on every channel |
| retailer timed out, still retrying | **"Page no longer exists (404/410). Monitoring has been paused."** — wrong cause, and monitoring had *not* stopped |

The reason and the paused flag already existed — they just stopped at the in-app history, so the history and the Telegram message disagreed about the same event.

Wording now lives once in `services/notifications/events.ts`, and `describeEvent` is **exhaustive over the union**: adding a seventh event type is a compile error until it has wording. Providers choose presentation — an embed, a header, a priority — never meaning.

## Also in this path

**Telegram + `&` in a product name.** The default message was sent `parse_mode: HTML` unescaped, so any product named like `Sony WH-1000XM5 <Black> & Case` was rejected with a 400. HTML now applies only to a custom template, where the user may actually want tags.

**Invented currency.** `getCurrencySymbol` fell back to ``, rendering a CHF price as `$49.90`. `formatMoney` uses the ISO code where there is no recognised symbol, omits currency rather than guessing, returns `null` for a missing amount so callers can leave price out instead of saying "available at N/A", and treats **zero as a real price**.

**Webhook payload.** Carried `event: back_in_stock` with nothing about stock, and `currency: "USD"` for products whose currency was never resolved. Now carries the transition, target price, product id and reason, and reports an unresolved currency as `null` — a wrong value is worse than an absent one for something being parsed.

**The prefilled email template — the actual mechanism behind issue point 2.** The settings form prefilled both fields with `{{product_name}} has dropped to {{current_price}}!`. Opening Notification Channels to configure *any other channel* and pressing Save stored it, and a configured template correctly wins over the per-event defaults — so every alert thereafter claimed a price drop. The prefill is now placeholder text, and **migration 018** clears the stored value only where it is byte-identical to the old prefill.

**`member_only` → `in_stock`** now counts as back in stock. Same event from the user's side: the item was there, they could not buy it, now they can. `unknown` stays out deliberately — it is an absence of information, not a state, and treating it as a transition would fire "back in stock" on the first successful scrape after any parse failure.

**History is a record, not a delivery receipt** (issue point 5, decided). It was written only if an external channel succeeded, so an install with **no channels configured — the state every install starts in — had no notification history at all**, and when every channel failed the one record that would have explained the silence was the record that was skipped. Delivery outcome is kept alongside; failed channels render struck through.

**Concurrency** (issue point 8). The decision compared against a snapshot read before the scrape and outside the advisory lock, so two concurrent refreshes both saw `out_of_stock` and both alerted. `saveScrapeResult` now returns the transition it applied *under the lock*; only the refresh that wrote the change notifies.

## Issue points not changed

**Point 7** (paused products are not watched for recovery) was already covered by the #73 lifecycle work — `describeMonitoringState` reports an automatic pause distinctly. Extended here to say what the user must actually do, since a paused product is excluded from scheduled refreshes and only a manual refresh can produce the scrape that resumes it.

## Verification

**417 backend tests, up from 260.** The new matrix runs every provider against every event and the price / currency / previous-status cases the issue lists, asserting nothing empty, nothing reading "back in stock" for another event, no `undefined`, no invented dollar sign. Reintroducing the old fallthrough fails 9 of them.

Migration 018 against PostgreSQL 16 — all four cases exact, and a no-op on a second run:

```
--- before ---
  never-chose@x   subject="PriceStalker Alert: {{product_name}}"   body="Hi,\n\n{{product_name}} has droppe..."
  edited-body@x   subject="PriceStalker Alert: {{product_name}}"   body="My own wording: {{product_name}} -..."
  nearly@x        subject="PriceStalker Alert: {{product_name}}!"  body="Hi,\n\n... {{product_url}} "   (trailing space)
  untouched@x     subject=NULL                                     body=NULL
--- after ---
  never-chose@x   subject=NULL                                     body=NULL            <- both cleared
  edited-body@x   subject=NULL                                     body="My own wording..."  <- theirs kept
  nearly@x        subject="PriceStalker Alert: {{product_name}}!"  body="Hi,\n\n..."     <- one char different, kept
  untouched@x     subject=NULL                                     body=NULL
```

`tsc`, frontend build, emoji lint, `git diff --check` all pass.

Closes #92