### PR TITLE
feat(admin): improve user password UX, add reset CLI, and relocate appearance settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Admin User Management Single Password UX & Utilities**: Replaced the dual-password input in the Admin user creation and editing forms with a single password input, an integrated cryptographically secure password generator, and a clipboard copy button (#76, #80).
+- **CLI Password Reset Tool**: Added `pnpm run reset-password <email-or-id> [password]` utility (`backend/src/scripts/reset-password.ts`) to recover or assign user passwords from the terminal.
+- **Optional Display Name on User Creation**: Added an optional Display Name field to the Admin Create User form and backend API route.
+
+### Changed
+
+- **Relocated Theme / Appearance Settings**: Moved the Appearance (Auto / Light / Dark theme) selector from Regional Settings (`/settings/regional`) to the main Profile page (`/settings/profile`) above the profile action buttons.
+
 ### Fixed
 
 - Retailer bot-challenge pages are recognised instead of being scraped as
@@ -21,8 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page size. The size limit that stops the word appearing on a genuine product
   page from triggering a false positive was also being applied to the title,
   which is far more specific and cheap to check.
-
-### Fixed
 
 - Log timestamps now follow the `TZ` you configure. The backend always printed
   UTC regardless, and the scraper was hardcoded to `Australia/Perth`, so every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Admin User Management Single Password UX & Utilities**: Replaced the dual-password input in the Admin user creation and editing forms with a single password input, an integrated cryptographically secure password generator, and a clipboard copy button (#76, #80).
-- **CLI Password Reset Tool**: Added `pnpm run reset-password <email-or-id> [password]` utility (`backend/src/scripts/reset-password.ts`) to recover or assign user passwords from the terminal.
+- **CLI Password Reset Tool**: Added `pnpm run reset-password <email-or-id> [password]` utility (`backend/src/scripts/reset-password.ts`) to recover or assign user passwords from the terminal. Runs the compiled script, so it works inside the production container, which is where a locked-out administrator needs it. Use `reset-password:dev` to run from source. It refuses to set a password on an SSO account unless `--force` is given, because doing so enables local sign-in for an account the identity provider owns.
 - **Optional Display Name on User Creation**: Added an optional Display Name field to the Admin Create User form and backend API route.
 
 ### Changed

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,8 @@
     "test": "vitest",
     "map": "tsx src/scripts/generate-codebase-map.ts",
     "generate-api-token": "node dist/scripts/generate-api-token.js",
+    "reset-password": "node dist/scripts/reset-password.js",
+    "reset-password:dev": "tsx src/scripts/reset-password.ts",
     "db:migrate": "node dist/config/migrate.js up",
     "db:migrate:down": "node dist/config/migrate.js down",
     "db:migrate:dev": "tsx src/config/migrate.ts up",

--- a/backend/src/routes/admin/users.ts
+++ b/backend/src/routes/admin/users.ts
@@ -11,20 +11,21 @@ router.get('/', asyncHandler(async (_req: AuthRequest, res: Response) => {
 }, 'Admin | Fetch Users', 'Admin', 'Failed to fetch users'));
 
 router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
-  const { email, password, is_admin, currency, locale } = req.body;
+  const { email, password, name, is_admin, currency, locale } = req.body;
 
   if (!email || !password) {
     res.status(400).json({ error: 'Email and password are required' });
     return;
   }
 
-  const user = await userService.createUser({ email, password, is_admin, currency, locale });
+  const user = await userService.createUser({ email, password, name, is_admin, currency, locale });
 
   res.status(201).json({
     message: 'User created successfully',
     user: {
       id: user.id,
       email: user.email,
+      name: user.name,
       is_admin: is_admin || false,
       currency: user.currency,
       locale: user.locale

--- a/backend/src/scripts/generate-api-token.ts
+++ b/backend/src/scripts/generate-api-token.ts
@@ -19,17 +19,17 @@ async function main() {
     });
 
     console.log('\n---------------------------------------------------------');
-    console.log('✅ API Token Generated Successfully!');
+    console.log('API Token Generated Successfully');
     console.log('---------------------------------------------------------');
     console.log(`ID:      ${systemToken.id}`);
     console.log(`Label:   ${systemToken.label}`);
     console.log(`Token:   ${token}`);
     console.log('---------------------------------------------------------');
-    console.log('⚠️  IMPORTANT: Store this token securely.');
-    console.log('   This is the ONLY time it will be displayed.');
+    console.log('[IMPORTANT] Store this token securely.');
+    console.log('  This is the ONLY time it will be displayed.');
     console.log('---------------------------------------------------------\n');
   } catch (error) {
-    console.error('❌ Error generating token:', error);
+    console.error('[ERROR] Error generating token:', error);
   } finally {
     // Ensure the database pool is closed so the script can exit
     await pool.end();

--- a/backend/src/scripts/reset-password.ts
+++ b/backend/src/scripts/reset-password.ts
@@ -13,15 +13,22 @@ function generateSecurePassword(length = 16): string {
 }
 
 async function main() {
-  const identifier = process.argv[2];
-  const customPassword = process.argv[3];
+  // --force may appear anywhere; the positionals keep their meaning either way.
+  const args = process.argv.slice(2).filter(a => a !== '--force');
+  const force = process.argv.slice(2).includes('--force');
+  const identifier = args[0];
+  const customPassword = args[1];
 
   if (!identifier) {
     console.log('');
-    console.error('Usage: pnpm run reset-password <email-or-user-id> [optional-password]');
+    console.error('Usage: pnpm run reset-password <email-or-user-id> [optional-password] [--force]');
     console.log('Examples:');
     console.log('  pnpm run reset-password admin@example.com');
     console.log('  pnpm run reset-password 1 "MySecretPassword123!"');
+    console.log('');
+    console.log('  --force  Also set a password on an SSO account. This enables local');
+    console.log('           sign-in for it, bypassing the identity provider. Use only');
+    console.log('           when SSO itself is broken.');
     console.log('');
     process.exit(1);
   }
@@ -45,9 +52,32 @@ async function main() {
       process.exit(1);
     }
 
-    if (user.auth_provider === 'oidc') {
-      console.warn('\n[WARNING] This account signs in via SSO (OIDC).');
-      console.warn('  Setting a local password enables local password authentication for this user.');
+    if (user.auth_provider === 'oidc' && !force) {
+      // UserAccountService.adminUpdateUser refuses this outright, calling it
+      // "an authentication bypass rather than a convenience", and it is right:
+      // AuthService.loginUser gates only on `!user.password_hash` and never
+      // looks at auth_provider. So writing a hash here permanently opens an
+      // SSO-provisioned account to the local login form, with a password the
+      // identity provider knows nothing about -- bypassing IdP-side MFA and
+      // surviving deprovisioning there. A warning is not enough for that.
+      //
+      // --force exists because this is also the break-glass tool for an
+      // instance whose SSO has broken, which is exactly when you cannot go
+      // through the admin UI. It has to be asked for explicitly.
+      console.error('\n[ERROR] This account signs in through SSO (OIDC).');
+      console.error('  Its password is managed by the identity provider. Setting one here would');
+      console.error('  enable local sign-in for it, bypassing the provider entirely -- including');
+      console.error('  any MFA it enforces, and any later deprovisioning there.');
+      console.error('');
+      console.error('  If SSO is broken and this is deliberate, re-run with --force.');
+      console.error('');
+      process.exit(1);
+    }
+
+    if (user.auth_provider === 'oidc' && force) {
+      console.warn('\n[WARNING] --force: enabling local sign-in for an SSO account.');
+      console.warn('  This account can now be reached with a password the identity provider');
+      console.warn('  does not know about. Remove the password once SSO is working again.');
     }
 
     const passwordToSet = customPassword || generateSecurePassword(16);
@@ -60,7 +90,10 @@ async function main() {
     const saltRounds = 12;
     const passwordHash = await bcrypt.hash(passwordToSet, saltRounds);
 
-    await pool.query('UPDATE users SET password_hash = $1 WHERE id = $2', [passwordHash, user.id]);
+    // userRepository.updatePassword runs exactly this statement. CLAUDE.md keeps
+    // SQL out of everything that is not a repository, and a second copy of the
+    // same UPDATE is a second place to forget a WHERE clause.
+    await userRepository.updatePassword(user.id, passwordHash);
 
     console.log('\n---------------------------------------------------------');
     console.log('Password Reset Successfully');

--- a/backend/src/scripts/reset-password.ts
+++ b/backend/src/scripts/reset-password.ts
@@ -1,0 +1,82 @@
+import bcrypt from 'bcryptjs';
+import { userRepository, pool } from '../models';
+import crypto from 'crypto';
+
+function generateSecurePassword(length = 16): string {
+  const chars = 'abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789!@#$%^&*()_+';
+  const bytes = crypto.randomBytes(length);
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += chars[bytes[i] % chars.length];
+  }
+  return result;
+}
+
+async function main() {
+  const identifier = process.argv[2];
+  const customPassword = process.argv[3];
+
+  if (!identifier) {
+    console.log('');
+    console.error('Usage: pnpm run reset-password <email-or-user-id> [optional-password]');
+    console.log('Examples:');
+    console.log('  pnpm run reset-password admin@example.com');
+    console.log('  pnpm run reset-password 1 "MySecretPassword123!"');
+    console.log('');
+    process.exit(1);
+  }
+
+  try {
+    let user;
+    if (/^\d+$/.test(identifier)) {
+      user = await userRepository.findById(parseInt(identifier, 10));
+    } else {
+      user = await userRepository.findByEmail(identifier);
+    }
+
+    if (!user) {
+      console.error(`\n[ERROR] User not found matching: "${identifier}"`);
+      const allUsers = await userRepository.findAll();
+      console.log('\nExisting users in database:');
+      for (const u of allUsers) {
+        console.log(`  - [ID: ${u.id}] ${u.email} (${u.is_admin ? 'Admin' : 'User'})`);
+      }
+      console.log('');
+      process.exit(1);
+    }
+
+    if (user.auth_provider === 'oidc') {
+      console.warn('\n[WARNING] This account signs in via SSO (OIDC).');
+      console.warn('  Setting a local password enables local password authentication for this user.');
+    }
+
+    const passwordToSet = customPassword || generateSecurePassword(16);
+
+    if (passwordToSet.length < 8) {
+      console.error('\n[ERROR] Password must be at least 8 characters long.\n');
+      process.exit(1);
+    }
+
+    const saltRounds = 12;
+    const passwordHash = await bcrypt.hash(passwordToSet, saltRounds);
+
+    await pool.query('UPDATE users SET password_hash = $1 WHERE id = $2', [passwordHash, user.id]);
+
+    console.log('\n---------------------------------------------------------');
+    console.log('Password Reset Successfully');
+    console.log('---------------------------------------------------------');
+    console.log(`User ID:  ${user.id}`);
+    console.log(`Email:    ${user.email}`);
+    console.log(`Password: ${passwordToSet}`);
+    console.log('---------------------------------------------------------');
+    console.log('Keep this password secure or share it with the user.');
+    console.log('---------------------------------------------------------\n');
+  } catch (error) {
+    console.error('\n[ERROR] Error resetting password:', error);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+main();

--- a/backend/src/services/domain/user/UserAccountService.ts
+++ b/backend/src/services/domain/user/UserAccountService.ts
@@ -9,11 +9,12 @@ export class UserAccountService {
   async createUser(data: {
     email: string;
     password: string;
+    name?: string | null;
     is_admin?: boolean;
     currency?: string | null;
     locale?: string | null;
   }): Promise<User> {
-    const { email, password, is_admin, currency, locale } = data;
+    const { email, password, name, is_admin, currency, locale } = data;
 
     const existingUser = await userRepository.findByEmail(email);
     if (existingUser) {
@@ -25,7 +26,7 @@ export class UserAccountService {
     const saltRounds = 12;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    const user = await userRepository.create(email, passwordHash, currency || null, locale || null);
+    const user = await userRepository.create(email, passwordHash, currency || null, locale || null, name || null);
 
     if (is_admin) {
       await userRepository.setAdmin(user.id, true);

--- a/backend/src/services/domain/user/repositories/user-account.repository.ts
+++ b/backend/src/services/domain/user/repositories/user-account.repository.ts
@@ -18,10 +18,16 @@ export const userAccountRepository = {
     return result.rows[0] || null;
   },
 
-  create: async (email: string, passwordHash: string, currency: string | null = null, locale: string | null = null): Promise<User> => {
+  create: async (
+    email: string,
+    passwordHash: string,
+    currency: string | null = null,
+    locale: string | null = null,
+    name: string | null = null
+  ): Promise<User> => {
     const result = await pool.query(
-      'INSERT INTO users (email, password_hash, currency, locale) VALUES ($1, $2, $3, $4) RETURNING *',
-      [email, passwordHash, currency, locale]
+      'INSERT INTO users (email, password_hash, currency, locale, name) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      [email, passwordHash, currency, locale, name]
     );
     return result.rows[0];
   },

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -52,8 +52,13 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
 
   const copyToClipboard = (text: string) => {
     if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(text);
-      showToast('Password copied to clipboard', 'success');
+      // writeText returns a promise. Reporting success before it settles means
+      // that on rejection -- the document not focused, or the permission denied
+      // -- the admin is told the password was copied, pastes nothing, and has
+      // already dismissed the only copy of it.
+      navigator.clipboard.writeText(text)
+        .then(() => showToast('Password copied to clipboard', 'success'))
+        .catch(() => showToast('Could not copy the password. Select it and copy manually.', 'error'));
     } else {
       const textArea = document.createElement("textarea");
       textArea.value = text;

--- a/frontend/src/features/admin/components/sections/UsersSection.tsx
+++ b/frontend/src/features/admin/components/sections/UsersSection.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../../../auth';
 import { useQuery } from '@tanstack/react-query';
 import { adminUsersQuery, queryKeys } from '../../../../api/queries';
 import { queryClient } from '../../../../api/queryClient';
+import Icon from '../../../../components/Icon';
 import PasswordInput from '../../../../components/PasswordInput';
 import SearchableSelect from '../../../../components/SearchableSelect';
 import { ToggleSwitch } from '../../components';
@@ -33,6 +34,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
 
   // Add User states
   const [newUserEmail, setNewUserEmail] = useState('');
+  const [newUserName, setNewUserName] = useState('');
   const [newUserPassword, setNewUserPassword] = useState('');
   const [newUserCurrency, setNewUserCurrency] = useState('');
   const [newUserLocale, setNewUserLocale] = useState('');
@@ -40,7 +42,36 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
 
   // Edit User states
   const [editUserPassword, setEditUserPassword] = useState('');
-  const [editUserConfirmPassword, setEditUserConfirmPassword] = useState('');
+
+  const generateRandomPassword = () => {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_+~';
+    const array = new Uint32Array(16);
+    crypto.getRandomValues(array);
+    return Array.from(array, x => chars[x % chars.length]).join('');
+  };
+
+  const copyToClipboard = (text: string) => {
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(text);
+      showToast('Password copied to clipboard', 'success');
+    } else {
+      const textArea = document.createElement("textarea");
+      textArea.value = text;
+      textArea.style.position = "fixed";
+      textArea.style.left = "-9999px";
+      textArea.style.top = "0";
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      try {
+        document.execCommand('copy');
+        showToast('Password copied to clipboard', 'success');
+      } catch {
+        showToast('Failed to copy password', 'error');
+      }
+      document.body.removeChild(textArea);
+    }
+  };
 
   // Filtering is local state, so a background refresh of the list leaves the
   // search box and its results alone.
@@ -60,17 +91,16 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
   const handleAddUser = async () => {
     if (!newUserEmail || !newUserPassword) { showToast('Email and password required', 'error'); return; }
     try {
-      await UserAdminService.createUser(newUserEmail, newUserPassword, newUserIsAdmin, newUserCurrency || undefined, newUserLocale || undefined);
+      await UserAdminService.createUser(newUserEmail, newUserPassword, newUserIsAdmin, newUserCurrency || undefined, newUserLocale || undefined, newUserName || undefined);
       showToast('User created', 'success');
       setIsAddingUser(false);
-      setNewUserEmail(''); setNewUserPassword('');
+      setNewUserEmail(''); setNewUserName(''); setNewUserPassword('');
       fetchUsers();
     } catch (err) { showToast(apiErrorMessage(err, 'Failed to create user')); }
   };
 
   const handleUpdateUser = async () => {
     if (!editingUser?.id) return;
-    if (editUserPassword && editUserPassword !== editUserConfirmPassword) { showToast('Passwords do not match', 'error'); return; }
     try {
       await UserAdminService.updateUser(editingUser.id, { 
         name: editingUser.name, email: editingUser.email, currency: editingUser.currency || null, locale: editingUser.locale || null,
@@ -175,7 +205,7 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
                       {u.product_count ?? 0}
                     </td>
                     <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
-                      <button className="btn btn-secondary btn-sm" onClick={() => { setEditingUser(u); setEditUserPassword(''); setEditUserConfirmPassword(''); }} style={{ marginRight: '0.5rem' }}>Edit</button>
+                      <button className="btn btn-secondary btn-sm" onClick={() => { setEditingUser(u); setEditUserPassword(''); }} style={{ marginRight: '0.5rem' }}>Edit</button>
                       {u.id !== currentUser?.id && <button className="btn btn-danger btn-sm" onClick={() => setUserToDelete(u)}>Delete</button>}
                     </td>
                   </tr>
@@ -190,7 +220,32 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
         <div className="settings-card" style={{ borderLeft: '4px solid var(--primary)' }}>
           <h3 className="settings-card-title">Create New User</h3>
           <div className="form-group"><label>Email Address</label><input type="email" value={newUserEmail} onChange={e => setNewUserEmail(e.target.value)} placeholder="user@example.com" autoComplete="off" /></div>
-          <div className="form-group"><label>Account Password</label><PasswordInput secret value={newUserPassword} onChange={e => setNewUserPassword(e.target.value)} autoComplete="new-password" /></div>
+          <div className="form-group"><label>Display Name (Optional)</label><input type="text" value={newUserName} onChange={e => setNewUserName(e.target.value)} placeholder="e.g. Jane Doe" autoComplete="off" /></div>
+          <div className="form-group">
+            <label>Account Password</label>
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <div style={{ flex: 1 }}>
+                <PasswordInput secret value={newUserPassword} onChange={e => setNewUserPassword(e.target.value)} autoComplete="new-password" />
+              </div>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setNewUserPassword(generateRandomPassword())}
+              >
+                Generate
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                disabled={!newUserPassword}
+                onClick={() => copyToClipboard(newUserPassword)}
+                title="Copy password"
+                aria-label="Copy password"
+              >
+                <Icon name="clipboard" />
+              </button>
+            </div>
+          </div>
           
           <div className="form-grid">
             <div className="form-group">
@@ -280,9 +335,30 @@ export default function UsersSection({ globalCurrencies }: UsersSectionProps) {
             </div>
           </div>
           {!isSsoUser(editingUser) && (
-            <div className="form-grid" style={{ marginTop: '1rem' }}>
-              <div className="form-group"><label>New Password (Optional)</label><PasswordInput secret value={editUserPassword} onChange={e => setEditUserPassword(e.target.value)} autoComplete="new-password" /></div>
-              <div className="form-group"><label>Confirm New Password</label><PasswordInput secret value={editUserConfirmPassword} onChange={e => setEditUserConfirmPassword(e.target.value)} autoComplete="new-password" /></div>
+            <div className="form-group" style={{ marginTop: '1rem' }}>
+              <label>New Password (Optional)</label>
+              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                <div style={{ flex: 1 }}>
+                  <PasswordInput secret value={editUserPassword} onChange={e => setEditUserPassword(e.target.value)} autoComplete="new-password" />
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => setEditUserPassword(generateRandomPassword())}
+                >
+                  Generate
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={!editUserPassword}
+                  onClick={() => copyToClipboard(editUserPassword)}
+                  title="Copy password"
+                  aria-label="Copy password"
+                >
+                  <Icon name="clipboard" />
+                </button>
+              </div>
             </div>
           )}
           

--- a/frontend/src/features/admin/services/UserAdminService.ts
+++ b/frontend/src/features/admin/services/UserAdminService.ts
@@ -8,6 +8,6 @@ export const UserAdminService = {
     api.put(`/admin/users/${id}`, data),
   setUserAdmin: (id: number, isAdmin: boolean) => 
     api.put(`/admin/users/${id}/admin`, { is_admin: isAdmin }),
-  createUser: (email: string, pass: string, isAdmin: boolean, currency?: string, locale?: string) => 
-    api.post('/admin/users', { email, password: pass, is_admin: isAdmin, currency, locale }),
+  createUser: (email: string, pass: string, isAdmin: boolean, currency?: string, locale?: string, name?: string) =>
+    api.post('/admin/users', { email, password: pass, is_admin: isAdmin, currency, locale, name }),
 };

--- a/frontend/src/features/settings/pages/ProfileSection.tsx
+++ b/frontend/src/features/settings/pages/ProfileSection.tsx
@@ -7,10 +7,18 @@ import { useAuth } from '../../auth';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import { queryClient } from '../../../api/queryClient';
 import { profileQuery, queryKeys } from '../../../api/queries';
+import { useTheme, ThemeMode } from '../../../context/ThemeContext';
+
+const THEME_MODES: { value: ThemeMode; label: string; hint: string }[] = [
+  { value: 'auto', label: 'Auto', hint: 'Follow your operating system' },
+  { value: 'light', label: 'Light', hint: 'Always light' },
+  { value: 'dark', label: 'Dark', hint: 'Always dark' },
+];
 
 export default function ProfileSection() {
   const { showToast } = useToast();
   const { updateUser } = useAuth();
+  const { mode, setMode } = useTheme();
   const [profileName, setProfileName] = useState('');
   const initializedProfileId = useRef<number | null>(null);
   const profileResult = useQuery(profileQuery());
@@ -54,7 +62,25 @@ export default function ProfileSection() {
         <input type="text" className="form-control" value={profileName} onChange={e => setProfileName(e.target.value)} placeholder="Enter your name" />
       </div>
 
-      <div className="settings-actions">
+      <h2 className="settings-card-title" style={{ marginTop: '2rem' }}>Appearance</h2>
+      <p className="text-muted mb-4" style={{ fontSize: '0.875rem' }}>
+        Choose a color theme, or let it follow your operating system. Applied
+        immediately on this device.
+      </p>
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+        {THEME_MODES.map(t => (
+          <button
+            key={t.value}
+            className={`btn btn-sm ${mode === t.value ? 'btn-primary' : 'btn-secondary'}`}
+            title={t.hint}
+            onClick={() => setMode(t.value)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="settings-actions" style={{ marginTop: '2rem' }}>
         <button className="btn btn-secondary" onClick={() => setProfileName(profile.name || '')}>Cancel</button>
         <button className="btn btn-primary" onClick={handleSaveProfile} disabled={updateProfile.isPending}>
           {updateProfile.isPending ? 'Saving...' : 'Save Profile'}

--- a/frontend/src/features/settings/pages/RegionalSection.tsx
+++ b/frontend/src/features/settings/pages/RegionalSection.tsx
@@ -9,18 +9,10 @@ import LoadingSpinner from '../../../components/LoadingSpinner';
 import { queryClient } from '../../../api/queryClient';
 import { currenciesQuery, profileQuery, queryKeys } from '../../../api/queries';
 import { AUTOMATIC_CURRENCY_OPTION, AUTOMATIC_LOCALE_OPTION, LOCALE_OPTIONS } from '../regionalOptions';
-import { useTheme, ThemeMode } from '../../../context/ThemeContext';
-
-const THEME_MODES: { value: ThemeMode; label: string; hint: string }[] = [
-  { value: 'auto', label: 'Auto', hint: 'Follow your operating system' },
-  { value: 'light', label: 'Light', hint: 'Always light' },
-  { value: 'dark', label: 'Dark', hint: 'Always dark' },
-];
 
 export default function RegionalSection() {
   const { showToast } = useToast();
   const { updateUser } = useAuth();
-  const { mode, setMode } = useTheme();
   const [profileCurrency, setProfileCurrency] = useState('');
   const [profileLocale, setProfileLocale] = useState('');
   const initializedProfileId = useRef<number | null>(null);
@@ -98,24 +90,6 @@ export default function RegionalSection() {
         <button className="btn btn-primary" onClick={handleSaveRegional} disabled={updateProfile.isPending}>
           {updateProfile.isPending ? 'Saving...' : 'Save Regional Settings'}
         </button>
-      </div>
-
-      <h2 className="settings-card-title" style={{ marginTop: '2rem' }}>Appearance</h2>
-      <p className="text-muted mb-4" style={{ fontSize: '0.875rem' }}>
-        Choose a color theme, or let it follow your operating system. Applied
-        immediately on this device.
-      </p>
-      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-        {THEME_MODES.map(t => (
-          <button
-            key={t.value}
-            className={`btn btn-sm ${mode === t.value ? 'btn-primary' : 'btn-secondary'}`}
-            title={t.hint}
-            onClick={() => setMode(t.value)}
-          >
-            {t.label}
-          </button>
-        ))}
       </div>
     </section>
   );

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start:frontend": "pnpm --filter pricestalker-frontend run dev",
     "db:migrate": "pnpm --filter pricestalker-backend run db:migrate",
     "db:migrate:dev": "pnpm --filter pricestalker-backend run db:migrate:dev",
+    "reset-password": "pnpm --filter pricestalker-backend run reset-password:dev",
     "test:dev-env": "node --test scripts/create-local-env.test.mjs",
     "tree": "pnpm dlx tree-node-cli -I \"node_modules|build|dist|\\.git|\\.js\\.map|\\.d\\.ts\" -a",
     "lint": "node scripts/check-no-emoji.mjs"

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "start:frontend": "pnpm --filter pricestalker-frontend run dev",
     "db:migrate": "pnpm --filter pricestalker-backend run db:migrate",
     "db:migrate:dev": "pnpm --filter pricestalker-backend run db:migrate:dev",
-    "reset-password": "pnpm --filter pricestalker-backend run reset-password:dev",
+    "reset-password": "pnpm --filter pricestalker-backend run reset-password",
     "test:dev-env": "node --test scripts/create-local-env.test.mjs",
     "tree": "pnpm dlx tree-node-cli -I \"node_modules|build|dist|\\.git|\\.js\\.map|\\.d\\.ts\" -a",
-    "lint": "node scripts/check-no-emoji.mjs"
+    "lint": "node scripts/check-no-emoji.mjs",
+    "reset-password:dev": "pnpm --filter pricestalker-backend run reset-password:dev"
   },
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^11.12.0"


### PR DESCRIPTION
## Summary
This PR improves the Admin User Management experience, adds an admin CLI password recovery tool, and relocates theme/appearance settings to the main user profile.

## Key Changes
- **Admin User Management Password UX (`UsersSection.tsx`)**: Replaced redundant dual-password input with single password input, cryptographically secure password generator, and clipboard copy buttons for Create & Edit user forms. Added optional Display Name input on user creation.
- **Appearance & Theme Relocation (`ProfileSection.tsx`, `RegionalSection.tsx`)**: Moved Appearance (Auto / Light / Dark theme) selector from Regional Settings to main Profile page directly above the action buttons.
- **CLI Password Reset Tool (`backend/src/scripts/reset-password.ts`)**: Added `pnpm run reset-password <email-or-id> [password]` utility with automatic secure password generation, bcrypt encryption (12 rounds), and SSO safety warnings (emoji-free).
- **Changelog**: Updated `CHANGELOG.md` under `## [Unreleased]`.

## Verification
- `pnpm run lint`: Passed (0 emojis)
- `git diff --check`: Passed
- Frontend & Backend Builds: Passed
- Backend Vitest Unit Tests: 34/34 passed (451 tests)