### PR TITLE
fix(logging): honour TZ in log timestamps across both services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Log timestamps now follow the `TZ` you configure. The backend always printed
+  UTC regardless, and the scraper was hardcoded to `Australia/Perth`, so every
+  install in the world read its scraper logs in Perth time -- while the
+  documentation said `TZ` controlled both. Unset or `UTC` is unchanged
+  (`2026-09-04T17:18:02.834Z`); any other zone renders the same ISO 8601 format
+  with a local offset (`2026-09-05T01:18:02.834+08:00`). Database rows and API
+  payloads stay UTC. A zone your runtime does not recognise falls back to UTC
+  and says so once at startup rather than failing silently.
+- Scraper log timestamps include milliseconds and are no longer written in an
+  ambiguous day/month format.
+
 ## [2.1.0-beta.4] - 2026-08-31
 
 ### Fixed

--- a/backend/src/app/server.ts
+++ b/backend/src/app/server.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { currencyCache } from '../utils/i18n/currency/cache';
+import { invalidTimezone, isTimezoneApplied } from '../utils/system/logging/timestamp';
 
 const PORT = process.env.PORT || 3001;
 
@@ -45,6 +46,16 @@ export async function startServer() {
   try {
     // Rotate logs if they exceed size limit on startup
     rotateLogsOnStartup();
+
+    // 0. Say once whether TZ is being honoured. A misspelled zone falls back to
+    //    UTC rather than taking the logger down, which without this line would
+    //    leave an operator staring at UTC timestamps with no idea why.
+    const badTz = invalidTimezone();
+    if (badTz) {
+      logger.warn(`System | Server | TZ="${badTz}" is not a timezone this runtime recognises. Log timestamps will use UTC.`, 'Server');
+    } else if (isTimezoneApplied()) {
+      logger.info(`System | Server | Log timestamps using TZ=${process.env.TZ}`, 'Server');
+    }
 
     // 1. Initialize DB and Logger Persistence
     await initializeDatabase();

--- a/backend/src/utils/system/logging/printer.ts
+++ b/backend/src/utils/system/logging/printer.ts
@@ -2,6 +2,7 @@ import { LogLevel, saveToDb } from './persistence';
 import fs from 'fs';
 import path from 'path';
 import { scrubSensitiveData } from './scrubber';
+import { formatLogTimestamp } from './timestamp';
 
 const DEFAULT_LOG_LEVEL = 'INFO';
 const LOG_DIR = process.env.LOG_DIR_PATH || path.join(process.cwd(), 'logs');
@@ -97,7 +98,9 @@ export function print(level: LogLevel, msg: string, context?: string, details?: 
   // Strip common redundant prefixes
   cleanMsg = cleanMsg.replace(/^System [|:] /, '');
 
-  const ts = new Date().toISOString();
+  // Respects TZ. Was toISOString(), which is UTC by definition whatever TZ
+  // says, so a Perth-configured install still logged in UTC (issue #146).
+  const ts = formatLogTimestamp();
   const ctx = context ? ' [' + context + ']' : '';
 
   // Prepare Console-safe version (Strip HTML tags for Docker visibility)

--- a/backend/src/utils/system/logging/timestamp.ts
+++ b/backend/src/utils/system/logging/timestamp.ts
@@ -1,0 +1,118 @@
+/**
+ * Log timestamps that respect the configured `TZ` (issue #146).
+ *
+ * `new Date().toISOString()` is always UTC, whatever `TZ` says -- that is what
+ * the method is for. So the backend emitted `2026-09-04T17:18:02.834Z` on an
+ * install configured for `Australia/Perth`, while both
+ * `docs/developer/ENVIRONMENT_VARIABLES.md` and `docs/developer/LOGGING.md`
+ * documented `TZ` as controlling exactly this. The scraper had the mirror-image
+ * problem: it hardcoded `Australia/Perth`, so every install in the world read
+ * its scraper logs in Perth time.
+ *
+ * Only console and file output changes. `system_logs` rows carry no timestamp
+ * from here -- Postgres supplies `created_at` -- so stored data and the API
+ * stay UTC, which is what they should be.
+ *
+ * ## Format
+ *
+ *   TZ unset, or UTC   2026-09-04T17:18:02.834Z        (byte-identical to before)
+ *   TZ=Australia/Perth 2026-09-05T01:18:02.834+08:00
+ *
+ * ISO 8601 either way, so a timestamp is still unambiguous and still sorts
+ * within a single stream. Leaving the UTC case exactly as it was matters:
+ * anything already grepping or parsing these logs keeps working unless the
+ * operator opts in by setting `TZ`.
+ */
+
+/** Zones that mean "just use UTC", where the plain ISO string is already right. */
+const UTC_ALIASES = new Set(['UTC', 'ETC/UTC', 'ETC/GMT', 'GMT', 'Z']);
+
+interface Formatter {
+  format(date: Date): string;
+}
+
+/**
+ * Built once. `Intl.DateTimeFormat` is expensive to construct and this runs on
+ * every log line, so building it per call would put a measurable cost on the
+ * hottest path in the process.
+ */
+const formatter: Formatter | null = buildFormatter();
+
+function buildFormatter(): Formatter | null {
+  const tz = process.env.TZ?.trim();
+  if (!tz || UTC_ALIASES.has(tz.toUpperCase())) return null;
+
+  try {
+    const intl = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      fractionalSecondDigits: 3,
+      timeZoneName: 'longOffset',
+    });
+    // Prove it actually works before installing it. A zone can be accepted by
+    // the constructor and still misbehave on a Node build without full ICU.
+    const probe = renderWith(intl, new Date());
+    if (!probe) return null;
+    return { format: (date: Date) => renderWith(intl, date) ?? date.toISOString() };
+  } catch {
+    // An unrecognised zone -- a typo like `Australia/Perht` -- must not take the
+    // logger down with it. A process that cannot log is far worse than one
+    // logging in the wrong timezone, so fall back silently to UTC. The warning
+    // is emitted by warnIfTimezoneInvalid() once, at startup, rather than from
+    // here: this module is imported by the logger, and logging from inside it
+    // during construction risks recursion.
+    return null;
+  }
+}
+
+/** Assembles `YYYY-MM-DDTHH:mm:ss.sss+HH:MM`, or null if the parts look wrong. */
+function renderWith(intl: Intl.DateTimeFormat, date: Date): string | null {
+  const parts: Record<string, string> = {};
+  for (const part of intl.formatToParts(date)) parts[part.type] = part.value;
+
+  const { year, month, day, hour, minute, second, fractionalSecond } = parts;
+  if (!year || !month || !day || !hour || !minute || !second) return null;
+
+  // `longOffset` renders as "GMT+08:00", and as a bare "GMT" at zero offset.
+  const raw = parts.timeZoneName ?? '';
+  const offset = raw === 'GMT' ? '+00:00' : raw.replace(/^GMT/, '');
+  if (!/^[+-]\d{2}:\d{2}$/.test(offset)) return null;
+
+  // 24:00 is a legal Intl rendering of midnight; ISO 8601 wants 00:00.
+  const hh = hour === '24' ? '00' : hour;
+
+  return `${year}-${month}-${day}T${hh}:${minute}:${second}.${fractionalSecond ?? '000'}${offset}`;
+}
+
+/**
+ * The timestamp prefix for one log line.
+ *
+ * Never throws. The logger is the thing you reach for when everything else is
+ * broken; it must not become the thing that breaks.
+ */
+export function formatLogTimestamp(date: Date = new Date()): string {
+  if (!formatter) return date.toISOString();
+  try {
+    return formatter.format(date);
+  } catch {
+    return date.toISOString();
+  }
+}
+
+/** True when `TZ` was set to something usable and is being applied. */
+export function isTimezoneApplied(): boolean {
+  return formatter !== null;
+}
+
+/**
+ * Whether `TZ` was set but could not be used, so a caller can say so once at
+ * startup. Silently ignoring a misspelled zone would leave an operator staring
+ * at UTC timestamps with no idea why.
+ */
+export function invalidTimezone(): string | null {
+  const tz = process.env.TZ?.trim();
+  if (!tz || UTC_ALIASES.has(tz.toUpperCase())) return null;
+  return formatter === null ? tz : null;
+}

--- a/backend/tests/unit/log-timestamp.test.ts
+++ b/backend/tests/unit/log-timestamp.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * `new Date().toISOString()` is UTC by definition, whatever `TZ` says, so a
+ * Perth-configured install logged in UTC while two docs pages promised
+ * otherwise (issue #146). The scraper had the mirror-image bug: it hardcoded
+ * `Australia/Perth`, so every install in the world read its scraper logs in
+ * Perth time.
+ *
+ * The module reads `process.env.TZ` once at import and caches the formatter --
+ * building an Intl.DateTimeFormat per log line would be a real cost on the
+ * hottest path in the process. So each case here re-imports with a fresh
+ * module registry.
+ */
+
+const FIXED = new Date('2026-09-04T17:18:02.834Z');
+const originalTz = process.env.TZ;
+
+async function loadWith(tz: string | undefined) {
+  vi.resetModules();
+  if (tz === undefined) delete process.env.TZ;
+  else process.env.TZ = tz;
+  return import('../../src/utils/system/logging/timestamp');
+}
+
+beforeEach(() => vi.resetModules());
+afterEach(() => {
+  if (originalTz === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTz;
+});
+
+describe('the bug', () => {
+  it('renders a TZ-configured install in that timezone, not UTC', async () => {
+    const { formatLogTimestamp } = await loadWith('Australia/Perth');
+    // 17:18 UTC is 01:18 the next day in Perth (UTC+8).
+    expect(formatLogTimestamp(FIXED)).toBe('2026-09-05T01:18:02.834+08:00');
+  });
+
+  it('handles a negative offset', async () => {
+    const { formatLogTimestamp } = await loadWith('America/New_York');
+    expect(formatLogTimestamp(FIXED)).toBe('2026-09-04T13:18:02.834-04:00');
+  });
+
+  it('handles a half-hour offset', async () => {
+    const { formatLogTimestamp } = await loadWith('Asia/Kolkata');
+    expect(formatLogTimestamp(FIXED)).toBe('2026-09-04T22:48:02.834+05:30');
+  });
+
+  it('keeps sub-second precision, which the scraper used to drop', async () => {
+    // The old scraper format was `01/09/2026, 3:11:40 am` -- no milliseconds,
+    // and day/month ambiguous to half its readers.
+    const { formatLogTimestamp } = await loadWith('Europe/Zurich');
+    expect(formatLogTimestamp(FIXED)).toMatch(/\.\d{3}\+02:00$/);
+  });
+});
+
+describe('the UTC case stays byte-identical', () => {
+  // Anything already grepping or parsing these logs must keep working unless
+  // the operator opts in by setting TZ.
+  it.each([undefined, 'UTC', 'Etc/UTC', 'GMT'])('TZ=%s renders exactly as before', async (tz) => {
+    const { formatLogTimestamp } = await loadWith(tz);
+    expect(formatLogTimestamp(FIXED)).toBe(FIXED.toISOString());
+    expect(formatLogTimestamp(FIXED)).toBe('2026-09-04T17:18:02.834Z');
+  });
+
+  it('treats an empty or whitespace TZ as unset', async () => {
+    for (const tz of ['', '   ']) {
+      const { formatLogTimestamp } = await loadWith(tz);
+      expect(formatLogTimestamp(FIXED)).toBe(FIXED.toISOString());
+    }
+  });
+});
+
+describe('a bad TZ must not take the logger down', () => {
+  // A process that cannot log is far worse than one logging in the wrong
+  // timezone. Intl.DateTimeFormat throws RangeError on an unknown zone.
+  it.each(['Australia/Perht', 'Not/A/Zone', 'garbage', '../../etc/passwd'])(
+    'falls back to UTC for TZ=%s instead of throwing',
+    async (tz) => {
+      const { formatLogTimestamp } = await loadWith(tz);
+      expect(() => formatLogTimestamp(FIXED)).not.toThrow();
+      expect(formatLogTimestamp(FIXED)).toBe(FIXED.toISOString());
+    }
+  );
+
+  it('reports the bad value so it can be surfaced once at startup', async () => {
+    const { invalidTimezone, isTimezoneApplied } = await loadWith('Australia/Perht');
+    expect(invalidTimezone()).toBe('Australia/Perht');
+    expect(isTimezoneApplied()).toBe(false);
+  });
+
+  it('reports nothing when the zone is good, or when none was asked for', async () => {
+    const good = await loadWith('Australia/Perth');
+    expect(good.invalidTimezone()).toBeNull();
+    expect(good.isTimezoneApplied()).toBe(true);
+
+    const none = await loadWith(undefined);
+    expect(none.invalidTimezone()).toBeNull();
+    expect(none.isTimezoneApplied()).toBe(false);
+  });
+});
+
+describe('the output is still a valid, parseable timestamp', () => {
+  it('round-trips back to the instant it was given', async () => {
+    // The whole point of keeping ISO 8601 with an offset: shifting the display
+    // timezone must not change which moment the line refers to.
+    for (const tz of ['Australia/Perth', 'America/New_York', 'Asia/Kolkata', 'Europe/Zurich']) {
+      const { formatLogTimestamp } = await loadWith(tz);
+      expect(new Date(formatLogTimestamp(FIXED)).getTime()).toBe(FIXED.getTime());
+    }
+  });
+
+  it('sorts in the same order as the instants, within one stream', async () => {
+    const { formatLogTimestamp } = await loadWith('Australia/Perth');
+    const stamps = [0, 1000, 60_000, 3_600_000].map(ms => formatLogTimestamp(new Date(FIXED.getTime() + ms)));
+    expect([...stamps].sort()).toEqual(stamps);
+  });
+
+  it('renders midnight as 00:00, not 24:00', async () => {
+    // Intl may legitimately render midnight as hour 24; ISO 8601 wants 00.
+    const { formatLogTimestamp } = await loadWith('Australia/Perth');
+    // 16:00 UTC is exactly midnight in Perth.
+    expect(formatLogTimestamp(new Date('2026-09-04T16:00:00.000Z'))).toBe('2026-09-05T00:00:00.000+08:00');
+  });
+
+  it('follows daylight saving rather than pinning one offset', async () => {
+    const { formatLogTimestamp } = await loadWith('Europe/Zurich');
+    expect(formatLogTimestamp(new Date('2026-01-15T12:00:00.000Z'))).toContain('+01:00');
+    expect(formatLogTimestamp(new Date('2026-07-15T12:00:00.000Z'))).toContain('+02:00');
+  });
+});

--- a/docs/developer/ENVIRONMENT_VARIABLES.md
+++ b/docs/developer/ENVIRONMENT_VARIABLES.md
@@ -35,7 +35,7 @@ Used to customize the database connection and volume persistence.
 | `IMAGE_REGISTRY` | Docker image registry URL. | `ghcr.io` |
 | `IMAGE_NAMESPACE` | GitHub container namespace or owner. | `mikeknight85` |
 | `IMAGE_TAG` | Image release tag. Use `stable` (or `latest`) for versioned releases, `beta` for the pre-release channel tracking `main`, or pin an immutable version tag (e.g. `v2.1.0-beta.4`). | `stable` |
-| `TZ` | System timezone. This affects log timestamps and cron job schedule targets. | `UTC` |
+| `TZ` | System timezone. Affects log timestamps in both services and cron schedule targets. Database timestamps and API payloads remain UTC. An unrecognised zone falls back to UTC and is reported once at startup. | `UTC` |
 | `LOG_LEVEL` | Verbosity of the system logger: `debug`, `info`, `warn`, or `error`. See [LOGGING.md](LOGGING.md) for detailed configuration options. | `info` |
 | `BACKEND_MEM_LIMIT` | Docker container memory constraint for the backend service. | `1g` |
 | `REDACT_API_KEYS` | When set to `true`, AI API credentials stored in settings are masked (`sk-...xxxx`) in the Admin panel and cannot be revealed via the UI. | `false` |

--- a/docs/developer/LOGGING.md
+++ b/docs/developer/LOGGING.md
@@ -26,7 +26,7 @@ Logging behavior is controlled via environment variables in your `.env` file or 
 | `SLOW_QUERY_MS` | Any positive integer | `500` | A SQL statement taking at least this long is logged at `WARN` instead of `DEBUG`. |
 | `AI_TRACE_CHARS` | Any positive integer | `2000` | How much of an AI prompt and response to record at `DEBUG`. Both are capped: a prompt carries the denoised product page. |
 | `LOG_DIR_PATH` | Any valid absolute/relative directory | `./logs` | Directory path where log files are written. |
-| `TZ` | e.g. `Australia/Perth`, `UTC` | `UTC` | Controls the timezone prefix format for both services. |
+| `TZ` | e.g. `Australia/Perth`, `UTC` | `UTC` | Timezone for log timestamps in both services. Unset or `UTC` gives ISO 8601 UTC (`2026-09-04T17:18:02.834Z`); any other zone gives the same format with a local offset (`2026-09-05T01:18:02.834+08:00`). Database rows and API payloads stay UTC regardless. A zone the runtime does not recognise falls back to UTC and is reported once at startup. |
 
 ---
 

--- a/scraper/src/scraper.ts
+++ b/scraper/src/scraper.ts
@@ -3,6 +3,7 @@ import { log } from './utils/logger.js';
 import { startWatchdog, cleanupStaleProfiles, shutdownAllSessions } from './core/SessionManager.js';
 import router from './api/routes.js';
 import { errorMessage } from './types.js';
+import { invalidTimezone } from './utils/timestamp.js';
 
 const app = express();
 app.use(express.json({ limit: '10mb' }));
@@ -31,5 +32,11 @@ for (const signal of ['SIGTERM', 'SIGINT'] as const) {
 }
 
 app.listen(PORT, '0.0.0.0', () => {
+  // Once, at startup: a misspelled TZ falls back to UTC rather than throwing,
+  // so without this the operator has no way to tell why it was ignored.
+  const badTz = invalidTimezone();
+  if (badTz) {
+    log(`TZ="${badTz}" is not a timezone this runtime recognises. Log timestamps will use UTC.`, 'WARN');
+  }
   log(`Scraper API listening at http://0.0.0.0:${PORT}`, 'INFO');
 });

--- a/scraper/src/utils/logger.ts
+++ b/scraper/src/utils/logger.ts
@@ -3,6 +3,7 @@
  */
 
 import type { LogContext } from '../types.js';
+import { formatLogTimestamp } from './timestamp.js';
 
 const LEVELS = {
   DEBUG: 0,
@@ -29,7 +30,7 @@ export function log(message: string, type: string = 'INFO', context: LogContext 
     return;
   }
 
-  const timestamp = new Date().toLocaleString('en-AU', { timeZone: 'Australia/Perth' });
+  const timestamp = formatLogTimestamp();
   const typeStr = type.padEnd(5);
   
   // Format context identifiers

--- a/scraper/src/utils/timestamp.ts
+++ b/scraper/src/utils/timestamp.ts
@@ -1,0 +1,106 @@
+/**
+ * Log timestamps that respect the configured `TZ` (issue #146).
+ *
+ * Duplicated from backend/src/utils/system/logging/timestamp.ts rather than
+ * shared, because the two workspaces have no common package -- the same reason
+ * scraper/src/utils/userAgent.ts is duplicated. Keep them in step: the point is
+ * that both services stamp their logs the same way, so a Docker log stream
+ * interleaving the two reads as one timeline.
+ *
+ * This side had the mirror-image bug. It hardcoded `Australia/Perth`, so every
+ * install in the world read its scraper logs in Perth time, and the format was
+ * `01/09/2026, 3:11:40 am` -- day/month ambiguous to half its readers.
+ */
+
+/** Zones that mean "just use UTC", where the plain ISO string is already right. */
+const UTC_ALIASES = new Set(['UTC', 'ETC/UTC', 'ETC/GMT', 'GMT', 'Z']);
+
+interface Formatter {
+  format(date: Date): string;
+}
+
+/**
+ * Built once. `Intl.DateTimeFormat` is expensive to construct and this runs on
+ * every log line, so building it per call would put a measurable cost on the
+ * hottest path in the process.
+ */
+const formatter: Formatter | null = buildFormatter();
+
+function buildFormatter(): Formatter | null {
+  const tz = process.env.TZ?.trim();
+  if (!tz || UTC_ALIASES.has(tz.toUpperCase())) return null;
+
+  try {
+    const intl = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      fractionalSecondDigits: 3,
+      timeZoneName: 'longOffset',
+    });
+    // Prove it actually works before installing it. A zone can be accepted by
+    // the constructor and still misbehave on a Node build without full ICU.
+    const probe = renderWith(intl, new Date());
+    if (!probe) return null;
+    return { format: (date: Date) => renderWith(intl, date) ?? date.toISOString() };
+  } catch {
+    // An unrecognised zone -- a typo like `Australia/Perht` -- must not take the
+    // logger down with it. A process that cannot log is far worse than one
+    // logging in the wrong timezone, so fall back silently to UTC. The warning
+    // is emitted by warnIfTimezoneInvalid() once, at startup, rather than from
+    // here: this module is imported by the logger, and logging from inside it
+    // during construction risks recursion.
+    return null;
+  }
+}
+
+/** Assembles `YYYY-MM-DDTHH:mm:ss.sss+HH:MM`, or null if the parts look wrong. */
+function renderWith(intl: Intl.DateTimeFormat, date: Date): string | null {
+  const parts: Record<string, string> = {};
+  for (const part of intl.formatToParts(date)) parts[part.type] = part.value;
+
+  const { year, month, day, hour, minute, second, fractionalSecond } = parts;
+  if (!year || !month || !day || !hour || !minute || !second) return null;
+
+  // `longOffset` renders as "GMT+08:00", and as a bare "GMT" at zero offset.
+  const raw = parts.timeZoneName ?? '';
+  const offset = raw === 'GMT' ? '+00:00' : raw.replace(/^GMT/, '');
+  if (!/^[+-]\d{2}:\d{2}$/.test(offset)) return null;
+
+  // 24:00 is a legal Intl rendering of midnight; ISO 8601 wants 00:00.
+  const hh = hour === '24' ? '00' : hour;
+
+  return `${year}-${month}-${day}T${hh}:${minute}:${second}.${fractionalSecond ?? '000'}${offset}`;
+}
+
+/**
+ * The timestamp prefix for one log line.
+ *
+ * Never throws. The logger is the thing you reach for when everything else is
+ * broken; it must not become the thing that breaks.
+ */
+export function formatLogTimestamp(date: Date = new Date()): string {
+  if (!formatter) return date.toISOString();
+  try {
+    return formatter.format(date);
+  } catch {
+    return date.toISOString();
+  }
+}
+
+/** True when `TZ` was set to something usable and is being applied. */
+export function isTimezoneApplied(): boolean {
+  return formatter !== null;
+}
+
+/**
+ * Whether `TZ` was set but could not be used, so a caller can say so once at
+ * startup. Silently ignoring a misspelled zone would leave an operator staring
+ * at UTC timestamps with no idea why.
+ */
+export function invalidTimezone(): string | null {
+  const tz = process.env.TZ?.trim();
+  if (!tz || UTC_ALIASES.has(tz.toUpperCase())) return null;
+  return formatter === null ? tz : null;
+}


### PR DESCRIPTION
Both services ignored the configured timezone, in opposite directions.

- **Backend** stamped every line with `new Date().toISOString()` — UTC by definition whatever `TZ` says; that is what the method is for.
- **Scraper** hardcoded `Australia/Perth`, so **every install in the world read its scraper logs in Perth time**.

Meanwhile `docs/developer/ENVIRONMENT_VARIABLES.md:38` and `docs/developer/LOGGING.md:29` both documented `TZ` as controlling exactly this. Thanks @stevene1919 — the diagnosis in the issue was accurate down to the line numbers.

## What changed

One formatter, duplicated across the two workspaces for the same reason `scraper/src/utils/userAgent.ts` is — they share no package. Keeping them identical is the point: a Docker stream interleaving both services should read as one timeline, which it could not while one was UTC and the other was Perth *in a different format entirely*.

**The UTC case is byte-identical to before.** Unset, `UTC`, `Etc/UTC` and `GMT` all still render `2026-09-04T17:18:02.834Z`, so anything already grepping or parsing these logs keeps working unless the operator opts in. Any other zone renders the same ISO 8601 shape with a local offset:

```
TZ=(unset)            2026-09-04T17:18:02.834Z
TZ=UTC                2026-09-04T17:18:02.834Z
TZ=Australia/Perth    2026-09-05T01:18:02.834+08:00
TZ=Europe/Zurich      2026-09-04T19:18:02.834+02:00
TZ=America/New_York   2026-09-04T13:18:02.834-04:00
TZ=Australia/Perht    2026-09-04T17:18:02.834Z   <- TZ rejected, fell back to UTC
```

**Only console and file output changes.** `persistence.ts` inserts no timestamp — Postgres supplies `system_logs.created_at` — so stored rows and the API stay UTC, which is the third point in the issue and where they belong.

## Two things the implementation is careful about

Both matter because this is the hottest path in the process:

1. **The `Intl.DateTimeFormat` is built once at import**, not per line. Constructing one per log call would be a real cost.
2. **A zone the runtime cannot parse falls back to UTC rather than throwing.** A process that cannot log is far worse than one logging in the wrong timezone. That fallback is silent at the call site and reported **once at startup** by each service — warning from inside the timestamp module risks recursion through the logger that imports it, and an operator who typed `Australia/Perht` would otherwise stare at UTC with no explanation.

## Scraper format

Old: `05/09/2026, 1:18:02 am` — no milliseconds, and day/month ambiguous to half its readers. Both fixed by the move to ISO. This is a visible change to scraper log output, which the issue asks for under "Unified Timestamp Format".

## Verification

Against the **built** output of both compiled services, not just source — six zones including a deliberate typo, as shown above.

470 backend tests, up from 451: the offset cases (positive, negative, half-hour), the byte-identical UTC path, four malformed zones, round-tripping back to the original instant, sort order within a stream, midnight rendering as `00` rather than `24`, and daylight saving moving the offset between January and July.

`tsc` (backend + scraper), frontend build, emoji lint, `git diff --check` all pass. Docs corrected.

Closes #146