### PR TITLE
fix(theme): prevent forced-dark algorithmic inversion in explicit light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and says so once at startup rather than failing silently.
 - Scraper log timestamps include milliseconds and are no longer written in an
   ambiguous day/month format.
+- Explicit Light mode now renders cleanly on Desktop Chrome when Windows Dark Mode
+  and Chrome Auto-Dark/Forced-Dark are active. Added `<meta name="color-scheme" content="light dark" />`
+  and set `color-scheme: only light` / `only dark` to explicitly opt out of browser-level
+  algorithmic color inversion when a theme is selected.
 
 ## [2.1.0-beta.4] - 2026-08-31
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="color-scheme" content="light dark" />
 
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#6366f1" />

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -32,6 +32,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.style.colorScheme = theme === 'dark' ? 'only dark' : 'only light';
   }, [theme]);
 
   const setMode = (next: ThemeMode) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,11 +22,11 @@
   --chart-text: #94a3b8;
 }
 
-/* An explicit light choice must also pin the UA colour scheme. Without this,
-   :root's `light dark` resolves to dark on a dark OS, so native controls render
-   with dark UA colours (buttontext turns white) on the app's light surfaces. */
+/* An explicit light choice must also pin the UA colour scheme. The `only` keyword
+   explicitly opts out of Chromium/Blink Auto-Dark / Forced-Dark heuristic inversions
+   when the user intentionally selected a light theme. */
 :root[data-theme="light"] {
-  color-scheme: light;
+  color-scheme: only light;
 }
 
 /* Dark theme variables */
@@ -45,7 +45,7 @@
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
   --chart-grid: #334155;
   --chart-text: #64748b;
-  color-scheme: dark;
+  color-scheme: only dark;
 }
 
 /* System dark preference - only apply if not explicitly set to light */
@@ -65,7 +65,7 @@
     --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
     --chart-grid: #334155;
     --chart-text: #64748b;
-    color-scheme: dark;
+    color-scheme: only dark;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes an issue on Desktop browsers (such as Chrome with Auto-Dark / Forced Dark enabled or Windows Dark Mode) where selecting explicit **Light Mode** caused the browser engine to algorithmically invert and mangle the light theme.

## Root Cause
When the OS is set to dark mode and browser-level forced dark algorithms are active, Chromium/Blink inspects the document's `color-scheme`. Because `index.html` lacked `<meta name="color-scheme">` and `index.css` used unpinned `color-scheme: light`, Blink heuristic engines assumed the page did not support dual themes and forcibly applied algorithmic color inversion to light surfaces and components.

## Changes
- **`<meta name="color-scheme">` (`index.html`)**: Added `<meta name="color-scheme" content="light dark" />` in `<head>` to signal native multi-theme support at the document level.
- **CSS Color Adjustment `only` keyword (`index.css`)**:
  - Updated `:root[data-theme="light"]` to `color-scheme: only light;` (and dark to `only dark;`).
  - The CSS Color Adjustment `only` keyword explicitly opts out of browser-level algorithmic color inversion when an explicit theme is chosen.
- **Dynamic Color-Scheme Sync (`ThemeContext.tsx`)**: Added `document.documentElement.style.colorScheme` synchronization on theme toggle to immediately notify browser engines of client-side theme transitions.
- **Changelog**: Added entry under `## [Unreleased]` in `CHANGELOG.md`.

## Verification
- `pnpm run lint`: Passed (0 emojis)
- `git diff --check`: Passed
- `pnpm --filter pricestalker-frontend run build`: Passed
- `pnpm --filter pricestalker-backend run build`: Passed
- `pnpm --filter pricestalker-backend exec vitest run`: Passed (34/34 test files, 451 tests)
- **Manual Browser Testing**: Verified in Chrome with forced dark mode and in Firefox with simulated dark mode; explicit light theme displays cleanly without inverted backgrounds or mangled contrast.