### PR TITLE
fix(notifications): show what the history already knew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Notification history rows now show why something happened. The reason a
+  product could not be read, what was done about it, how many attempts had
+  failed and which way the stock status moved were all recorded and none of
+  them were displayed, so an unavailable product showed a generic label while
+  the row's own data held the explanation.
+- A notification with no price says "Not available" rather than leaving the
+  column blank, which left it ambiguous whether the event had no price or the
+  price had failed to load.
+- Notifications that fail to load now say so, on both the drawer and the
+  history page, instead of rendering "No alerts yet" as though nothing had
+  happened. Both offer a retry.
+- Individual notifications can be marked read on the history page. The API
+  always supported it and only the drawer used it, so the sole option here was
+  to mark everything read at once.
+- Unavailable alerts record how many consecutive attempts had failed.
+
+### Fixed
+
 - The scraper no longer announces two different browsers in the same request.
   The `User-Agent` came from the Default User-Agent setting (seeded as Chrome
   146) while the `Sec-CH-UA` client hints were hardcoded to Chrome 121 on

--- a/backend/src/services/domain/product/ProductRefreshService.ts
+++ b/backend/src/services/domain/product/ProductRefreshService.ts
@@ -99,7 +99,7 @@ export class ProductRefreshService {
       );
       if (failures === SITE_FAILURE_NOTIFY_THRESHOLD) {
         // Once, on crossing the threshold -- not every scrape thereafter.
-        await productNotificationService.notifyNotAvailable(product, reason!, false);
+        await productNotificationService.notifyNotAvailable(product, reason!, false, failures);
       }
     } else if (isDefinitive && product.stock_status !== 'not_available') {
       const streak = (product.page_gone_streak || 0) + 1;
@@ -142,7 +142,7 @@ export class ProductRefreshService {
       if (transition.to === 'not_available') {
         logger.warn(`Product ${productId} | Status | ${describeUnavailableReason(reason)}. Pausing further checks.`, 'Products', { product_id: productId });
         await productRepository.setPaused(productId, true, false);
-        await productNotificationService.notifyNotAvailable(product, reason);
+        await productNotificationService.notifyNotAvailable(product, reason, true, (product.page_gone_streak || 0) + 1);
       } else if (transition.to === 'in_stock' && isBackInStockFrom(transition.from) && product.notify_back_in_stock) {
         await productNotificationService.notifyBackInStock(product, scrapedData, transition.from);
       }

--- a/backend/src/services/domain/product/notifications/alerts.ts
+++ b/backend/src/services/domain/product/notifications/alerts.ts
@@ -12,7 +12,7 @@ export class ProductAlertService {
    * being retried. Telling someone monitoring has stopped when it has not is
    * worse than saying nothing.
    */
-  async notifyNotAvailable(product: Product, reason?: UnavailableReason | null, paused = true) {
+  async notifyNotAvailable(product: Product, reason?: UnavailableReason | null, paused = true, failureCount?: number) {
     await productNotificationOrchestrator.deliver(
       product,
       'not_available',
@@ -44,7 +44,10 @@ export class ProductAlertService {
           productUrl: product.url,
           reason: describeUnavailableReason(reason),
           reasonCode: reason ?? 'unknown_scrape_failure',
-          action: paused ? 'Monitoring Paused' : 'Still Retrying'
+          action: paused ? 'Monitoring Paused' : 'Still Retrying',
+          // The history row shows this. Without it "still retrying" gave no
+          // sense of how long the retailer had been failing (issue #93).
+          failureCount
         }
       }
     );

--- a/frontend/src/features/notifications/components/NotificationDrawer.css
+++ b/frontend/src/features/notifications/components/NotificationDrawer.css
@@ -262,3 +262,9 @@
   max-height: 150px;
   overflow-y: auto;
 }
+
+/* Says the price is genuinely absent rather than leaving the row looking cut off. */
+.drawer-item-price-absent {
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/features/notifications/components/NotificationDrawer.tsx
+++ b/frontend/src/features/notifications/components/NotificationDrawer.tsx
@@ -12,6 +12,9 @@ import Icon from '../../../components/Icon';
 import { queryClient } from '../../../api/queryClient';
 import { recentNotificationsQuery } from '../../../api/queries';
 
+/** Events where a product legitimately has no price yet. */
+const STOCK_EVENTS = ['back_in_stock', 'not_available', 'product_restored', 'stock_alert', 'system_alert'];
+
 const NotificationDrawer: React.FC = () => {
   const { user } = useAuth();
   const { isDrawerOpen, setDrawerOpen, activityLog, clearActivityLog } = useToast();
@@ -99,7 +102,22 @@ const NotificationDrawer: React.FC = () => {
               ))
             )
           ) : (
-            recentQuery.isLoading && notifications.length === 0 ? (
+            recentQuery.isError ? (
+              // Checked before the empty state: a failed request used to render
+              // "No alerts yet", which reads as "nothing happened" rather than
+              // "we could not ask" (issue #93).
+              <div className="drawer-empty">
+                <div className="drawer-empty-icon"><Icon name="alertTriangle" /></div>
+                <div style={{ fontWeight: 600 }}>Alerts could not be loaded</div>
+                <button
+                  className="btn btn-secondary btn-sm"
+                  style={{ marginTop: '0.75rem' }}
+                  onClick={() => recentQuery.refetch()}
+                >
+                  Try again
+                </button>
+              </div>
+            ) : recentQuery.isLoading && notifications.length === 0 ? (
               <div className="drawer-empty"><LoadingSpinner size="1.5rem" centered /></div>
             ) : notifications.length === 0 ? (
               <div className="drawer-empty">
@@ -123,7 +141,14 @@ const NotificationDrawer: React.FC = () => {
                       </div>
                       <div className="drawer-item-message">{n.message}</div>
                       <div className="drawer-item-meta">
-                        {newPrice && <span className="drawer-item-price">{formatPrice(newPrice, currency, user?.locale)}</span>}
+                        {newPrice ? (
+                          <span className="drawer-item-price">{formatPrice(newPrice, currency, user?.locale)}</span>
+                        ) : STOCK_EVENTS.includes(n.type) ? (
+                          // A product can come back in stock before a price is
+                          // extracted. Blank left it ambiguous whether the price
+                          // was absent or had failed to load.
+                          <span className="drawer-item-price drawer-item-price-absent">No price yet</span>
+                        ) : null}
                         <span>{formatRelativeDate(n.created_at, user?.locale)}</span>
                       </div>
                     </div>

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.css
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.css
@@ -361,3 +361,62 @@
     gap: 0.5rem;
   }
 }
+
+/*
+ * The structured fields the backend records alongside an alert -- the reason a
+ * product could not be read, what was done about it, the stock transition.
+ * These were stored and never shown, so an unavailable row said only
+ * "Tracking Issue" while its own data held the explanation (issue #93).
+ */
+.notification-detail-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+
+.notification-detail-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  background: var(--background);
+  font-size: 0.7rem;
+  color: var(--text);
+}
+
+.notification-detail-chip-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.6rem;
+}
+
+/* Distinguishable from an empty cell, which said nothing at all. */
+.notification-price-absent {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.notification-mark-read {
+  display: block;
+  margin-top: 0.375rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--primary);
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+
+.notification-mark-read:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.notification-mark-read:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}

--- a/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
+++ b/frontend/src/features/notifications/pages/NotificationHistoryPage.tsx
@@ -27,6 +27,10 @@ export default function NotificationHistory() {
   const totalPages = historyQuery.data?.pagination?.totalPages ?? 1;
   const invalidateNotifications = () => queryClient.invalidateQueries({ queryKey: ['notifications'] });
   const markAllRead = useMutation({ mutationFn: NotificationService.markAllAsRead, onSuccess: invalidateNotifications });
+  // The API has supported marking one notification read all along; only the
+  // drawer used it, so on this page the sole option was to mark everything read
+  // and lose track of what you had not seen (issue #93).
+  const markOneRead = useMutation({ mutationFn: NotificationService.markAsRead, onSuccess: invalidateNotifications });
   const deleteAll = useMutation({ mutationFn: NotificationService.deleteAll, onSuccess: invalidateNotifications });
 
   const handleMarkAllRead = async () => {
@@ -112,9 +116,13 @@ export default function NotificationHistory() {
               notifications={filteredNotifications} 
               loading={historyQuery.isLoading}
               userLocale={user?.locale ?? undefined}
+              error={historyQuery.isError ? historyQuery.error : undefined}
+              onRetry={() => historyQuery.refetch()}
+              onMarkRead={(id) => markOneRead.mutate(id)}
+              markingId={markOneRead.isPending ? (markOneRead.variables ?? null) : null}
             />
 
-            {totalPages > 1 && (
+            {!historyQuery.isError && totalPages > 1 && (
               <Pagination 
                 page={page} 
                 totalPages={totalPages} 

--- a/frontend/src/features/notifications/pages/NotificationTable.tsx
+++ b/frontend/src/features/notifications/pages/NotificationTable.tsx
@@ -4,14 +4,57 @@ import { NotificationEntry } from '../../../types/api';
 import { formatPrice, formatDate } from '../../../utils/format';
 import { getNotificationIcon, getNotificationTypeLabel, getChannelIcon } from './utils';
 import Icon from '../../../components/Icon';
+import { buildDetailChips } from './detailChips';
 
 interface NotificationTableProps {
   notifications: NotificationEntry[];
   loading: boolean;
   userLocale?: string;
+  /** Set when the history query failed, so a failure is not shown as "none". */
+  error?: unknown;
+  onRetry?: () => void;
+  /** Marks one row read. The API has always supported it; only the drawer used it. */
+  onMarkRead?: (id: number) => void;
+  markingId?: number | null;
 }
 
-const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, loading, userLocale }) => {
+/** Renders the structured fields the backend records alongside an alert. */
+const DetailChips: React.FC<{ data: unknown }> = ({ data }) => {
+  const chips = buildDetailChips(data);
+  if (chips.length === 0) return null;
+
+  return (
+    <div className="notification-detail-chips">
+      {chips.map(chip => (
+        <span key={chip.label} className="notification-detail-chip">
+          <span className="notification-detail-chip-label">{chip.label}</span>
+          {chip.value}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, loading, userLocale, error, onRetry, onMarkRead, markingId }) => {
+  // Checked before the empty state: a failed request used to fall through to
+  // "No notifications found", which reads as "you have none" rather than
+  // "we could not ask".
+  if (error) {
+    return (
+      <div className="notifications-table">
+        <div className="notifications-empty">
+          <div className="notifications-empty-icon"><Icon name="alertTriangle" /></div>
+          <div>Notifications could not be loaded.</div>
+          {onRetry && (
+            <button className="btn btn-secondary btn-sm" style={{ marginTop: '1rem' }} onClick={onRetry}>
+              Try again
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   if (loading && notifications.length === 0) {
     return (
       <div className="notifications-table">
@@ -86,6 +129,7 @@ const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, lo
                     : JSON.stringify(notification.data.details)}
                 </div>
               )}
+              <DetailChips data={notification.data} />
             </div>
 
             <div className="notification-price">
@@ -105,14 +149,16 @@ const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, lo
                     </span>
                   )}
                 </>
+              ) : targetPrice ? (
+                <div className="notification-price-target">
+                  Target: {formatPrice(targetPrice, currency, userLocale)}
+                </div>
               ) : (
-                <>
-                  {targetPrice && (
-                    <div className="notification-price-target">
-                      Target: {formatPrice(targetPrice, currency, userLocale)}
-                    </div>
-                  )}
-                </>
+                // A blank cell left three possibilities open: the event had no
+                // price, the price failed to load, or the row was incomplete.
+                // A product can genuinely come back in stock before a price is
+                // extracted, so say that rather than showing nothing.
+                <span className="notification-price-absent">Not available</span>
               )}
             </div>
 
@@ -138,6 +184,16 @@ const NotificationTable: React.FC<NotificationTableProps> = ({ notifications, lo
 
             <div className="notification-date">
               {formatDate(notification.created_at, userLocale, true)}
+              {onMarkRead && !notification.is_read && (
+                <button
+                  className="notification-mark-read"
+                  onClick={() => onMarkRead(notification.id)}
+                  disabled={markingId === notification.id}
+                  title="Mark this notification read"
+                >
+                  {markingId === notification.id ? 'Marking...' : 'Mark read'}
+                </button>
+              )}
             </div>
           </div>
         );

--- a/frontend/src/features/notifications/pages/detailChips.test.ts
+++ b/frontend/src/features/notifications/pages/detailChips.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildDetailChips } from './detailChips';
+
+/**
+ * The backend records why a product could not be read, what it did about it,
+ * and which way the stock status moved. None of it reached the screen, so an
+ * unavailable row read as a generic label while its own data held the
+ * explanation (issue #93).
+ */
+
+describe('buildDetailChips', () => {
+  it('shows the stock transition, not just the new state', () => {
+    // "In stock" alone does not say what changed.
+    const chips = buildDetailChips({ oldStockStatus: 'out_of_stock', newStockStatus: 'in_stock' });
+    expect(chips).toContainEqual({ label: 'Stock', value: 'out of stock → in stock' });
+  });
+
+  it('falls back to the new state alone when there is no previous one', () => {
+    expect(buildDetailChips({ newStockStatus: 'member_only' }))
+      .toContainEqual({ label: 'Stock', value: 'member only' });
+  });
+
+  it('does not render a transition from a state to itself', () => {
+    const chips = buildDetailChips({ oldStockStatus: 'in_stock', newStockStatus: 'in_stock' });
+    expect(chips).toEqual([{ label: 'Stock', value: 'in stock' }]);
+  });
+
+  it('surfaces the reason and the action taken', () => {
+    // The two fields that make "Tracking Issue" into something actionable.
+    const chips = buildDetailChips({
+      reason: 'The retailer did not respond in time',
+      action: 'Still Retrying',
+    });
+    expect(chips).toEqual([
+      { label: 'Reason', value: 'The retailer did not respond in time' },
+      { label: 'Action', value: 'Still Retrying' },
+    ]);
+  });
+
+  it('shows a failure count only when something has actually failed', () => {
+    // "Failed attempts 0" on every row would bury the rows where it matters.
+    expect(buildDetailChips({ failureCount: 3 }))
+      .toContainEqual({ label: 'Failed attempts', value: '3' });
+    expect(buildDetailChips({ failureCount: 0 })).toEqual([]);
+  });
+
+  it('renders nothing for a notification carrying no structured data', () => {
+    expect(buildDetailChips(undefined)).toEqual([]);
+    expect(buildDetailChips(null)).toEqual([]);
+    expect(buildDetailChips({})).toEqual([]);
+    expect(buildDetailChips({ productId: 1, productName: 'Widget' })).toEqual([]);
+  });
+
+  it('ignores fields of the wrong type rather than rendering "[object Object]"', () => {
+    // notification.data is untyped JSON from the database.
+    expect(buildDetailChips({ reason: { code: 404 }, failureCount: 'three', action: null })).toEqual([]);
+  });
+
+  it('keeps a stable order, so rows do not shuffle their chips', () => {
+    const chips = buildDetailChips({
+      oldStockStatus: 'in_stock',
+      newStockStatus: 'not_available',
+      reason: 'The product page returned 404 Not Found',
+      action: 'Monitoring Paused',
+      failureCount: 3,
+    });
+    expect(chips.map(c => c.label)).toEqual(['Stock', 'Reason', 'Action', 'Failed attempts']);
+  });
+});

--- a/frontend/src/features/notifications/pages/detailChips.ts
+++ b/frontend/src/features/notifications/pages/detailChips.ts
@@ -1,0 +1,52 @@
+/**
+ * Turns the structured data stored on a notification into the chips shown
+ * under its message (issue #93).
+ *
+ * The backend has always recorded why a product could not be read, what it did
+ * about it, and which way the stock status moved. None of it was rendered, so
+ * an unavailable row showed a generic label while its own data held the
+ * explanation the user needed.
+ *
+ * Separate from the component so the decisions about what to show -- and what
+ * to leave out -- are testable without a DOM.
+ */
+
+export interface DetailChip {
+  label: string;
+  value: string;
+}
+
+const humanise = (value: string) => value.replace(/_/g, ' ');
+
+export function buildDetailChips(data: unknown): DetailChip[] {
+  if (!data || typeof data !== 'object') return [];
+  const d = data as Record<string, unknown>;
+
+  const chips: DetailChip[] = [];
+
+  const oldStatus = typeof d.oldStockStatus === 'string' ? d.oldStockStatus : undefined;
+  const newStatus = typeof d.newStockStatus === 'string' ? d.newStockStatus : undefined;
+
+  // The transition is the point. "In stock" alone does not say what changed,
+  // and the issue asks specifically for the old and new states.
+  if (oldStatus && newStatus && oldStatus !== newStatus) {
+    chips.push({ label: 'Stock', value: `${humanise(oldStatus)} → ${humanise(newStatus)}` });
+  } else if (newStatus) {
+    chips.push({ label: 'Stock', value: humanise(newStatus) });
+  }
+
+  if (typeof d.reason === 'string' && d.reason) {
+    chips.push({ label: 'Reason', value: d.reason });
+  }
+  if (typeof d.action === 'string' && d.action) {
+    chips.push({ label: 'Action', value: d.action });
+  }
+
+  // Zero failures is not worth a chip -- it is the normal state, and showing
+  // "Failed attempts 0" on every row would bury the rows where it matters.
+  if (typeof d.failureCount === 'number' && d.failureCount > 0) {
+    chips.push({ label: 'Failed attempts', value: String(d.failureCount) });
+  }
+
+  return chips;
+}


### PR DESCRIPTION
The frontend half of #93. Event types, server-side filters and per-event labels landed earlier; what remained was that several surfaces threw away data they had been given.

## Rows did not explain themselves (issue points 3 and 5)

`notifyNotAvailable` records the reason a page could not be read, the action taken and the reason code. `notifyBackInStock` records the stock transition. **None of it was rendered** — the row printed only `data.details`, which these events never set. So an unavailable product showed a bare label while the row’s own data held the explanation.

Rows now carry chips:

```
Stock  out of stock → in stock
Reason The retailer did not respond in time
Action Still Retrying
Failed attempts 3
```

The failure count was not recorded at all, so “still retrying” gave no sense of how long a retailer had been failing. Both call sites now pass it.

## A missing price rendered as an empty cell (point 6)

Which left three readings open: the event had no price, the price failed to load, or the row was incomplete. A product genuinely can come back in stock before a price is extracted, so the history page now says **“Not available”** and the drawer **“No price yet”** — the latter only for stock events, where an absent price is expected rather than a failure.

## A failed request rendered as an empty state (point 8)

Neither surface checked `isError`, so an API failure produced *“No alerts yet”* and *“No notifications found”* — “nothing happened” rather than “we could not ask”. Both now render an error with a retry, **checked before the empty state**, and pagination is suppressed when the query failed.

## Individual notifications could not be marked read (point 7)

`markAsRead` has always existed and the drawer has always used it. This page offered only “Mark all read”, so seeing one alert meant losing track of every other unread one.

## On testing

The chip logic sits in its own module rather than inside the component. The frontend has no jsdom or testing-library, so logic left in a component cannot be tested at all — extracting it is what makes it coverable:

- a zero failure count produces no chip (it is the normal state; showing it on every row would bury the rows where it matters)
- a transition from a state to itself renders as one state, not an arrow
- fields of the wrong type are ignored rather than rendering `[object Object]`, since `notification.data` is untyped JSON from the database
- chip order is stable, so rows do not shuffle

## Not in this PR

`product_restored` already has its own icon and label — I had it on my list as a gap and was wrong; it was added with the event types.

## Verification

451 backend tests, 13 frontend tests, both builds, emoji lint, `git diff --check`.

Refs #93