### PR TITLE
fix(scraper): recognise challenge pages whatever the casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retailer bot-challenge pages are recognised instead of being scraped as
+  though they were products. Detection matched case-sensitively, so a
+  PerimeterX page (which spells the vendor `PerimeterX`), Amazon's
+  `/errors_page/validateCaptcha`, Amazon's "Server Busy" title and any
+  "Access Denied" title carrying a suffix all went unnoticed. A missed
+  challenge meant no price was found, auto-mapping rejected a config built
+  from challenge HTML, the add failed with an unexplained error, and the
+  browser-scraper fallback never fired.
+- A challenge page whose title names a captcha is now detected regardless of
+  page size. The size limit that stops the word appearing on a genuine product
+  page from triggering a false positive was also being applied to the title,
+  which is far more specific and cheap to check.
+
+### Fixed
+
 - Log timestamps now follow the `TZ` you configure. The backend always printed
   UTC regardless, and the scraper was hardcoded to `Australia/Perth`, so every
   install in the world read its scraper logs in Perth time -- while the

--- a/backend/src/services/scraper/transport/detection.ts
+++ b/backend/src/services/scraper/transport/detection.ts
@@ -2,44 +2,97 @@ import { type CheerioAPI } from 'cheerio';
 
 /**
  * Detects common bot challenges in HTML.
+ *
+ * Getting this wrong is expensive in a specific way (issue #149). A challenge
+ * page arrives with HTTP 200 and looks, to everything downstream, like a
+ * product page that simply has no price on it. So a miss here means:
+ * extraction finds nothing, AI auto-mapping generates a config from challenge
+ * HTML and rejects it, the add fails with a flat 400 explaining nothing, and
+ * the browser-scraper fallback never fires because it is gated on the
+ * challengeReason this function returns.
+ *
+ * Matching was case-sensitive, which missed four things outright -- including
+ * `PerimeterX`, the vendor's own casing of its own name, and Amazon's
+ * `/errors_page/validateCaptcha`. Everything is matched case-insensitively now.
+ *
+ * ## Why regexes rather than html.toLowerCase()
+ *
+ * This runs on every scrape, and a real product page is routinely several
+ * megabytes. Lowercasing it would allocate a second copy of the whole document
+ * every time, on the path where we expect to find nothing. These patterns are
+ * compiled once at module load and scan in place.
  */
-export function detectBotChallenge(html: string, $: CheerioAPI): string | null {
-  const title = $('title').text().toLowerCase();
 
-  // Akamai / Edgesuite (Kmart)
-  if (title === 'access denied' || html.includes('Reference #18.') || html.includes('errors.edgesuite.net')) {
+/** Body markers, compiled once. Order is irrelevant; each is tried in turn. */
+const AKAMAI_BODY = /Reference\s*#18\.|errors\.edgesuite\.net/i;
+const CLOUDFLARE_BODY = /cloudflare-static|cf-browser-verification|\/cdn-cgi\/challenge-platform/i;
+const DATADOME_BODY = /geo\.captcha|dd-captcha|datadome\.co/i;
+const INCAPSULA_BODY = /Incapsula incident ID|_Incapsula_Resource/i;
+const PERIMETERX_BODY = /perimeterx|px-captcha|block\.perimeterx\.net/i;
+
+/**
+ * Generic last-resort markers, only ever applied to a small body.
+ *
+ * The size guard is what keeps the word "captcha" appearing somewhere in a
+ * genuine 3MB product page from taking that product offline. A challenge page
+ * is small by nature -- the ones measured on this project are 2.8KB and 8.3KB.
+ */
+const GENERIC_BODY = /captcha|prove you are human|are you a robot|unusual traffic|automated access/i;
+const GENERIC_BODY_MAX_BYTES = 15000;
+
+/** Titles are cheap to test and far more specific, so they are never size-gated. */
+const AKAMAI_TITLE = /access denied/i;
+const ROBOT_TITLE = /are you a robot|robot check|verify you are human|bot verification|verify you are a human/i;
+const CLOUDFLARE_TITLE = /just a moment|cloudflare|attention required/i;
+const PERIMETERX_TITLE = /access to this page has been denied/i;
+/** Amazon serves its CAPTCHA under this title, which matched nothing before. */
+const AMAZON_TITLE = /server busy|robot check/i;
+const GENERIC_TITLE = /captcha|are you human|security check/i;
+
+export function detectBotChallenge(html: string, $: CheerioAPI): string | null {
+  const title = $('title').text();
+
+  // Akamai / Edgesuite (Kmart, Target). The title test was an exact equality
+  // against 'access denied', so anything with a suffix -- "Access Denied -
+  // Target Australia" -- fell straight through.
+  if (AKAMAI_TITLE.test(title) || AKAMAI_BODY.test(html)) {
     return 'Akamai Access Denied';
   }
 
   // Retailer-specific robot interstitials (e.g. digitec/galaxus "Are you a
   // robot?"). These pages carry robots-noindex and no product data, so
   // without this check they are misread as soft-404 dead pages.
-  if (title.includes('are you a robot') || title.includes('robot check') || title.includes('verify you are human') || title.includes('bot verification')) {
+  if (ROBOT_TITLE.test(title)) {
     return 'Robot Check Interstitial';
   }
 
-  // Cloudflare
-  if (title.includes('just a moment') || title.includes('cloudflare') || html.includes('cloudflare-static') || html.includes('cf-browser-verification')) {
+  if (CLOUDFLARE_TITLE.test(title) || CLOUDFLARE_BODY.test(html)) {
     return 'Cloudflare Challenge';
   }
 
-  // DataDome
-  if (html.includes('geo.captcha') || html.includes('dd-captcha') || html.includes('datadome.co')) {
+  if (DATADOME_BODY.test(html)) {
     return 'DataDome Challenge';
   }
 
-  // Imperva / Incapsula
-  if (html.includes('Incapsula incident ID') || html.includes('_Incapsula_Resource')) {
+  if (INCAPSULA_BODY.test(html)) {
     return 'Imperva/Incapsula Challenge';
   }
 
-  // PerimeterX
-  if (html.includes('perimeterx') || html.includes('px-captcha') || title.includes('access to this page has been denied') || html.includes('block.perimeterx.net')) {
+  if (PERIMETERX_TITLE.test(title) || PERIMETERX_BODY.test(html)) {
     return 'PerimeterX Challenge';
   }
 
-  // Generic Captcha / Bot signals
-  if (html.length < 15000 && (html.includes('captcha') || title.includes('captcha') || html.includes('Prove you are human') || html.includes('Are you a robot'))) {
+  // Amazon's CAPTCHA page: title "Server Busy", body linking
+  // /errors_page/validateCaptcha. Named separately from the generic branch
+  // because "no price found" on Amazon is a common enough report that the log
+  // line saying which of the two happened is worth having.
+  if (AMAZON_TITLE.test(title)) {
+    return 'Amazon Bot Challenge';
+  }
+
+  // Generic signals. The title is checked whatever the page size; the body only
+  // when the page is too small to be a real product page.
+  if (GENERIC_TITLE.test(title) || (html.length < GENERIC_BODY_MAX_BYTES && GENERIC_BODY.test(html))) {
     return 'Generic Bot Challenge';
   }
 

--- a/backend/tests/unit/bot-challenge-detection.test.ts
+++ b/backend/tests/unit/bot-challenge-detection.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { load } from 'cheerio';
+import { detectBotChallenge } from '../../src/services/scraper/transport/detection';
+
+/**
+ * A challenge page arrives with HTTP 200 and looks, to everything downstream,
+ * like a product page that simply has no price on it. A miss here means
+ * extraction finds nothing, auto-mapping generates a config from challenge HTML
+ * and rejects it, the add fails with a flat 400, and the browser fallback never
+ * fires -- because it is gated on what this function returns (issue #149).
+ *
+ * This function had no tests at all despite gating that whole path.
+ */
+
+const detect = (html: string) => detectBotChallenge(html, load(html));
+const page = (title: string, body = '') => `<html><head><title>${title}</title></head><body>${body}</body></html>`;
+
+/** Padding, to build a page too large for the size-gated generic body check. */
+const bulk = (bytes: number) => '<div>product detail</div>'.repeat(Math.ceil(bytes / 25));
+
+describe('the four case-sensitivity misses', () => {
+  it('catches PerimeterX in the vendor own casing', () => {
+    // html.includes('perimeterx') returned false against 'PerimeterX'.
+    expect(detect(page('Loading', '<script src="/_px/PerimeterX/init.js"></script>')))
+      .toBe('PerimeterX Challenge');
+  });
+
+  it('catches Amazon /errors_page/validateCaptcha', () => {
+    // html.includes('captcha') returned false against the capital C.
+    expect(detect(page('Amazon.com', '<form action="/errors_page/validateCaptcha"></form>')))
+      .not.toBeNull();
+  });
+
+  it('catches Amazon "Server Busy", which matched nothing at all', () => {
+    expect(detect(page('Server Busy'))).toBe('Amazon Bot Challenge');
+  });
+
+  it('catches an Access Denied title that carries a suffix', () => {
+    // The check was an exact equality against 'access denied'.
+    expect(detect(page('Access Denied - Target Australia'))).toBe('Akamai Access Denied');
+    expect(detect(page('Access Denied'))).toBe('Akamai Access Denied');
+  });
+});
+
+describe('each vendor, however it cases its markers', () => {
+  it.each([
+    ['Akamai reference', page('Error', 'Reference #18.abc123'), 'Akamai Access Denied'],
+    ['Akamai edgesuite', page('Error', 'errors.EDGESUITE.net'), 'Akamai Access Denied'],
+    ['Cloudflare title', page('Just a moment...'), 'Cloudflare Challenge'],
+    ['Cloudflare body', page('x', '<script src="/cdn-cgi/challenge-platform/h/b/x"></script>'), 'Cloudflare Challenge'],
+    ['DataDome', page('x', '<script src="https://geo.captcha-delivery.com/c.js"></script>'), 'DataDome Challenge'],
+    ['Incapsula', page('x', 'Incapsula incident ID: 1234'), 'Imperva/Incapsula Challenge'],
+    ['PerimeterX denied title', page('Access to this page has been denied'), 'PerimeterX Challenge'],
+    ['robot interstitial', page('Are you a robot?'), 'Robot Check Interstitial'],
+  ])('%s', (_label, html, expected) => {
+    expect(detect(html)).toBe(expected);
+  });
+
+  it('matches regardless of how the marker is cased', () => {
+    for (const variant of ['DataDome.co', 'datadome.co', 'DATADOME.CO']) {
+      expect(detect(page('x', `<script src="//${variant}/x.js"></script>`))).toBe('DataDome Challenge');
+    }
+  });
+});
+
+describe('the size guard, which is what stops false positives', () => {
+  it('does not flag a large genuine page that happens to say captcha', () => {
+    // A 3MB product page mentioning the word must not take that product
+    // offline. This is the guard's whole purpose.
+    const real = page('Sony WH-1000XM5 | Retailer', `${bulk(40000)}<p>Our login uses a captcha.</p>`);
+    expect(real.length).toBeGreaterThan(15000);
+    expect(detect(real)).toBeNull();
+  });
+
+  it('does flag a small page that says captcha', () => {
+    expect(detect(page('Verification', '<p>Please complete the captcha.</p>')))
+      .toBe('Generic Bot Challenge');
+  });
+
+  it('still reads the title on a large page, which the guard used to cover', () => {
+    // The size gate wrapped the title checks too, so a big challenge page whose
+    // title said captcha was missed.
+    const big = page('Captcha Required', bulk(40000));
+    expect(big.length).toBeGreaterThan(15000);
+    expect(detect(big)).toBe('Generic Bot Challenge');
+  });
+});
+
+describe('genuine product pages are left alone', () => {
+  it.each([
+    ['a plain product page', page('Sony WH-1000XM5 | Retailer', '<span class="price">$49.99</span>')],
+    ['one mentioning security', page('Security Camera 1080p | Retailer', '<span class="price">$89.00</span>')],
+    ['one with an empty title', page('', '<span class="price">$10.00</span>')],
+    ['one with no title element', '<html><body><span class="price">$10.00</span></body></html>'],
+    ['an empty document', ''],
+  ])('%s is not a challenge', (_label, html) => {
+    expect(detect(html)).toBeNull();
+  });
+
+  it('does not fire on a product whose name contains "robot"', () => {
+    // "Robot Vacuum" must not read as a robot check.
+    expect(detect(page('Roborock S8 Robot Vacuum | Retailer', '<span class="price">$899</span>')))
+      .toBeNull();
+  });
+});
+
+describe('real captures from this project', () => {
+  it('recognises the target.com.au block page', () => {
+    // 8,315 bytes, title "Access Denied" -- measured in #67.
+    expect(detect(page('Access Denied', 'Reference #18.4f7c2d17'))).toBe('Akamai Access Denied');
+  });
+
+  it('recognises the amazon.com.au challenge from the #68 log', () => {
+    // 2,860 bytes, 32 DOM nodes, served as HTTP 200.
+    const amazon = page('Server Busy', '<form action="/errors_page/validateCaptcha" method="get"></form>');
+    expect(amazon.length).toBeLessThan(15000);
+    expect(detect(amazon)).toBe('Amazon Bot Challenge');
+  });
+});


### PR DESCRIPTION
A bot-challenge page arrives with **HTTP 200** and looks, to everything downstream, like a product page that simply has no price on it. So a miss here is expensive in a specific way:

1. extraction finds nothing
2. AI auto-mapping generates a config from challenge HTML and rejects it
3. the add fails with a flat 400 explaining nothing
4. the browser-scraper fallback never fires — it is gated on the `challengeReason` this function returns

That is exactly the sequence in the original #68 log, and what @stevene1919 described on #67 as *"some of these exceptions we can't scrape don't offer anything in the front-end for user feedback"*.

## The misses

Matching was case-sensitive. Four, each verified in node before changing anything:

```js
'<script src="/_px/PerimeterX/init.js">'.includes('perimeterx')     // false
'<form action="/errors_page/validateCaptcha">'.includes('captcha')  // false
// Amazon's "Server Busy" title — matched nothing at all
'access denied - target australia' === 'access denied'              // false
```

The first is **the vendor's own casing of its own name**. The last was an exact equality, so any title with a suffix — "Access Denied - Target Australia" — fell straight through.

## Why regexes rather than `html.toLowerCase()`

This runs on every scrape and a real product page is routinely several megabytes. Lowercasing would allocate a second copy of the whole document on the path where we expect to find nothing. Patterns are compiled once at module load and scan in place.

Measured on a real 386 KB page:

| | per call |
|---|---|
| `detectBotChallenge` | **1.5 ms** |
| `cheerio.load()` already paid on the same page | 13.7 ms |

So ~11% of a cost we are already paying. Not free, but not the bottleneck.

## The size guard

Kept for body scanning — it is what stops the word "captcha" appearing somewhere in a genuine 3 MB product page from taking that product offline. It **no longer covers the title checks**, which are cheap and far more specific; a large challenge page whose title said captcha was previously missed.

Amazon's challenge is named separately from the generic branch, because "no price found on Amazon" is a common enough report that a log line distinguishing the two is worth having.

## Tests

There were **none** for this function, despite it gating the whole fallback path. There are now 24: the four regressions above, every vendor's markers in varied casing, the size guard in both directions, and pages that must *not* fire — a product called "Robot Vacuum", a page mentioning a login captcha, an empty document, one with no `<title>` element.

494 backend tests total, up from 470.

## Deliberately not changed

`html.includes('cloudflare-static')` has a pre-existing false-positive risk — that string appears in Rocket Loader asset URLs on ordinary Cloudflare-served pages. Case-insensitivity does not create that problem, and narrowing it is a judgement call better made with a real example in hand than guessed at.

Closes #149
