### PR TITLE
feat(items): every product belongs to a canonical item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Admin User Management Single Password UX & Utilities**: Replaced the dual-password input in the Admin user creation and editing forms with a single password input, an integrated cryptographically secure password generator, and a clipboard copy button (#76, #80).
 - **CLI Password Reset Tool**: Added `pnpm run reset-password <email-or-id> [password]` utility (`backend/src/scripts/reset-password.ts`) to recover or assign user passwords from the terminal. Runs the compiled script, so it works inside the production container, which is where a locked-out administrator needs it. Use `reset-password:dev` to run from source. It refuses to set a password on an SSO account unless `--force` is given, because doing so enables local sign-in for an account the identity provider owns.
 - **Optional Display Name on User Creation**: Added an optional Display Name field to the Admin Create User form and backend API route.
+- Groundwork for tracking one product across several retailers (#143). Every
+  product now belongs to a canonical *item* — the thing you want to buy, as
+  opposed to one shop's listing of it. A product tracked at a single retailer
+  is an item with one listing, so nothing looks or behaves differently yet.
+- Price target, drop threshold and back-in-stock alerts are now properties of
+  the item rather than of an individual listing, so that a future product with
+  several stores has one set of alert settings rather than one per store. Your
+  existing settings are carried over on upgrade.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,14 +277,44 @@ tag, which production tracks. Production runs on Docker Swarm; the schema
 migrates one-way on deploy, so **a database backup precedes any production
 deploy**. See `deploy/swarm-stack.yml` and `CHANGELOG.md`.
 
+## Items and products are different things
+
+A **`products`** row is one retailer's listing: a URL, its own schedule, its own
+scrape history. An **`items`** row is the thing the user actually wants to buy,
+which may be listed at several retailers. Every product belongs to exactly one
+item; a product tracked at a single shop is an item with one listing.
+
+The two layers use different words on purpose:
+
+| | canonical thing | one retailer's listing |
+|---|---|---|
+| database | `items` | `products` |
+| UI | "Product" | "Store" |
+
+Users think "I am tracking a product, sold by these stores". Developers need
+names that cannot be misread. Do not try to make these agree — the mismatch is
+the design, and it is why the table is `items` rather than `products`.
+
+**Alert settings live on the item**, not the listing: `target_price`,
+`price_drop_threshold` and `notify_back_in_stock` describe what the user wants
+("tell me when anyone has this under 50"), not anything about a shop's page.
+The identically-named columns still on `products` are dead — retained only so
+migration 020 can be rolled back — and a later migration drops them. Never read
+them. Any query returning a product for code that reads those fields must join
+through `ITEM_ALERT_COLUMNS` / `ITEM_ALERT_JOIN` and map rows with
+`withItemAlertSettings` (`repositories/item-alert-settings.ts`); the aliases
+exist because selecting `i.target_price` beside `p.*` yields two columns of the
+same name and the winner is a driver detail.
+
 ## Things that are intentionally the way they are
 
 - Emoji removed in favour of the icon set (rule 1).
 - The database is named `priceghost`, not `pricestalker` — renaming it would
   orphan existing data. See `deploy/swarm-stack.yml`.
-- `product_groups`, `site_configs`, `user_memberships` tables exist but are
-  unused by current code. Leave them; do not build against them without checking
-  first.
+- `site_configs` and `user_memberships` tables exist but are unused by current
+  code. Leave them; do not build against them without checking first.
+  (`product_groups` used to be on this list. It is now `items` and is in active
+  use — see below.)
 - The daily update-check, per-product currency override and
   notify-on-any-change were dropped from 1.x. Do not "restore" them without
   asking — their absence is deliberate. (OpenRouter was also dropped, but was

--- a/backend/src/migrations/020_canonical_items.ts
+++ b/backend/src/migrations/020_canonical_items.ts
@@ -1,0 +1,190 @@
+import { MigrationContext } from '../config/migrate';
+
+/**
+ * Introduces the canonical item -- the thing you want to buy, as opposed to one
+ * retailer's listing of it (issue #143).
+ *
+ * The v1 schema already anticipated this and the v2 rewrite never built on it:
+ * `product_groups`, `products.group_id` and `products.is_primary` all exist,
+ * fully constrained, with zero rows and zero code references. So this is
+ * finishing an unfinished data model rather than inventing one.
+ *
+ * ## Naming
+ *
+ * `product_groups` becomes `items`. "Group" implies different physical things
+ * sold together -- a keyboard and a mouse -- whereas these are the *same* thing
+ * sold by different merchants. The UI will say "Product" for an item and
+ * "Store" for a listing, because that is how people think; the database says
+ * `items` and `products` because those are unambiguous to read. That split is
+ * deliberate and is recorded in CLAUDE.md.
+ *
+ * ## Every product gets an item
+ *
+ * A product sold at one retailer is an item with one listing. The alternative
+ * -- creating items only when a user links two URLs -- means `item_id` is
+ * sometimes null, and then alert settings have to live on both tables with a
+ * rule about which wins. One code path is worth one migration.
+ *
+ * ## Alert settings move up
+ *
+ * `target_price`, `price_drop_threshold` and `notify_back_in_stock` describe
+ * intent about the thing you want ("tell me when anyone has this under 50"),
+ * not about one shop's page. They are copied onto the item here.
+ *
+ * The columns on `products` are deliberately **left in place**. Migrations run
+ * one-way at boot with no rollback, so dropping a column in the same release
+ * that stops reading it leaves nothing to fall back on if the new path is
+ * wrong. A later migration drops them once this has run in beta.
+ */
+export const up = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    // 1. product_groups -> items, and its sequence and constraints with it.
+    //    Postgres keeps constraint names across a table rename, and
+    //    `product_groups_pkey` on a table called `items` is a trap for whoever
+    //    reads it next.
+    await client.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='product_groups')
+           AND NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='items') THEN
+          ALTER TABLE public.product_groups RENAME TO items;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM pg_class WHERE relkind='S' AND relname='product_groups_id_seq') THEN
+          ALTER SEQUENCE public.product_groups_id_seq RENAME TO items_id_seq;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname='product_groups_pkey') THEN
+          ALTER TABLE public.items RENAME CONSTRAINT product_groups_pkey TO items_pkey;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname='product_groups_user_id_fkey') THEN
+          ALTER TABLE public.items RENAME CONSTRAINT product_groups_user_id_fkey TO items_user_id_fkey;
+        END IF;
+      END $$;
+    `);
+
+    // 2. products.group_id -> products.item_id.
+    await client.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='products' AND column_name='group_id')
+           AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='products' AND column_name='item_id') THEN
+          ALTER TABLE public.products RENAME COLUMN group_id TO item_id;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname='products_group_id_fkey') THEN
+          ALTER TABLE public.products RENAME CONSTRAINT products_group_id_fkey TO products_item_id_fkey;
+        END IF;
+      END $$;
+    `);
+
+    // 3. Alert settings on the item.
+    await client.query(`
+      ALTER TABLE public.items ADD COLUMN IF NOT EXISTS target_price numeric(10,2);
+      ALTER TABLE public.items ADD COLUMN IF NOT EXISTS price_drop_threshold numeric(10,2);
+      ALTER TABLE public.items ADD COLUMN IF NOT EXISTS notify_back_in_stock boolean DEFAULT false;
+    `);
+
+    // 4. One item per product that does not have one.
+    //
+    //    A temporary column carries the link, because INSERT ... RETURNING
+    //    cannot map generated ids back to the rows that produced them.
+    //    Products with no user_id are skipped: items.user_id is NOT NULL with a
+    //    foreign key, and an ownerless product is already orphaned.
+    await client.query(`ALTER TABLE public.items ADD COLUMN IF NOT EXISTS migration_source_product_id integer`);
+
+    await client.query(`
+      INSERT INTO public.items (name, category, image_url, user_id, target_price, price_drop_threshold, notify_back_in_stock, migration_source_product_id)
+      SELECT
+        LEFT(COALESCE(NULLIF(TRIM(p.name), ''), p.url), 255),
+        p.category,
+        p.image_url,
+        p.user_id,
+        p.target_price,
+        p.price_drop_threshold,
+        COALESCE(p.notify_back_in_stock, false),
+        p.id
+      FROM public.products p
+      WHERE p.item_id IS NULL AND p.user_id IS NOT NULL
+    `);
+
+    const linked = await client.query(`
+      UPDATE public.products p
+      SET item_id = i.id, is_primary = true
+      FROM public.items i
+      WHERE i.migration_source_product_id = p.id AND p.item_id IS NULL
+    `);
+
+    await client.query(`ALTER TABLE public.items DROP COLUMN IF EXISTS migration_source_product_id`);
+
+    // 5. Indexes. Fetching every listing for an item is the single most common
+    //    query this feature adds, and there was no index on the column.
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_products_item_id ON public.products (item_id)`);
+
+    //    At most one primary listing per item. Without this the "which listing
+    //    supplies the name and image" question has no single answer, and the
+    //    bug only shows up as a display flicker much later.
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS products_one_primary_per_item
+      ON public.products (item_id) WHERE is_primary
+    `);
+
+    if (linked.rowCount) {
+      console.log(`[020] Created ${linked.rowCount} item(s), one per existing product, and carried their alert settings up.`);
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+/**
+ * Reverses the renames, and removes only the items this migration created.
+ *
+ * The alert columns on `products` were never dropped, so nothing needs copying
+ * back -- they still hold what they held. Items with exactly one listing are
+ * the ones created here; an item a user has since attached a second store to is
+ * left alone rather than silently discarded.
+ */
+export const down = async ({ context: pool }: { context: MigrationContext }) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    await client.query(`DROP INDEX IF EXISTS products_one_primary_per_item`);
+    await client.query(`DROP INDEX IF EXISTS idx_products_item_id`);
+
+    await client.query(`
+      UPDATE public.products SET item_id = NULL, is_primary = false
+      WHERE item_id IN (SELECT item_id FROM public.products WHERE item_id IS NOT NULL GROUP BY item_id HAVING count(*) = 1)
+    `);
+    await client.query(`DELETE FROM public.items i WHERE NOT EXISTS (SELECT 1 FROM public.products p WHERE p.item_id = i.id)`);
+
+    await client.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='products' AND column_name='item_id') THEN
+          ALTER TABLE public.products RENAME COLUMN item_id TO group_id;
+        END IF;
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='items') THEN
+          ALTER TABLE public.items RENAME TO product_groups;
+        END IF;
+      END $$;
+    `);
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -14,6 +14,7 @@ export {
   exchangeRateRepository as exchangeRateQueries, exchangeRateRepository
 } from '../services/domain/system/repositories/currency.repository';
 export { productRepository as productQueries, productRepository } from '../services/domain/product/repositories/product.repository';
+export { itemRepository } from '../services/domain/product/repositories/item.repository';
 export { priceHistoryRepository as priceHistoryQueries, priceHistoryRepository } from '../services/domain/product/repositories/price-history.repository';
 export { stockHistoryRepository as stockStatusHistoryQueries, stockHistoryRepository } from '../services/domain/product/repositories/stock-history.repository';
 import { retailerQueryRepository as rQueries } from '../services/domain/retailer/repositories/retailer-query.repository';

--- a/backend/src/models/types/index.ts
+++ b/backend/src/models/types/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 export * from './user';
 export * from './auth';
 export * from './product';
+export * from './item';
 export * from './stock';
 export * from './notification';
 export * from './retailer';

--- a/backend/src/models/types/item.ts
+++ b/backend/src/models/types/item.ts
@@ -1,0 +1,31 @@
+/**
+ * The canonical thing a user wants to buy, as opposed to one retailer's
+ * listing of it (issue #143).
+ *
+ * A `Product` row is one retailer's page. An `Item` is the thing itself, and
+ * owns everything that describes intent rather than a shop: the display name,
+ * the image, and the alert settings. "Tell me when anyone has this under 50" is
+ * a statement about the item, not about any one store.
+ *
+ * Every product belongs to exactly one item -- a product sold at a single
+ * retailer is an item with one listing. The alternative, creating items only
+ * when a user links two URLs, means alert settings have to live on both tables
+ * with a rule about which wins.
+ *
+ * Naming: the UI says "Product" for an item and "Store" for a listing, because
+ * that is how people think about it. The database says `items` and `products`
+ * because those are unambiguous to read. See CLAUDE.md.
+ */
+export interface Item {
+  id: number;
+  name: string;
+  category: string | null;
+  image_url: string | null;
+  user_id: number;
+  /** Alert settings live here, not on the listing. */
+  target_price: number | null;
+  price_drop_threshold: number | null;
+  notify_back_in_stock: boolean;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/backend/src/services/domain/product/repositories/item-alert-settings.ts
+++ b/backend/src/services/domain/product/repositories/item-alert-settings.ts
@@ -1,0 +1,52 @@
+import { Product } from '../../../../models/types';
+
+/**
+ * Alert settings live on the item, not the listing (issue #143).
+ *
+ * Every query that returns a product for anything that reads `target_price`,
+ * `price_drop_threshold` or `notify_back_in_stock` has to join the item and
+ * pass its rows through here.
+ *
+ * They are aliased in SQL rather than selected as bare `i.target_price`
+ * alongside `p.*`. That would produce two result columns of the same name, and
+ * which one the driver keeps is an undocumented implementation detail --
+ * currently the later one, but relying on that would mean alerts silently
+ * firing against a stale threshold if it ever changed. Explicit aliases cost a
+ * line and cannot drift.
+ */
+export const ITEM_ALERT_COLUMNS = `
+              i.target_price         AS item_target_price,
+              i.price_drop_threshold AS item_price_drop_threshold,
+              i.notify_back_in_stock AS item_notify_back_in_stock`;
+
+/** The join those columns require. */
+export const ITEM_ALERT_JOIN = `LEFT JOIN items i ON i.id = p.item_id`;
+
+/**
+ * Overlays a row's item alert settings onto the product shape the rest of the
+ * code reads.
+ *
+ * A product with no item keeps whatever the row already held rather than
+ * silently becoming "no target price". That should not arise -- every product
+ * gets an item -- but a scrape is the wrong place to discover a broken
+ * invariant by turning someone's alerts off.
+ */
+export function withItemAlertSettings<T extends Record<string, any>>(row: T): T {
+  const { item_target_price, item_price_drop_threshold, item_notify_back_in_stock, ...rest } = row;
+  if (row.item_id == null) return rest as T;
+  return {
+    ...rest,
+    target_price: item_target_price ?? null,
+    price_drop_threshold: item_price_drop_threshold ?? null,
+    notify_back_in_stock: item_notify_back_in_stock ?? false,
+  } as unknown as T;
+}
+
+/** Convenience for a query returning many rows. */
+export function withItemAlertSettingsAll<T extends Record<string, any>>(rows: T[]): T[] {
+  return rows.map(withItemAlertSettings);
+}
+
+/** Narrower alias, for call sites that specifically produce Products. */
+export const asProductWithItemAlerts = (row: Record<string, any>): Product =>
+  withItemAlertSettings(row) as unknown as Product;

--- a/backend/src/services/domain/product/repositories/item.repository.ts
+++ b/backend/src/services/domain/product/repositories/item.repository.ts
@@ -1,0 +1,114 @@
+import pool from '../../../../config/database';
+import { Item } from '../../../../models/types';
+
+type Executor = { query: (text: string, values?: unknown[]) => Promise<{ rows: any[]; rowCount: number | null }> };
+
+/**
+ * The canonical item a product listing belongs to (issue #143).
+ *
+ * Alert settings are written here rather than on `products`, because they
+ * describe what the user wants ("tell me when anyone has this under 50") rather
+ * than anything about a particular shop's page.
+ */
+export const itemRepository = {
+  /**
+   * Creates an item.
+   *
+   * `name` is truncated to the column width rather than being allowed to fail
+   * the insert: a product title long enough to overflow is a scraping artefact,
+   * and rejecting the whole add over it would be the wrong trade.
+   */
+  create: async (
+    userId: number,
+    name: string,
+    imageUrl: string | null = null,
+    category: string | null = null,
+    client?: Executor
+  ): Promise<Item> => {
+    const executor = client || pool;
+    const result = await executor.query(
+      `INSERT INTO items (user_id, name, image_url, category)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [userId, name.slice(0, 255), imageUrl, category]
+    );
+    return result.rows[0];
+  },
+
+  findById: async (id: number, userId: number, client?: Executor): Promise<Item | null> => {
+    const executor = client || pool;
+    const result = await executor.query(
+      `SELECT * FROM items WHERE id = $1 AND user_id = $2`,
+      [id, userId]
+    );
+    return result.rows[0] || null;
+  },
+
+  /** Every listing attached to an item, primary first. */
+  listingsFor: async (itemId: number, userId: number, client?: Executor) => {
+    const executor = client || pool;
+    const result = await executor.query(
+      `SELECT * FROM products WHERE item_id = $1 AND user_id = $2
+       ORDER BY is_primary DESC, id ASC`,
+      [itemId, userId]
+    );
+    return result.rows;
+  },
+
+  /**
+   * Updates the alert settings that used to live on `products`.
+   *
+   * Returns null when nothing was passed, matching productLifecycleRepository
+   * .update, so a caller can tell "no change requested" from "not found".
+   */
+  updateAlertSettings: async (
+    id: number,
+    userId: number,
+    updates: {
+      target_price?: number | null;
+      price_drop_threshold?: number | null;
+      notify_back_in_stock?: boolean;
+      name?: string;
+      image_url?: string | null;
+      category?: string | null;
+    },
+    client?: Executor
+  ): Promise<Item | null> => {
+    const executor = client || pool;
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+
+    for (const field of ['target_price', 'price_drop_threshold', 'notify_back_in_stock', 'name', 'image_url', 'category'] as const) {
+      if (updates[field] !== undefined) {
+        fields.push(`${field} = $${i++}`);
+        values.push(updates[field]);
+      }
+    }
+    if (fields.length === 0) return null;
+
+    fields.push('updated_at = CURRENT_TIMESTAMP');
+    values.push(id, userId);
+    const result = await executor.query(
+      `UPDATE items SET ${fields.join(', ')} WHERE id = $${i++} AND user_id = $${i} RETURNING *`,
+      values
+    );
+    return result.rows[0] || null;
+  },
+
+  /**
+   * Deletes an item once its last listing has gone.
+   *
+   * An item with no listings has nothing to check and nothing to show, so
+   * leaving it behind would accumulate invisible rows. Guarded on the item
+   * genuinely being empty rather than assuming the caller checked.
+   */
+  deleteIfEmpty: async (id: number, client?: Executor): Promise<boolean> => {
+    const executor = client || pool;
+    const result = await executor.query(
+      `DELETE FROM items WHERE id = $1 AND NOT EXISTS (SELECT 1 FROM products WHERE item_id = $1)`,
+      [id]
+    );
+    return (result.rowCount ?? 0) > 0;
+  },
+};

--- a/backend/src/services/domain/product/repositories/product-core.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-core.repository.ts
@@ -3,6 +3,7 @@ import { asExecutor, type Executor } from './executor';
 import { 
   ProductWithLatestPrice, 
 } from '../../../../models/types';
+import { ITEM_ALERT_COLUMNS, ITEM_ALERT_JOIN, withItemAlertSettings } from './item-alert-settings';
 
 export const productQueryCoreRepository = {
   findByUserId: async (userId: number): Promise<ProductWithLatestPrice[]> => {
@@ -13,9 +14,10 @@ export const productQueryCoreRepository = {
                 WHEN ph.currency = u.currency THEN ph.price
                 ELSE ph.price * er.rate
               END as converted_price,
-              COALESCE(rc.name, rc.domain) as retailer_name
+              COALESCE(rc.name, rc.domain) as retailer_name,${ITEM_ALERT_COLUMNS}
        FROM products p
        JOIN users u ON u.id = p.user_id
+       ${ITEM_ALERT_JOIN}
        LEFT JOIN LATERAL (
          SELECT price, currency, ai_status FROM price_history
          WHERE product_id = p.id AND price_type = 'standard'
@@ -49,7 +51,7 @@ export const productQueryCoreRepository = {
        ORDER BY p.created_at DESC`,
       [userId]
     );
-    return result.rows;
+    return result.rows.map(withItemAlertSettings);
   },
 
   /**
@@ -74,9 +76,10 @@ export const productQueryCoreRepository = {
                 ELSE ph.price * er.rate
               END as converted_price,
               COALESCE(rc.name, rc.domain) as retailer_name,
-              (SELECT MIN(price) FROM price_history WHERE product_id = p.id AND price_type = 'standard') as min_price
+              (SELECT MIN(price) FROM price_history WHERE product_id = p.id AND price_type = 'standard') as min_price,${ITEM_ALERT_COLUMNS}
        FROM products p
        JOIN users u ON u.id = p.user_id
+       ${ITEM_ALERT_JOIN}
        LEFT JOIN LATERAL (
          SELECT price, currency, ai_status FROM price_history
          WHERE product_id = p.id AND price_type = 'standard'
@@ -121,6 +124,6 @@ export const productQueryCoreRepository = {
        WHERE p.id = $1 AND ($3::boolean = true OR p.user_id = $2)`,
       [id, userId, options?.asAdmin === true]
     );
-    return result.rows[0] || null;
+    return result.rows[0] ? withItemAlertSettings(result.rows[0]) : null;
   },
 };

--- a/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
@@ -5,6 +5,7 @@ import {
   ProductWithSparkline, 
   SparklinePoint
 } from '../../../../models/types';
+import { ITEM_ALERT_COLUMNS, ITEM_ALERT_JOIN, withItemAlertSettings } from './item-alert-settings';
 
 export const productDashboardRepository = {
   findByUserIdWithSparkline: async (userId: number): Promise<ProductWithSparkline[]> => {
@@ -19,9 +20,10 @@ export const productDashboardRepository = {
                 ELSE ph.price * er.rate 
               END as converted_price,
               COALESCE(p.ai_status, ph.ai_status) as ai_status,
-              COALESCE(rc.name, rc.domain) as retailer_name
+              COALESCE(rc.name, rc.domain) as retailer_name,${ITEM_ALERT_COLUMNS}
        FROM products p
        JOIN users u ON u.id = p.user_id
+       ${ITEM_ALERT_JOIN}
        LEFT JOIN LATERAL (
          SELECT price, currency, ai_status FROM price_history
          WHERE product_id = p.id AND price_type = 'standard'
@@ -68,7 +70,7 @@ export const productDashboardRepository = {
       [userId]
     );
 
-    const products = productsResult.rows;
+    const products = productsResult.rows.map(withItemAlertSettings);
     if (products.length === 0) return [];
 
     // Get sparkline data for all products (last 7 days)

--- a/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-lifecycle.repository.ts
@@ -5,6 +5,7 @@ import {
   AIStatus
 } from '../../../../models/types';
 import { getSmartJitter } from '../../../../utils/system/scheduler-helpers';
+import { itemRepository } from './item.repository';
 
 export const productLifecycleRepository = {
   create: async (
@@ -19,13 +20,39 @@ export const productLifecycleRepository = {
   ): Promise<Product> => {
     const jitter = getSmartJitter(refreshInterval);
     const initialDelaySeconds = Math.max(60, Math.floor(refreshInterval / 2) + jitter);
-    const result = await pool.query(
-      `INSERT INTO products (user_id, url, name, image_url, refresh_interval, stock_status, ai_status, next_check_at, category)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP + ($8 || ' seconds')::interval, $9)
-       RETURNING *`,
-      [userId, url, name, imageUrl, refreshInterval, stockStatus, aiStatus, initialDelaySeconds, category]
-    );
-    return result.rows[0];
+
+    // Every product belongs to an item, including one tracked at a single
+    // retailer -- that is an item with one listing (issue #143). Creating them
+    // together in a transaction matters: a product with no item would have
+    // nowhere to keep its alert settings, and would be invisible to the
+    // grouped view without anything indicating why.
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const item = await itemRepository.create(
+        userId,
+        (name && name.trim()) || url,
+        imageUrl,
+        category,
+        client
+      );
+
+      const result = await client.query(
+        `INSERT INTO products (user_id, url, name, image_url, refresh_interval, stock_status, ai_status, next_check_at, category, item_id, is_primary)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP + ($8 || ' seconds')::interval, $9, $10, true)
+         RETURNING *`,
+        [userId, url, name, imageUrl, refreshInterval, stockStatus, aiStatus, initialDelaySeconds, category, item.id]
+      );
+
+      await client.query('COMMIT');
+      return result.rows[0];
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   },
 
   update: async (
@@ -52,9 +79,14 @@ export const productLifecycleRepository = {
     let paramIndex = 1;
 
     // Build fields dynamically
+    // price_drop_threshold, target_price and notify_back_in_stock are absent on
+    // purpose: they moved to the item, because they describe what the user
+    // wants rather than anything about one shop's page (issue #143). They are
+    // routed below. The columns still exist on `products` and are no longer
+    // read -- a later migration drops them, once this has run in beta.
     const updateableFields = [
-      'name', 'image_url', 'refresh_interval', 'price_drop_threshold', 'target_price',
-      'notify_back_in_stock', 'ai_verification_disabled', 'ai_extraction_disabled',
+      'name', 'image_url', 'refresh_interval',
+      'ai_verification_disabled', 'ai_extraction_disabled',
       'checking_paused', 'category', 'stock_status', 'needs_price_review', 'ai_status'
     ];
 
@@ -91,7 +123,42 @@ export const productLifecycleRepository = {
       fields.push('auto_paused = false');
     }
 
-    if (fields.length === 0) return null;
+    // Alert settings belong to the item, so they are written there rather than
+    // here (issue #143). Done before the product update so that a request
+    // carrying only alert settings still resolves to the item's owner, and a
+    // request carrying both is not left half-applied.
+    const alertUpdates = {
+      target_price: (updates as any).target_price,
+      price_drop_threshold: (updates as any).price_drop_threshold,
+      notify_back_in_stock: (updates as any).notify_back_in_stock,
+    };
+    const hasAlertUpdate = Object.values(alertUpdates).some(v => v !== undefined);
+
+    if (hasAlertUpdate) {
+      const owner = await executor.query(
+        `SELECT p.item_id, p.user_id FROM products p
+         WHERE p.id = $1 AND ($3::boolean = true OR p.user_id = $2)`,
+        [id, userId, options?.asAdmin === true]
+      );
+      const itemId = owner.rows[0]?.item_id;
+      if (itemId) {
+        // The item's own user_id, not the caller's -- an admin acting on
+        // another user's product must still write to that user's item.
+        await itemRepository.updateAlertSettings(itemId, owner.rows[0].user_id, alertUpdates, executor);
+      }
+    }
+
+    // Nothing left for the product itself. Returning the row rather than null
+    // matters: a request that only changed a target price did succeed, and a
+    // null here would read to the caller as "product not found".
+    if (fields.length === 0) {
+      if (!hasAlertUpdate) return null;
+      const current = await executor.query(
+        `SELECT * FROM products WHERE id = $1 AND ($3::boolean = true OR user_id = $2)`,
+        [id, userId, options?.asAdmin === true]
+      );
+      return current.rows[0] || null;
+    }
 
     // Order matters: the WHERE clause numbers these as id, userId, admin flag.
     values.push(id, userId, options?.asAdmin === true);
@@ -105,11 +172,38 @@ export const productLifecycleRepository = {
   },
 
   delete: async (id: number, userId: number, options?: { asAdmin?: boolean }): Promise<boolean> => {
-    const result = await pool.query(
-      'DELETE FROM products WHERE id = $1 AND ($3::boolean = true OR user_id = $2)',
-      [id, userId, options?.asAdmin === true]
-    );
-    return (result.rowCount ?? 0) > 0;
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Remember the item before the listing goes, so the orphan can be swept.
+      const owner = await client.query(
+        'SELECT item_id FROM products WHERE id = $1 AND ($3::boolean = true OR user_id = $2)',
+        [id, userId, options?.asAdmin === true]
+      );
+
+      const result = await client.query(
+        'DELETE FROM products WHERE id = $1 AND ($3::boolean = true OR user_id = $2)',
+        [id, userId, options?.asAdmin === true]
+      );
+
+      // An item with no listings has nothing to check and nothing to show, so
+      // leaving it would accumulate invisible rows. deleteIfEmpty re-checks
+      // rather than trusting that this was the last one -- an item with a
+      // second store attached must survive.
+      const itemId = owner.rows[0]?.item_id;
+      if (itemId && (result.rowCount ?? 0) > 0) {
+        await itemRepository.deleteIfEmpty(itemId, client);
+      }
+
+      await client.query('COMMIT');
+      return (result.rowCount ?? 0) > 0;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   },
 
   /**

--- a/backend/src/services/domain/product/repositories/product-lookup.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-lookup.repository.ts
@@ -1,14 +1,27 @@
 import pool from '../../../../config/database';
 import { Product } from '../../../../models/types';
+import { ITEM_ALERT_COLUMNS, ITEM_ALERT_JOIN, asProductWithItemAlerts } from './item-alert-settings';
 
 export const productLookupRepository = {
+  /**
+   * Products due a check, carrying their item's alert settings.
+   *
+   * The alert settings come from the item, not the listing (issue #143). They
+   * are aliased rather than selected as bare `i.target_price` alongside `p.*`:
+   * that produces two columns of the same name, and which one the driver keeps
+   * is an undocumented detail. Getting it wrong would mean alerts firing
+   * against a stale threshold -- a silent, hard-to-trace bug -- so the mapping
+   * is explicit here instead.
+   */
   findDueForRefresh: async (): Promise<Product[]> => {
     const result = await pool.query(
-      `SELECT * FROM products
-       WHERE (next_check_at IS NULL OR next_check_at < CURRENT_TIMESTAMP)
-       AND (checking_paused IS NULL OR checking_paused = false)`
+      `SELECT p.*,${ITEM_ALERT_COLUMNS}
+       FROM products p
+       ${ITEM_ALERT_JOIN}
+       WHERE (p.next_check_at IS NULL OR p.next_check_at < CURRENT_TIMESTAMP)
+       AND (p.checking_paused IS NULL OR p.checking_paused = false)`
     );
-    return result.rows;
+    return result.rows.map(asProductWithItemAlerts);
   },
 
   findDuplicateUrl: async (url: string, userId: number): Promise<number | null> => {

--- a/backend/tests/unit/item-alert-settings.test.ts
+++ b/backend/tests/unit/item-alert-settings.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { withItemAlertSettings, ITEM_ALERT_COLUMNS, ITEM_ALERT_JOIN } from '../../src/services/domain/product/repositories/item-alert-settings';
+
+/**
+ * Alert settings moved from the listing to the item (issue #143), because
+ * "tell me when anyone has this under 50" describes what the user wants, not
+ * one shop's page.
+ *
+ * The risk this guards is quiet: if a query returns the product's own stale
+ * column instead of the item's, alerts fire against a threshold the user
+ * changed days ago, and nothing looks broken.
+ */
+
+const row = (over: Record<string, any> = {}) => ({
+  id: 7,
+  item_id: 3,
+  url: 'https://shop.example/p/1',
+  // What the products table still carries. These columns are retained until a
+  // later migration drops them, so they are exactly the stale values that must
+  // not win.
+  target_price: 999.99,
+  price_drop_threshold: 99,
+  notify_back_in_stock: false,
+  // What the join supplies.
+  item_target_price: 249.99,
+  item_price_drop_threshold: 10,
+  item_notify_back_in_stock: true,
+  ...over,
+});
+
+describe('withItemAlertSettings', () => {
+  it('lets the item win over the listing column', () => {
+    const p = withItemAlertSettings(row());
+    expect(p.target_price).toBe(249.99);
+    expect(p.price_drop_threshold).toBe(10);
+    expect(p.notify_back_in_stock).toBe(true);
+  });
+
+  it('strips the aliased columns, so nothing downstream sees two spellings', () => {
+    const p = withItemAlertSettings(row());
+    expect(p).not.toHaveProperty('item_target_price');
+    expect(p).not.toHaveProperty('item_price_drop_threshold');
+    expect(p).not.toHaveProperty('item_notify_back_in_stock');
+  });
+
+  it('leaves every other column alone', () => {
+    const p = withItemAlertSettings(row());
+    expect(p.id).toBe(7);
+    expect(p.url).toBe('https://shop.example/p/1');
+    expect(p.item_id).toBe(3);
+  });
+
+  it('reads a cleared item setting as cleared, not as the stale listing value', () => {
+    // A user who removes their target price must not have the old one revived
+    // from the column we stopped writing to.
+    const p = withItemAlertSettings(row({ item_target_price: null, item_price_drop_threshold: null }));
+    expect(p.target_price).toBeNull();
+    expect(p.price_drop_threshold).toBeNull();
+  });
+
+  it('treats a missing back-in-stock flag as off rather than undefined', () => {
+    expect(withItemAlertSettings(row({ item_notify_back_in_stock: null })).notify_back_in_stock).toBe(false);
+  });
+
+  it('keeps a zero target price, which is a real value', () => {
+    expect(withItemAlertSettings(row({ item_target_price: 0 })).target_price).toBe(0);
+  });
+
+  describe('a product with no item', () => {
+    it('keeps whatever the row held rather than silently clearing alerts', () => {
+      // Should not arise -- every product gets an item -- but a scrape is the
+      // wrong place to discover a broken invariant by turning alerts off.
+      const p = withItemAlertSettings(row({ item_id: null, item_target_price: null, item_notify_back_in_stock: null }));
+      expect(p.target_price).toBe(999.99);
+      expect(p.notify_back_in_stock).toBe(false);
+    });
+
+    it('still strips the aliased columns', () => {
+      const p = withItemAlertSettings(row({ item_id: null }));
+      expect(p).not.toHaveProperty('item_target_price');
+    });
+  });
+});
+
+describe('the SQL fragments', () => {
+  it('alias every column, so none collides with p.*', () => {
+    // Selecting bare i.target_price alongside p.* yields two columns of the
+    // same name, and which one the driver keeps is undocumented.
+    for (const col of ['target_price', 'price_drop_threshold', 'notify_back_in_stock']) {
+      expect(ITEM_ALERT_COLUMNS).toContain(`AS item_${col}`);
+    }
+  });
+
+  it('join on the item, and do so as a LEFT join', () => {
+    // An inner join would silently drop any product whose item is missing --
+    // taking it out of the scheduler entirely rather than surfacing the fault.
+    expect(ITEM_ALERT_JOIN).toContain('LEFT JOIN items i');
+    expect(ITEM_ALERT_JOIN).toContain('i.id = p.item_id');
+  });
+});


### PR DESCRIPTION
Phase 1 of #143. **Schema and repositories only** — no UI change, and nothing looks or behaves differently to a user yet. Safe to ship on its own.

## This finishes an unfinished model rather than inventing one

`product_groups`, `products.group_id` and `products.is_primary` already existed, fully constrained, with **zero rows and zero code references** outside the baseline migration. The v1 schema anticipated this; the v2 rewrite never built on it.

## Naming

`product_groups` → `items`. "Group" implies different physical things sold together; these are the *same* thing sold by different merchants.

| | canonical thing | one retailer's listing |
|---|---|---|
| **database** | `items` | `products` |
| **UI** | "Product" | "Store" |

The mismatch is deliberate — users think *"a product, sold by these stores"*, developers need names that cannot be misread. Written into CLAUDE.md rather than left to be rediscovered.

## Decisions this implements

**Every product gets an item**, including one tracked at a single retailer. Creating items only when a user links two URLs means `item_id` is sometimes null, and alert settings then have to live on both tables with a rule about which wins. One code path is worth one migration.

**Alert settings move to the item.** `target_price`, `price_drop_threshold` and `notify_back_in_stock` describe what the user wants — *"tell me when anyone has this under 50"* — not anything about a shop's page.

**The `products` columns are deliberately left in place.** Migrations run one-way at boot with no rollback, so dropping a column in the same release that stops reading it leaves nothing to fall back on. A later migration drops them once this has run in beta.

## The subtle bit

Read paths **alias** the item's columns rather than selecting `i.target_price` beside `p.*`:

```sql
i.target_price AS item_target_price,
```

Selecting both yields two result columns of the same name. I checked, and node-pg keeps the later one — but relying on that would mean alerts silently firing against a stale threshold if it ever changed, which is a bug that looks like nothing being wrong. `withItemAlertSettings` maps them explicitly, and a product whose item is missing keeps what it had rather than having its alerts turned off to announce a broken invariant.

Deleting a listing sweeps its item only once the item is genuinely empty, so removing one store from a two-store product leaves the other alone.

## Verification

**Migration 020 against PostgreSQL 16**, across the cases that actually bite:

| case | result |
|---|---|
| null name, whitespace-only name | falls back to the URL |
| 400-character name | truncated to the column width, insert succeeds |
| product with no `user_id` | skipped (`items.user_id` is NOT NULL), no crash |
| constraint + sequence names | renamed with the table (`items_pkey`, `products_item_id_fkey`) |
| second run | matches nothing |
| `down()` | removes items it created, **keeps** any item since given a second listing |
| duplicate primary listing | rejected by `products_one_primary_per_item` |
| second *non*-primary listing | allowed |

**Repositories exercised end to end against a real database**, with a deliberately planted stale `999.99` left in the product column:

```
findDueForRefresh (scheduler): target_price=149.5  price_drop_threshold=15  notify_back_in_stock=true   leaks: []
findById (detail):             target_price=149.5  notify_back_in_stock=true                            leaks: []
findByUserId (list):           price_drop_threshold=15  notify_back_in_stock=true                       leaks: []
after clearing:                null   (not the stale 999.99)
delete non-primary listing:    item survives
delete last listing:           item swept
```

504 tests, up from 494. `tsc`, frontend build, emoji lint, `git diff --check` all pass.

## Next phases

2. grouped dashboard view behind a toggle (flat stays default)
3. item page with the multi-series chart
4. notifications naming which store triggered
5. attach a second store, then SearXNG multi-select

Refs #143
