### PR TITLE
fix(scraper): stop announcing two different browsers in one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The scraper no longer announces two different browsers in the same request.
+  The `User-Agent` came from the Default User-Agent setting (seeded as Chrome
+  146) while the `Sec-CH-UA` client hints were hardcoded to Chrome 121 on
+  Windows, so every request from every install described a browser that cannot
+  exist. Client hints are now derived from whichever User-Agent is in play,
+  including a per-retailer override, and are omitted entirely for Firefox and
+  Safari, which do not send them.
+- The browser scraper now presents the same identity as the HTTP scraper. Both
+  remote calls passed no User-Agent at all, so a retailer that had just been
+  shown the configured browser saw headless Chromium on the fallback.
+- Overriding the User-Agent in the browser scraper now sets matching client-hint
+  metadata, instead of leaving Chrome reporting its own build in the hints.
+
+### Fixed
+
 - Notifications now describe the event that actually happened on every channel.
   A product becoming reachable again was announced as "Back in Stock!" on
   Discord, Pushover, Gotify and ntfy, and was never delivered to Telegram at

--- a/backend/src/services/scraper/acquisition/fallback.ts
+++ b/backend/src/services/scraper/acquisition/fallback.ts
@@ -4,7 +4,8 @@ import { settingsCache } from '../../../utils/cache';
 import { 
   detectBotChallenge, 
   fetchRemoteHtml, 
-  fetchBrowserHtml
+  fetchBrowserHtml,
+  resolveUserAgent
 } from '../transport';
 
 export interface FallbackOptions {
@@ -13,6 +14,8 @@ export interface FallbackOptions {
   productId?: number;
   extractionSteps: string[];
   challengeReason: string;
+  /** The retailer's User-Agent override, if it has one. */
+  userAgent?: string | null;
 }
 
 export interface FallbackResult {
@@ -23,7 +26,7 @@ export interface FallbackResult {
 }
 
 export async function handleAcquisitionFallback(options: FallbackOptions): Promise<FallbackResult | null> {
-  const { url, domain, productId, extractionSteps, challengeReason } = options;
+  const { url, domain, productId, extractionSteps, challengeReason, userAgent } = options;
   
   logger.warn(`Scraper | Block | ${challengeReason} detected. Triggering fallback for ${domain}`, 'Scraper', { product_id: productId });
   extractionSteps.push(`Scraper | Fallback | Triggered by ${challengeReason}`);
@@ -37,7 +40,11 @@ export async function handleAcquisitionFallback(options: FallbackOptions): Promi
   if (rsUrl) {
     try {
       const isDiscovery = !productId;
-      const remoteOptions: any = { productId, isDiscovery };
+      // The same identity the HTTP attempt just used. Both remote calls used to
+      // omit it entirely, so the fallback presented a different browser -- and
+      // headless Chromium's own -- to a retailer that had just been shown the
+      // configured one.
+      const remoteOptions: any = { productId, isDiscovery, userAgent: await resolveUserAgent(userAgent) };
       // Referrer policy: system default or none — never a fabricated random
       // one (issue #44).
       const defaultReferrer = await settingsCache.getDefaultReferrer();
@@ -58,7 +65,7 @@ export async function handleAcquisitionFallback(options: FallbackOptions): Promi
   } else {
     try {
       logger.warn(`Scraper | Fallback | Local browser fallback for ${domain}`, 'Scraper', { product_id: productId });
-      html = await fetchBrowserHtml(url, undefined, undefined, undefined, productId);
+      html = await fetchBrowserHtml(url, await resolveUserAgent(userAgent), undefined, undefined, productId);
       if (html) logger.info(`Scraper | Fallback | Local success for ${domain}`, 'Scraper', { product_id: productId });
       extractionSteps.push(html ? `Scraper | Fallback | Local Success` : `Scraper | Fallback | Local Failed`);
       

--- a/backend/src/services/scraper/acquisition/index.ts
+++ b/backend/src/services/scraper/acquisition/index.ts
@@ -80,6 +80,9 @@ export async function acquireHtml(options: AcquisitionOptions): Promise<Acquisit
       productId,
       extractionSteps,
       challengeReason
+      // No retailer override to pass: this branch only runs when the domain has
+      // no config, so the system default is the right identity -- and is the
+      // one the HTTP attempt just used.
     });
 
     if (fallbackResult) {

--- a/backend/src/services/scraper/transport/headers.ts
+++ b/backend/src/services/scraper/transport/headers.ts
@@ -1,19 +1,62 @@
 import { settingsCache } from '../../../utils/cache';
+import { logger } from '../../../utils/system/logger';
+import { parseUserAgent, buildClientHintHeaders } from './user-agent';
 
+/**
+ * The fallback used when no User-Agent is configured.
+ *
+ * Kept in step with the seeded `default_user_agent`. Client hints are derived
+ * from whichever string wins, so the two can differ without producing a
+ * contradiction -- but there is no reason for them to.
+ */
+export const FALLBACK_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+
+/**
+ * The User-Agent this scrape will present: retailer override, then the system
+ * setting, then the fallback.
+ *
+ * Exported so the browser path resolves it the same way. It previously did not
+ * resolve one at all -- both remote calls passed `undefined` -- so a retailer
+ * that saw the configured Chrome on the first request saw whatever Chromium
+ * build happened to be in the scraper container on the fallback. Presenting two
+ * different browsers for one product is the same fault as presenting two
+ * different versions in one request.
+ */
+export async function resolveUserAgent(override?: string | null): Promise<string> {
+  return override || (await settingsCache.getDefaultUserAgent()) || FALLBACK_USER_AGENT;
+}
+
+/**
+ * Request headers for the plain HTTP scraper.
+ *
+ * Every header describing who is asking is derived from the User-Agent, so the
+ * request cannot claim to be two browsers at once. The client hints used to be
+ * hardcoded to Chrome 121 on Windows regardless of the configured UA -- see
+ * ./user-agent.ts for what that cost.
+ */
 export async function getHeaders(userAgent?: string): Promise<Record<string, string>> {
-  const ua = userAgent || await settingsCache.getDefaultUserAgent();
-  const headers: Record<string, string> = {
-    'User-Agent': ua || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+  const ua = await resolveUserAgent(userAgent);
+  const identity = parseUserAgent(ua);
+
+  if (identity.family === 'unknown') {
+    // Worth saying out loud: an unrecognised UA gets no client hints, which is
+    // correct but means a Chromium UA we failed to parse silently loses them.
+    logger.warn(
+      `Scraper | Headers | Could not identify the browser in the configured User-Agent, so no client hints will be sent: "${ua.slice(0, 120)}"`,
+      'Scraper'
+    );
+  }
+
+  return {
+    'User-Agent': ua,
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
     'Accept-Language': 'en-US,en;q=0.9',
-    'Sec-Ch-Ua': '"Not A(Brand";v="99", "Google Chrome";v="121", "Chromium";v="121"',
-    'Sec-Ch-Ua-Mobile': '?0',
-    'Sec-Ch-Ua-Platform': '"Windows"',
+    ...buildClientHintHeaders(identity),
     'Sec-Fetch-Dest': 'document',
     'Sec-Fetch-Mode': 'navigate',
     'Sec-Fetch-Site': 'none',
     'Sec-Fetch-User': '?1',
     'Upgrade-Insecure-Requests': '1',
   };
-  return headers;
 }

--- a/backend/src/services/scraper/transport/index.ts
+++ b/backend/src/services/scraper/transport/index.ts
@@ -1,4 +1,5 @@
 export * from './headers';
+export * from './user-agent';
 export * from './detection';
 export * from './errors';
 export * from './remote';

--- a/backend/src/services/scraper/transport/user-agent.ts
+++ b/backend/src/services/scraper/transport/user-agent.ts
@@ -1,0 +1,204 @@
+/**
+ * Derives a request identity from one User-Agent string (issues #67, #68).
+ *
+ * The headers used to be half configurable and half hardcoded:
+ *
+ *   User-Agent  <- system setting `default_user_agent`, or a retailer override
+ *   Sec-Ch-Ua   <- the literal string '"Google Chrome";v="121"', always
+ *
+ * The seeded default is Chrome 146. So out of the box, every request announced
+ * Chrome 146 in the User-Agent and Chrome 121 in the client hints -- a
+ * twenty-five version contradiction that no real browser can produce, sent to
+ * every retailer on every scrape. Amazon's WAF answered it with a challenge
+ * page served as HTTP 200, which is why extraction found no price and
+ * auto-mapping then rejected the config it generated from challenge HTML.
+ *
+ * The reporter confirmed this from the other end: setting the User-Agent to
+ * Chrome 121 on Windows fixed amazon.com.au. That is the one string that
+ * happens to agree with the hardcoded hints, which is the proof rather than a
+ * coincidence.
+ *
+ * A per-retailer `user_agent` override was worse still: it got the same
+ * hardcoded Chrome-on-Windows hints, so configuring a Safari or Android UA for
+ * a retailer produced a browser that has never existed.
+ *
+ * Everything is now derived from the one string, and a UA whose brand does not
+ * support client hints gets none -- inventing them for Firefox or Safari is
+ * itself the tell.
+ */
+
+export type BrandFamily = 'chrome' | 'edge' | 'opera' | 'firefox' | 'safari' | 'unknown';
+
+export interface UserAgentIdentity {
+  userAgent: string;
+  family: BrandFamily;
+  /** Major version, as a string because that is what the hint carries. */
+  majorVersion: string | null;
+  /** The `Sec-CH-UA-Platform` value, quoted form without the quotes. */
+  platform: string;
+  mobile: boolean;
+  /** True when this browser actually sends User-Agent Client Hints. */
+  supportsClientHints: boolean;
+}
+
+/**
+ * A GREASE brand, as Chromium sends alongside the real ones.
+ *
+ * Chrome varies this deliberately to stop servers hardcoding the list. A fixed
+ * plausible value is fine here -- what matters is that the *versions* agree
+ * with the User-Agent, which is what was broken.
+ */
+const GREASE_BRAND = { brand: 'Not)A;Brand', version: '8' };
+
+function detectPlatform(ua: string): { platform: string; mobile: boolean } {
+  // Order matters: an Android UA also contains "Linux", and an iPad UA in
+  // desktop mode contains "Macintosh".
+  if (/Android/i.test(ua)) return { platform: 'Android', mobile: true };
+  if (/iPhone|iPod/i.test(ua)) return { platform: 'iOS', mobile: true };
+  if (/iPad/i.test(ua)) return { platform: 'iOS', mobile: false };
+  if (/CrOS/i.test(ua)) return { platform: 'Chrome OS', mobile: false };
+  if (/Windows/i.test(ua)) return { platform: 'Windows', mobile: false };
+  if (/Macintosh|Mac OS X/i.test(ua)) return { platform: 'macOS', mobile: false };
+  if (/Linux|X11/i.test(ua)) return { platform: 'Linux', mobile: false };
+  return { platform: 'Unknown', mobile: false };
+}
+
+function detectBrand(ua: string): { family: BrandFamily; majorVersion: string | null } {
+  // Checked before Chrome: every Chromium derivative also claims "Chrome".
+  const edge = ua.match(/Edg(?:e|A|iOS)?\/(\d+)/);
+  if (edge) return { family: 'edge', majorVersion: edge[1] };
+
+  const opera = ua.match(/OPR\/(\d+)/);
+  if (opera) return { family: 'opera', majorVersion: opera[1] };
+
+  const firefox = ua.match(/Firefox\/(\d+)/);
+  if (firefox) return { family: 'firefox', majorVersion: firefox[1] };
+
+  const chrome = ua.match(/Chrome\/(\d+)/);
+  if (chrome) return { family: 'chrome', majorVersion: chrome[1] };
+
+  // Safari last: Chrome and Edge UAs both end in a Safari token.
+  const safari = ua.match(/Version\/(\d+)[\d.]*\s+Safari\//);
+  if (safari) return { family: 'safari', majorVersion: safari[1] };
+
+  return { family: 'unknown', majorVersion: null };
+}
+
+export function parseUserAgent(userAgent: string): UserAgentIdentity {
+  const ua = userAgent.trim();
+  const { family, majorVersion } = detectBrand(ua);
+  const { platform, mobile } = detectPlatform(ua);
+
+  // Firefox and Safari do not implement User-Agent Client Hints. Sending them
+  // anyway announces a browser that cannot exist.
+  const isChromium = family === 'chrome' || family === 'edge' || family === 'opera';
+
+  return {
+    userAgent: ua,
+    family,
+    majorVersion,
+    platform,
+    mobile,
+    supportsClientHints: isChromium && majorVersion !== null,
+  };
+}
+
+/**
+ * The `Sec-CH-UA` brand list for an identity, or null where the browser sends
+ * none.
+ *
+ * Chromium lists the GREASE brand, "Chromium", and its own brand, all at the
+ * same major version -- which is exactly the agreement that was missing.
+ */
+export function buildBrandList(identity: UserAgentIdentity): string | null {
+  if (!identity.supportsClientHints || !identity.majorVersion) return null;
+
+  const v = identity.majorVersion;
+  const brands: { brand: string; version: string }[] = [
+    GREASE_BRAND,
+    { brand: 'Chromium', version: v },
+  ];
+
+  switch (identity.family) {
+    case 'chrome': brands.push({ brand: 'Google Chrome', version: v }); break;
+    case 'edge': brands.push({ brand: 'Microsoft Edge', version: v }); break;
+    case 'opera': brands.push({ brand: 'Opera', version: v }); break;
+    default: break;
+  }
+
+  return brands.map(b => `"${b.brand}";v="${b.version}"`).join(', ');
+}
+
+/**
+ * Client-hint headers consistent with the User-Agent, or none.
+ *
+ * Only the three low-entropy hints are sent. The rest -- architecture,
+ * platform version, full version list -- are only sent by a real browser after
+ * a server asks for them with `Accept-CH`, so volunteering them unprompted is
+ * another way to stand out.
+ */
+export function buildClientHintHeaders(identity: UserAgentIdentity): Record<string, string> {
+  const brands = buildBrandList(identity);
+  if (!brands) return {};
+
+  return {
+    'Sec-Ch-Ua': brands,
+    'Sec-Ch-Ua-Mobile': identity.mobile ? '?1' : '?0',
+    'Sec-Ch-Ua-Platform': `"${identity.platform}"`,
+  };
+}
+
+/**
+ * Puppeteer's `userAgentMetadata`, so an overridden UA in the browser scraper
+ * carries matching client hints.
+ *
+ * Without it, `page.setUserAgent(ua)` changes the string while Chrome keeps
+ * emitting hints from its own build -- the same contradiction the HTTP path
+ * had, arrived at from the other direction.
+ */
+export function buildUserAgentMetadata(identity: UserAgentIdentity) {
+  if (!identity.supportsClientHints || !identity.majorVersion) return undefined;
+
+  const v = identity.majorVersion;
+  const brands = [GREASE_BRAND, { brand: 'Chromium', version: v }];
+  if (identity.family === 'chrome') brands.push({ brand: 'Google Chrome', version: v });
+  if (identity.family === 'edge') brands.push({ brand: 'Microsoft Edge', version: v });
+  if (identity.family === 'opera') brands.push({ brand: 'Opera', version: v });
+
+  return {
+    brands,
+    fullVersion: `${v}.0.0.0`,
+    platform: identity.platform,
+    platformVersion: platformVersionFor(identity),
+    architecture: identity.mobile ? '' : 'x86',
+    model: '',
+    mobile: identity.mobile,
+  };
+}
+
+/**
+ * A platform version consistent with the UA string.
+ *
+ * Only used for the browser path's metadata, where Chrome will answer an
+ * `Accept-CH` request for it. A blank value where we cannot tell is better
+ * than a confident wrong one.
+ */
+function platformVersionFor(identity: UserAgentIdentity): string {
+  const ua = identity.userAgent;
+
+  const windows = ua.match(/Windows NT (\d+\.\d+)/);
+  if (windows) {
+    // Chrome reports Windows 10 and 11 as platform versions 10.0 and 13.0+
+    // respectively, both behind "Windows NT 10.0" in the UA. 10.0 is the safe
+    // reading of that string.
+    return windows[1] === '10.0' ? '10.0.0' : `${windows[1]}.0`;
+  }
+
+  const mac = ua.match(/Mac OS X (\d+)[._](\d+)(?:[._](\d+))?/);
+  if (mac) return `${mac[1]}.${mac[2]}.${mac[3] || '0'}`;
+
+  const android = ua.match(/Android (\d+(?:\.\d+)*)/);
+  if (android) return android[1];
+
+  return '';
+}

--- a/backend/tests/unit/scraper-headers.test.ts
+++ b/backend/tests/unit/scraper-headers.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getDefaultUserAgent = vi.fn<[], Promise<string | null>>();
+
+vi.mock('../../src/utils/cache', () => ({
+  settingsCache: {
+    getDefaultUserAgent: () => getDefaultUserAgent(),
+    get: vi.fn(),
+    getScraperProxy: vi.fn(),
+    getRemoteScraperUrl: vi.fn(),
+    getDefaultReferrer: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/utils/system/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { getHeaders, resolveUserAgent, FALLBACK_USER_AGENT } from '../../src/services/scraper/transport/headers';
+import { logger } from '../../src/utils/system/logger';
+
+/** The value migration 006 seeds into `default_user_agent`. */
+const SEEDED_DEFAULT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+
+/** Reads back the version each of the two halves of the request claims. */
+function claimedVersions(headers: Record<string, string>) {
+  return {
+    fromUserAgent: headers['User-Agent'].match(/Chrom(?:e|ium)\/(\d+)/)?.[1] ?? null,
+    fromHints: headers['Sec-Ch-Ua']?.match(/"Chromium";v="(\d+)"/)?.[1] ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDefaultUserAgent.mockResolvedValue(SEEDED_DEFAULT);
+});
+
+describe('getHeaders', () => {
+  it('does not announce two different browsers in one request', async () => {
+    // The bug, stated as a test. The seeded default is Chrome 146 and the
+    // hints were hardcoded to Chrome 121, on every request of every install.
+    const { fromUserAgent, fromHints } = claimedVersions(await getHeaders());
+    expect(fromUserAgent).toBe('146');
+    expect(fromHints).toBe(fromUserAgent);
+  });
+
+  it('follows a retailer override with its hints', async () => {
+    // A per-retailer user_agent used to receive the same hardcoded
+    // Chrome-on-Windows hints, so configuring a Mac UA for one retailer
+    // produced a browser that has never existed.
+    const headers = await getHeaders(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'
+    );
+    expect(claimedVersions(headers)).toEqual({ fromUserAgent: '133', fromHints: '133' });
+    expect(headers['Sec-Ch-Ua-Platform']).toBe('"macOS"');
+  });
+
+  it('sends no client hints for a Firefox override', async () => {
+    // Rather than describing a Firefox that ships Chromium's hints.
+    const headers = await getHeaders('Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0');
+    expect(headers['Sec-Ch-Ua']).toBeUndefined();
+    expect(headers['Sec-Ch-Ua-Mobile']).toBeUndefined();
+    expect(headers['Sec-Ch-Ua-Platform']).toBeUndefined();
+    expect(headers['User-Agent']).toContain('Firefox/129.0');
+  });
+
+  it('still sends the fetch metadata every browser sends', async () => {
+    const headers = await getHeaders();
+    expect(headers['Sec-Fetch-Dest']).toBe('document');
+    expect(headers['Sec-Fetch-Mode']).toBe('navigate');
+    expect(headers['Upgrade-Insecure-Requests']).toBe('1');
+  });
+
+  it('falls back to a self-consistent User-Agent when nothing is configured', async () => {
+    getDefaultUserAgent.mockResolvedValue(null);
+    const { fromUserAgent, fromHints } = claimedVersions(await getHeaders());
+    expect(fromUserAgent).toBe(fromHints);
+  });
+
+  it('says so when it cannot identify the configured browser', async () => {
+    // Silently dropping the hints for a UA we failed to parse would look like
+    // the headers were simply fine.
+    getDefaultUserAgent.mockResolvedValue('some-internal-crawler/1.0');
+    const headers = await getHeaders();
+    expect(headers['Sec-Ch-Ua']).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not identify the browser'),
+      'Scraper'
+    );
+  });
+});
+
+describe('resolveUserAgent', () => {
+  it('prefers a retailer override', async () => {
+    await expect(resolveUserAgent('custom/1.0')).resolves.toBe('custom/1.0');
+  });
+
+  it('falls back to the system setting, then to the built-in', async () => {
+    await expect(resolveUserAgent()).resolves.toBe(SEEDED_DEFAULT);
+    getDefaultUserAgent.mockResolvedValue(null);
+    await expect(resolveUserAgent()).resolves.toBe(FALLBACK_USER_AGENT);
+  });
+
+  it('gives the browser path the same identity as the HTTP path', async () => {
+    // Both remote calls used to pass undefined, so a retailer that had just
+    // seen the configured Chrome saw headless Chromium on the fallback.
+    const httpUa = (await getHeaders())['User-Agent'];
+    await expect(resolveUserAgent()).resolves.toBe(httpUa);
+  });
+});

--- a/backend/tests/unit/scraper-identity.test.ts
+++ b/backend/tests/unit/scraper-identity.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  parseUserAgent,
+  buildBrandList,
+  buildClientHintHeaders,
+  buildUserAgentMetadata,
+} from '../../src/services/scraper/transport/user-agent';
+
+/**
+ * The scrape used to announce two different browsers in one request: the
+ * User-Agent came from a setting (seeded as Chrome 146) while Sec-Ch-Ua was
+ * hardcoded to Chrome 121 on Windows. No real browser can produce that, and
+ * Amazon's WAF answered it with a challenge page served as HTTP 200 -- which is
+ * why extraction found no price and auto-mapping rejected the config it had
+ * generated from challenge HTML (issues #67, #68).
+ *
+ * The reporter confirmed it from the other side: setting the User-Agent to
+ * Chrome 121 on Windows fixed amazon.com.au, that being the one string which
+ * agrees with the hardcoded hints.
+ */
+
+const CHROME_146_WIN = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+const CHROME_121_WIN = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36';
+const CHROME_MAC = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+const CHROME_ANDROID = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Mobile Safari/537.36';
+const EDGE_WIN = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0';
+const FIREFOX_WIN = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0';
+const SAFARI_MAC = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15';
+const SAFARI_IPHONE = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1';
+
+/** The major version a Sec-Ch-Ua brand list claims for Chromium. */
+function hintVersion(brands: string | null): string | null {
+  const m = brands?.match(/"Chromium";v="(\d+)"/);
+  return m ? m[1] : null;
+}
+
+describe('the invariant that was broken', () => {
+  const chromiumAgents = [CHROME_146_WIN, CHROME_121_WIN, CHROME_MAC, CHROME_ANDROID, EDGE_WIN];
+
+  it.each(chromiumAgents)('client hints report the same version as the User-Agent: %s', (ua) => {
+    // This single assertion is the whole bug. The old headers hardcoded 121
+    // while the seeded UA said 146.
+    const uaVersion = ua.match(/Chrom(?:e|ium)\/(\d+)/)![1];
+    expect(hintVersion(buildBrandList(parseUserAgent(ua)))).toBe(uaVersion);
+  });
+
+  it('would have failed against the old hardcoded header', () => {
+    // The literal string that used to ship, checked against the seeded default.
+    const wasHardcoded = '"Not A(Brand";v="99", "Google Chrome";v="121", "Chromium";v="121"';
+    expect(hintVersion(wasHardcoded)).toBe('121');
+    expect(hintVersion(buildBrandList(parseUserAgent(CHROME_146_WIN)))).toBe('146');
+  });
+});
+
+describe('brand detection', () => {
+  it('reads Chrome', () => {
+    const id = parseUserAgent(CHROME_146_WIN);
+    expect(id.family).toBe('chrome');
+    expect(id.majorVersion).toBe('146');
+  });
+
+  it('reads Edge rather than the Chrome token it also carries', () => {
+    // Every Chromium derivative claims "Chrome" too, so order of checks matters.
+    const id = parseUserAgent(EDGE_WIN);
+    expect(id.family).toBe('edge');
+    expect(id.majorVersion).toBe('138');
+  });
+
+  it('reads Firefox', () => {
+    expect(parseUserAgent(FIREFOX_WIN).family).toBe('firefox');
+  });
+
+  it('reads Safari rather than the Safari token Chrome also carries', () => {
+    expect(parseUserAgent(SAFARI_MAC).family).toBe('safari');
+    expect(parseUserAgent(CHROME_146_WIN).family).toBe('chrome');
+  });
+
+  it('does not guess at something it cannot identify', () => {
+    const id = parseUserAgent('curl/8.4.0');
+    expect(id.family).toBe('unknown');
+    expect(id.supportsClientHints).toBe(false);
+  });
+});
+
+describe('platform detection', () => {
+  it.each([
+    [CHROME_146_WIN, 'Windows', false],
+    [CHROME_MAC, 'macOS', false],
+    [CHROME_ANDROID, 'Android', true],
+    [SAFARI_IPHONE, 'iOS', true],
+  ])('reads %s as %s', (ua, platform, mobile) => {
+    const id = parseUserAgent(ua);
+    expect(id.platform).toBe(platform);
+    expect(id.mobile).toBe(mobile);
+  });
+
+  it('reads Android before Linux, which the same string also contains', () => {
+    expect(parseUserAgent(CHROME_ANDROID).platform).toBe('Android');
+  });
+});
+
+describe('which browsers get client hints at all', () => {
+  it('gives them to Chromium', () => {
+    expect(parseUserAgent(CHROME_146_WIN).supportsClientHints).toBe(true);
+    expect(parseUserAgent(EDGE_WIN).supportsClientHints).toBe(true);
+  });
+
+  it('withholds them from Firefox and Safari, which do not send them', () => {
+    // Sending Sec-Ch-Ua alongside a Firefox User-Agent describes a browser that
+    // does not exist -- a stronger signal than sending nothing.
+    expect(parseUserAgent(FIREFOX_WIN).supportsClientHints).toBe(false);
+    expect(parseUserAgent(SAFARI_MAC).supportsClientHints).toBe(false);
+    expect(buildClientHintHeaders(parseUserAgent(FIREFOX_WIN))).toEqual({});
+    expect(buildClientHintHeaders(parseUserAgent(SAFARI_MAC))).toEqual({});
+  });
+});
+
+describe('the header set', () => {
+  it('names the brand matching the User-Agent', () => {
+    expect(buildBrandList(parseUserAgent(CHROME_146_WIN))).toContain('"Google Chrome";v="146"');
+    expect(buildBrandList(parseUserAgent(EDGE_WIN))).toContain('"Microsoft Edge";v="138"');
+    expect(buildBrandList(parseUserAgent(EDGE_WIN))).not.toContain('Google Chrome');
+  });
+
+  it('agrees with the User-Agent about the platform', () => {
+    expect(buildClientHintHeaders(parseUserAgent(CHROME_MAC))['Sec-Ch-Ua-Platform']).toBe('"macOS"');
+    expect(buildClientHintHeaders(parseUserAgent(CHROME_146_WIN))['Sec-Ch-Ua-Platform']).toBe('"Windows"');
+  });
+
+  it('agrees with the User-Agent about mobile', () => {
+    expect(buildClientHintHeaders(parseUserAgent(CHROME_ANDROID))['Sec-Ch-Ua-Mobile']).toBe('?1');
+    expect(buildClientHintHeaders(parseUserAgent(CHROME_146_WIN))['Sec-Ch-Ua-Mobile']).toBe('?0');
+  });
+
+  it('sends only the three low-entropy hints', () => {
+    // A real browser sends architecture, platform version and full version list
+    // only after a server asks with Accept-CH. Volunteering them is another way
+    // to stand out.
+    expect(Object.keys(buildClientHintHeaders(parseUserAgent(CHROME_146_WIN))).sort())
+      .toEqual(['Sec-Ch-Ua', 'Sec-Ch-Ua-Mobile', 'Sec-Ch-Ua-Platform']);
+  });
+});
+
+describe('Puppeteer metadata', () => {
+  it('matches the User-Agent it accompanies', () => {
+    const meta = buildUserAgentMetadata(parseUserAgent(CHROME_MAC))!;
+    expect(meta.mobile).toBe(false);
+    expect(meta.platform).toBe('macOS');
+    expect(meta.platformVersion).toBe('10.15.7');
+    expect(meta.brands).toContainEqual({ brand: 'Google Chrome', version: '140' });
+    expect(meta.fullVersion).toBe('140.0.0.0');
+  });
+
+  it('reads an Android platform version', () => {
+    expect(buildUserAgentMetadata(parseUserAgent(CHROME_ANDROID))!.platformVersion).toBe('14');
+  });
+
+  it('is withheld where the browser sends no hints, so the bare string is used', () => {
+    expect(buildUserAgentMetadata(parseUserAgent(FIREFOX_WIN))).toBeUndefined();
+    expect(buildUserAgentMetadata(parseUserAgent(SAFARI_MAC))).toBeUndefined();
+  });
+});

--- a/scraper/src/services/ScraperService.ts
+++ b/scraper/src/services/ScraperService.ts
@@ -2,6 +2,7 @@ import { log } from '../utils/logger.js';
 import { performHumanLikeActions } from '../core/Actions.js';
 import type { BrowserSession, ScrapeOptions, ScrapeResult, ScraperPage } from '../types.js';
 import { errorMessage } from '../types.js';
+import { parseUserAgent, buildUserAgentMetadata } from '../utils/userAgent.js';
 
 export class ScraperService {
   /**
@@ -61,7 +62,21 @@ export class ScraperService {
 
       if (options.userAgent) {
         if (context.forceDebug) log(`Applying User-Agent: ${options.userAgent}`, 'DEBUG', context);
-        await page.setUserAgent(options.userAgent);
+        // The metadata is what keeps Sec-CH-UA in step with the string. Calling
+        // setUserAgent with the string alone leaves Chrome reporting its own
+        // build in the client hints, so the page announces one browser in the
+        // User-Agent and another in the hints -- and overrides the coordinated
+        // override the stealth plugin had already set up.
+        const identity = parseUserAgent(options.userAgent);
+        const metadata = buildUserAgentMetadata(identity);
+        if (metadata) {
+          await page.setUserAgent(options.userAgent, metadata);
+        } else {
+          // Firefox and Safari send no client hints, so there is nothing to
+          // keep in step and the bare string is correct.
+          if (context.forceDebug) log(`No client hints for ${identity.family} UA`, 'DEBUG', context);
+          await page.setUserAgent(options.userAgent);
+        }
       }
 
       if (options.referrer) {

--- a/scraper/src/utils/userAgent.ts
+++ b/scraper/src/utils/userAgent.ts
@@ -1,0 +1,190 @@
+/**
+ * Derives Chrome's User-Agent Client Hint metadata from a User-Agent string.
+ *
+ * Duplicated from backend/src/services/scraper/transport/user-agent.ts rather
+ * than shared, because the two workspaces have no common package. Keep them in
+ * step: the whole point is that the backend and the browser scraper present the
+ * same identity for the same retailer.
+ *
+ * Why this exists: `page.setUserAgent(ua)` replaces the UA string but leaves
+ * Chrome emitting Sec-CH-UA headers from its own build, so overriding the UA
+ * without metadata announces one browser in the User-Agent and a different one
+ * in the client hints -- which is exactly the mismatch that had amazon.com.au
+ * serving a challenge page (issues #67, #68).
+ */
+
+export type BrandFamily = 'chrome' | 'edge' | 'opera' | 'firefox' | 'safari' | 'unknown';
+
+export interface UserAgentIdentity {
+  userAgent: string;
+  family: BrandFamily;
+  /** Major version, as a string because that is what the hint carries. */
+  majorVersion: string | null;
+  /** The `Sec-CH-UA-Platform` value, quoted form without the quotes. */
+  platform: string;
+  mobile: boolean;
+  /** True when this browser actually sends User-Agent Client Hints. */
+  supportsClientHints: boolean;
+}
+
+/**
+ * A GREASE brand, as Chromium sends alongside the real ones.
+ *
+ * Chrome varies this deliberately to stop servers hardcoding the list. A fixed
+ * plausible value is fine here -- what matters is that the *versions* agree
+ * with the User-Agent, which is what was broken.
+ */
+const GREASE_BRAND = { brand: 'Not)A;Brand', version: '8' };
+
+function detectPlatform(ua: string): { platform: string; mobile: boolean } {
+  // Order matters: an Android UA also contains "Linux", and an iPad UA in
+  // desktop mode contains "Macintosh".
+  if (/Android/i.test(ua)) return { platform: 'Android', mobile: true };
+  if (/iPhone|iPod/i.test(ua)) return { platform: 'iOS', mobile: true };
+  if (/iPad/i.test(ua)) return { platform: 'iOS', mobile: false };
+  if (/CrOS/i.test(ua)) return { platform: 'Chrome OS', mobile: false };
+  if (/Windows/i.test(ua)) return { platform: 'Windows', mobile: false };
+  if (/Macintosh|Mac OS X/i.test(ua)) return { platform: 'macOS', mobile: false };
+  if (/Linux|X11/i.test(ua)) return { platform: 'Linux', mobile: false };
+  return { platform: 'Unknown', mobile: false };
+}
+
+function detectBrand(ua: string): { family: BrandFamily; majorVersion: string | null } {
+  // Checked before Chrome: every Chromium derivative also claims "Chrome".
+  const edge = ua.match(/Edg(?:e|A|iOS)?\/(\d+)/);
+  if (edge) return { family: 'edge', majorVersion: edge[1] };
+
+  const opera = ua.match(/OPR\/(\d+)/);
+  if (opera) return { family: 'opera', majorVersion: opera[1] };
+
+  const firefox = ua.match(/Firefox\/(\d+)/);
+  if (firefox) return { family: 'firefox', majorVersion: firefox[1] };
+
+  const chrome = ua.match(/Chrome\/(\d+)/);
+  if (chrome) return { family: 'chrome', majorVersion: chrome[1] };
+
+  // Safari last: Chrome and Edge UAs both end in a Safari token.
+  const safari = ua.match(/Version\/(\d+)[\d.]*\s+Safari\//);
+  if (safari) return { family: 'safari', majorVersion: safari[1] };
+
+  return { family: 'unknown', majorVersion: null };
+}
+
+export function parseUserAgent(userAgent: string): UserAgentIdentity {
+  const ua = userAgent.trim();
+  const { family, majorVersion } = detectBrand(ua);
+  const { platform, mobile } = detectPlatform(ua);
+
+  // Firefox and Safari do not implement User-Agent Client Hints. Sending them
+  // anyway announces a browser that cannot exist.
+  const isChromium = family === 'chrome' || family === 'edge' || family === 'opera';
+
+  return {
+    userAgent: ua,
+    family,
+    majorVersion,
+    platform,
+    mobile,
+    supportsClientHints: isChromium && majorVersion !== null,
+  };
+}
+
+/**
+ * The `Sec-CH-UA` brand list for an identity, or null where the browser sends
+ * none.
+ *
+ * Chromium lists the GREASE brand, "Chromium", and its own brand, all at the
+ * same major version -- which is exactly the agreement that was missing.
+ */
+export function buildBrandList(identity: UserAgentIdentity): string | null {
+  if (!identity.supportsClientHints || !identity.majorVersion) return null;
+
+  const v = identity.majorVersion;
+  const brands: { brand: string; version: string }[] = [
+    GREASE_BRAND,
+    { brand: 'Chromium', version: v },
+  ];
+
+  switch (identity.family) {
+    case 'chrome': brands.push({ brand: 'Google Chrome', version: v }); break;
+    case 'edge': brands.push({ brand: 'Microsoft Edge', version: v }); break;
+    case 'opera': brands.push({ brand: 'Opera', version: v }); break;
+    default: break;
+  }
+
+  return brands.map(b => `"${b.brand}";v="${b.version}"`).join(', ');
+}
+
+/**
+ * Client-hint headers consistent with the User-Agent, or none.
+ *
+ * Only the three low-entropy hints are sent. The rest -- architecture,
+ * platform version, full version list -- are only sent by a real browser after
+ * a server asks for them with `Accept-CH`, so volunteering them unprompted is
+ * another way to stand out.
+ */
+export function buildClientHintHeaders(identity: UserAgentIdentity): Record<string, string> {
+  const brands = buildBrandList(identity);
+  if (!brands) return {};
+
+  return {
+    'Sec-Ch-Ua': brands,
+    'Sec-Ch-Ua-Mobile': identity.mobile ? '?1' : '?0',
+    'Sec-Ch-Ua-Platform': `"${identity.platform}"`,
+  };
+}
+
+/**
+ * Puppeteer's `userAgentMetadata`, so an overridden UA in the browser scraper
+ * carries matching client hints.
+ *
+ * Without it, `page.setUserAgent(ua)` changes the string while Chrome keeps
+ * emitting hints from its own build -- the same contradiction the HTTP path
+ * had, arrived at from the other direction.
+ */
+export function buildUserAgentMetadata(identity: UserAgentIdentity) {
+  if (!identity.supportsClientHints || !identity.majorVersion) return undefined;
+
+  const v = identity.majorVersion;
+  const brands = [GREASE_BRAND, { brand: 'Chromium', version: v }];
+  if (identity.family === 'chrome') brands.push({ brand: 'Google Chrome', version: v });
+  if (identity.family === 'edge') brands.push({ brand: 'Microsoft Edge', version: v });
+  if (identity.family === 'opera') brands.push({ brand: 'Opera', version: v });
+
+  return {
+    brands,
+    fullVersion: `${v}.0.0.0`,
+    platform: identity.platform,
+    platformVersion: platformVersionFor(identity),
+    architecture: identity.mobile ? '' : 'x86',
+    model: '',
+    mobile: identity.mobile,
+  };
+}
+
+/**
+ * A platform version consistent with the UA string.
+ *
+ * Only used for the browser path's metadata, where Chrome will answer an
+ * `Accept-CH` request for it. A blank value where we cannot tell is better
+ * than a confident wrong one.
+ */
+function platformVersionFor(identity: UserAgentIdentity): string {
+  const ua = identity.userAgent;
+
+  const windows = ua.match(/Windows NT (\d+\.\d+)/);
+  if (windows) {
+    // Chrome reports Windows 10 and 11 as platform versions 10.0 and 13.0+
+    // respectively, both behind "Windows NT 10.0" in the UA. 10.0 is the safe
+    // reading of that string.
+    return windows[1] === '10.0' ? '10.0.0' : `${windows[1]}.0`;
+  }
+
+  const mac = ua.match(/Mac OS X (\d+)[._](\d+)(?:[._](\d+))?/);
+  if (mac) return `${mac[1]}.${mac[2]}.${mac[3] || '0'}`;
+
+  const android = ua.match(/Android (\d+(?:\.\d+)*)/);
+  if (android) return android[1];
+
+  return '';
+}


### PR DESCRIPTION
The scraper headers were half configurable and half hardcoded:

```
User-Agent  <- setting `default_user_agent`, or a per-retailer override
Sec-Ch-Ua   <- the literal ‘"Google Chrome";v="121"’, always
```

Migration 006 seeds the default as **Chrome 146**. So out of the box, every request from every install announced **Chrome 146 in the User-Agent and Chrome 121 in the client hints** — a twenty-five version contradiction no real browser can produce, sent to every retailer on every scrape.

@stevene1919 arrived at the same place from the other end in #68: setting the User-Agent to `Chrome/121.0.0.0` on Windows fixed amazon.com.au. That is the one string which agrees with the hardcoded hints — which is the proof rather than a coincidence.

A **per-retailer `user_agent` override was worse**: it received the same hardcoded Chrome-on-Windows hints, so configuring a Safari or Android UA for a retailer described a browser that has never existed.

## What changed

Everything derives from one string now. A UA whose brand does not support client hints gets none — inventing `Sec-Ch-Ua` for Firefox or Safari is itself the tell — and only the three low-entropy hints are sent, because a real browser volunteers the rest only after a server asks with `Accept-CH`.

Two more instances of the same fault, found while fixing it:

- **The browser path passed no User-Agent at all.** Both remote calls in `acquisition/fallback.ts` sent `undefined`, so a retailer that had just been shown the configured browser over HTTP saw headless Chromium on the fallback. Both now resolve identity the same way.
- **`page.setUserAgent(ua)` with no metadata.** Replaces the UA string while Chrome keeps emitting `Sec-CH-UA` from its own build — the same contradiction from the other direction — and it overrode the coordinated override the stealth plugin had already installed. Now passes matching `userAgentMetadata`.

## What this does NOT do

I could not reproduce either reported symptom from this machine, so **this is not evidence the change resolves them**:

| | old headers | new headers |
|---|---|---|
| amazon.com.au product page | 200, no challenge, price present | 200, no challenge, price present |
| target.com.au product page | **403, Akamai Access Denied** | **403, Akamai Access Denied** |

Carrying a cookie jar from the homepage does not help target.com.au either — the `_abck` cookie is issued unvalidated and Akamai’s JS sensor has to run before it grants access, which plain HTTP cannot do and the browser scraper can. My requests also geolocate to Switzerland (`t_geo_country=CH`), a confound the reporter’s would not have.

So this ships as **its own defect** — contradictory headers are wrong however the retailers respond today — and **#67 stays open** on the evidence above rather than being claimed as fixed.

## Verification

**451 backend tests, up from 417.** The core one is the invariant that was broken:

```ts
it.each(chromiumAgents)("client hints report the same version as the User-Agent", (ua) => {
  const uaVersion = ua.match(/Chrom(?:e|ium)\/(\d+)/)![1];
  expect(hintVersion(buildBrandList(parseUserAgent(ua)))).toBe(uaVersion);
});
```

Header output also checked on the wire against a local echo server:

```
seeded default (Chrome 146 / Windows)
  sec-ch-ua : "Not)A;Brand";v="8", "Chromium";v="146", "Google Chrome";v="146"   -> CONSISTENT
retailer override (Chrome 133 / macOS)
  sec-ch-ua : "Not)A;Brand";v="8", "Chromium";v="133", "Google Chrome";v="133"
  sec-ch-ua-platform: "macOS"                                                   -> CONSISTENT
Firefox override
  sec-ch-ua : (none sent)                                                       -> CONSISTENT
```

`tsc` (backend + scraper), frontend build, emoji lint, `git diff --check` all pass.

Refs #67, #68