### PR TITLE
feat(items): a grouped "By product" view on the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A **By product** view on the dashboard, alongside the existing **All stores**
+  list (#143). It shows one card per product with the best price across the
+  stores selling it, how many stores were compared, and the gap between the
+  cheapest and dearest. Your choice of view is remembered.
+- The best price is worked out in your own currency. A store whose currency
+  could not be converted is left out of the comparison and the card says so,
+  rather than ranking amounts in different currencies against each other.
+
 ## [2.1.0-beta.5] - 2026-09-05
 
 ### Added

--- a/backend/src/models/types/index.ts
+++ b/backend/src/models/types/index.ts
@@ -3,6 +3,7 @@ export * from './user';
 export * from './auth';
 export * from './product';
 export * from './item';
+export * from './item-view';
 export * from './stock';
 export * from './notification';
 export * from './retailer';

--- a/backend/src/models/types/item-view.ts
+++ b/backend/src/models/types/item-view.ts
@@ -1,0 +1,50 @@
+import { Item } from './item';
+import { ProductWithSparkline } from './product';
+
+/**
+ * An item as the grouped dashboard shows it: the thing you want to buy, with
+ * every store that sells it (issue #143).
+ *
+ * Deliberately built by grouping the same rows the flat dashboard already
+ * fetches, rather than by a second query. The flat and grouped views must agree
+ * about every number on screen, and the surest way to guarantee that is for
+ * both to come from one place. It also avoids a second copy of the exchange
+ * rate triangulation, which is the fiddliest SQL in the repository.
+ */
+export interface ItemWithListings extends Item {
+  /** Every store selling this item, best comparable price first. */
+  listings: ProductWithSparkline[];
+  store_count: number;
+
+  /**
+   * The lowest price across stores, in the user's own currency.
+   *
+   * Null when no store has a comparable price -- see `excluded_count`. Never a
+   * raw figure from a currency we could not convert: comparing 49.99 EUR with
+   * 49.99 CHF and declaring a winner is worse than declining to.
+   */
+  best_price: number | null;
+  /** Which listing supplies `best_price`, so the UI can name the store. */
+  best_price_listing_id: number | null;
+  /** The currency `best_price` is expressed in: the user's preferred one. */
+  best_price_currency: string | null;
+
+  /**
+   * Difference between the cheapest and dearest comparable store, or null when
+   * fewer than two could be compared. This is the number that justifies
+   * tracking an item in several places at all.
+   */
+  price_spread: number | null;
+
+  /** How many listings had a price that could be converted and compared. */
+  comparable_count: number;
+  /**
+   * How many were left out of the comparison -- no price scraped yet, or a
+   * currency that could not be resolved. Surfaced rather than hidden: "cheapest
+   * of 2 of your 4 stores" is honest, "cheapest" alone is not.
+   */
+  excluded_count: number;
+
+  /** True when at least one store has it. */
+  any_in_stock: boolean;
+}

--- a/backend/src/routes/products/crud.ts
+++ b/backend/src/routes/products/crud.ts
@@ -12,6 +12,18 @@ router.get('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   res.json(products);
 }, 'Product', 'Products', 'Failed to fetch products'));
 
+/**
+ * The same listings, grouped into items (issue #143).
+ *
+ * Declared before `/:id` on purpose: Express matches in order, and a route
+ * added below it would be swallowed by the id parameter and fail as
+ * "invalid product id".
+ */
+router.get('/items', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const items = await productHistoryService.getUserItems(req.userId!);
+  res.json(items);
+}, 'Product', 'Products', 'Failed to fetch items'));
+
 router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { url } = req.body;
   const userId = req.userId!;

--- a/backend/src/services/domain/product/ProductHistoryService.ts
+++ b/backend/src/services/domain/product/ProductHistoryService.ts
@@ -4,14 +4,31 @@ import {
   stockHistoryRepository, 
   userRepository,
   ProductWithLatestPrice,
-  ProductWithSparkline
+  ProductWithSparkline,
+  ItemWithListings
 } from '../../../models';
 import { syncUserCategories } from './utils';
+import { groupIntoItems } from './utils/group-into-items';
 import { logger } from '../../../utils/system/logger';
 
 export class ProductHistoryService {
   async getUserProducts(userId: number): Promise<ProductWithSparkline[]> {
     return await productRepository.findByUserIdWithSparkline(userId);
+  }
+
+  /**
+   * The same listings, grouped into the items they belong to (issue #143).
+   *
+   * Built from getUserProducts rather than its own query, so the flat and
+   * grouped views cannot disagree about a price, and so the exchange rate
+   * triangulation exists in one place.
+   */
+  async getUserItems(userId: number): Promise<ItemWithListings[]> {
+    const [products, user] = await Promise.all([
+      productRepository.findByUserIdWithSparkline(userId),
+      userRepository.findById(userId),
+    ]);
+    return groupIntoItems(products, user?.currency ?? null);
   }
 
   async getProduct(productId: number, userId: number, asAdmin = false): Promise<ProductWithLatestPrice | null> {

--- a/backend/src/services/domain/product/repositories/item-alert-settings.ts
+++ b/backend/src/services/domain/product/repositories/item-alert-settings.ts
@@ -19,6 +19,18 @@ export const ITEM_ALERT_COLUMNS = `
               i.price_drop_threshold AS item_price_drop_threshold,
               i.notify_back_in_stock AS item_notify_back_in_stock`;
 
+/**
+ * The item's own display fields, for queries that render an item rather than a
+ * listing.
+ *
+ * Separate from the alert columns because most callers do not need them, and
+ * because the two have different lifetimes: a listing's name is scraped and
+ * re-scraped, while an item's is the user's own label for the thing.
+ */
+export const ITEM_DISPLAY_COLUMNS = `
+              i.name      AS item_name,
+              i.image_url AS item_image_url`;
+
 /** The join those columns require. */
 export const ITEM_ALERT_JOIN = `LEFT JOIN items i ON i.id = p.item_id`;
 

--- a/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
+++ b/backend/src/services/domain/product/repositories/product-dashboard.repository.ts
@@ -5,7 +5,7 @@ import {
   ProductWithSparkline, 
   SparklinePoint
 } from '../../../../models/types';
-import { ITEM_ALERT_COLUMNS, ITEM_ALERT_JOIN, withItemAlertSettings } from './item-alert-settings';
+import { ITEM_ALERT_COLUMNS, ITEM_ALERT_JOIN, ITEM_DISPLAY_COLUMNS, withItemAlertSettings } from './item-alert-settings';
 
 export const productDashboardRepository = {
   findByUserIdWithSparkline: async (userId: number): Promise<ProductWithSparkline[]> => {
@@ -20,7 +20,7 @@ export const productDashboardRepository = {
                 ELSE ph.price * er.rate 
               END as converted_price,
               COALESCE(p.ai_status, ph.ai_status) as ai_status,
-              COALESCE(rc.name, rc.domain) as retailer_name,${ITEM_ALERT_COLUMNS}
+              COALESCE(rc.name, rc.domain) as retailer_name,${ITEM_ALERT_COLUMNS},${ITEM_DISPLAY_COLUMNS}
        FROM products p
        JOIN users u ON u.id = p.user_id
        ${ITEM_ALERT_JOIN}

--- a/backend/src/services/domain/product/utils/group-into-items.ts
+++ b/backend/src/services/domain/product/utils/group-into-items.ts
@@ -1,0 +1,117 @@
+import { ItemWithListings, ProductWithSparkline } from '../../../../models/types';
+
+/**
+ * Groups listings into the items they belong to (issue #143).
+ *
+ * A pure function over rows the flat dashboard already fetched, rather than a
+ * second query. Both views must agree about every number on screen, and the
+ * surest way to guarantee that is for both to come from one place -- it also
+ * avoids a second copy of the exchange rate triangulation.
+ *
+ * ## What "best price" means, and what it refuses to mean
+ *
+ * Only listings whose price could be expressed in the user's own currency are
+ * compared. `converted_price` is that figure: equal to the price when the
+ * currencies already match, the converted amount when a rate resolved, and null
+ * when no rate could be found.
+ *
+ * A listing with a price but no usable rate is therefore excluded rather than
+ * compared raw. Ranking 49.99 EUR against 49.99 CHF and declaring a winner is
+ * worse than declining to -- the user acts on that number. `excluded_count`
+ * exists so the UI can say "cheapest of 2 of your 4 stores" instead of
+ * "cheapest", which would be a claim we cannot support.
+ */
+export function groupIntoItems(
+  products: ProductWithSparkline[],
+  preferredCurrency: string | null | undefined
+): ItemWithListings[] {
+  const byItem = new Map<number, ProductWithSparkline[]>();
+  // Listings whose item is missing are skipped rather than invented into one:
+  // every product has an item, so this means something is wrong, and silently
+  // creating a phantom item would hide it.
+  for (const product of products) {
+    const itemId = (product as any).item_id;
+    if (itemId == null) continue;
+    const bucket = byItem.get(itemId);
+    if (bucket) bucket.push(product);
+    else byItem.set(itemId, [product]);
+  }
+
+  const items: ItemWithListings[] = [];
+
+  for (const [itemId, listings] of byItem) {
+    const comparable = listings.filter(l => isComparable(l));
+    const prices = comparable.map(l => Number(l.converted_price));
+
+    const best = prices.length > 0 ? Math.min(...prices) : null;
+    const worst = prices.length > 0 ? Math.max(...prices) : null;
+    const bestListing = best === null
+      ? null
+      : comparable.find(l => Number(l.converted_price) === best) ?? null;
+
+    // Ordered cheapest first, then the ones that could not be compared. The
+    // store a user acts on is the cheapest one, so it goes at the top; the rest
+    // still appear, because a listing left out of the comparison is not a
+    // listing the user has stopped tracking.
+    const ordered = [
+      ...comparable.slice().sort((a, b) => Number(a.converted_price) - Number(b.converted_price)),
+      ...listings.filter(l => !isComparable(l)),
+    ];
+
+    // The primary listing supplies anything the item itself is missing, which
+    // is how a freshly migrated item that never had its own name displays
+    // sensibly.
+    const primary = listings.find(l => (l as any).is_primary) ?? listings[0];
+
+    items.push({
+      id: itemId,
+      name: (primary as any).item_name || primary.name || primary.url,
+      image_url: (primary as any).item_image_url ?? primary.image_url ?? null,
+      category: primary.category ?? null,
+      user_id: primary.user_id,
+      target_price: primary.target_price,
+      price_drop_threshold: primary.price_drop_threshold,
+      notify_back_in_stock: primary.notify_back_in_stock,
+      created_at: primary.created_at,
+      updated_at: primary.created_at,
+
+      listings: ordered,
+      store_count: listings.length,
+
+      best_price: best,
+      best_price_listing_id: bestListing?.id ?? null,
+      // Null rather than a guessed code when nothing was comparable, so the UI
+      // never renders an amount beside a currency we did not actually use.
+      best_price_currency: best === null ? null : (preferredCurrency ?? null),
+
+      // A spread needs two points. One store is not a comparison.
+      price_spread: prices.length >= 2 && worst !== null && best !== null
+        ? round2(worst - best)
+        : null,
+
+      comparable_count: comparable.length,
+      excluded_count: listings.length - comparable.length,
+
+      any_in_stock: listings.some(l => l.stock_status === 'in_stock'),
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Whether a listing can take part in a price comparison.
+ *
+ * `converted_price` is null when the scrape found no price, or when the price
+ * is in a currency no exchange rate could resolve. Both mean the same thing
+ * here: there is no figure we can honestly rank.
+ */
+function isComparable(listing: ProductWithSparkline): boolean {
+  const value = listing.converted_price;
+  return value !== null && value !== undefined && Number.isFinite(Number(value));
+}
+
+/** Currency arithmetic, kept to two places so a spread reads as money. */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/backend/tests/unit/group-into-items.test.ts
+++ b/backend/tests/unit/group-into-items.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { groupIntoItems } from '../../src/services/domain/product/utils/group-into-items';
+
+/**
+ * The grouped dashboard: one card per item, showing the best price across the
+ * stores that sell it (issue #143).
+ *
+ * The decision this encodes is what "best price" refuses to mean. A listing
+ * priced in a currency we could not convert is excluded, not compared raw --
+ * ranking 49.99 EUR against 49.99 CHF and declaring a winner is worse than
+ * declining to, because the user acts on that number.
+ */
+
+const listing = (over: Record<string, any> = {}): any => ({
+  id: 1,
+  user_id: 1,
+  item_id: 100,
+  is_primary: true,
+  url: 'https://shop.example/p/1',
+  name: 'Sony WH-1000XM5',
+  item_name: 'Sony WH-1000XM5',
+  item_image_url: null,
+  image_url: null,
+  category: 'audio',
+  stock_status: 'in_stock',
+  current_price: 299,
+  currency: 'CHF',
+  converted_price: 299,
+  target_price: null,
+  price_drop_threshold: null,
+  notify_back_in_stock: false,
+  created_at: new Date('2026-01-01'),
+  sparkline: [],
+  price_change_7d: null,
+  min_price: null,
+  ...over,
+});
+
+describe('grouping', () => {
+  it('puts every store for one item on a single card', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, item_id: 100 }),
+      listing({ id: 2, item_id: 100, is_primary: false }),
+      listing({ id: 3, item_id: 200 }),
+    ], 'CHF');
+    expect(items).toHaveLength(2);
+    expect(items.find(i => i.id === 100)!.store_count).toBe(2);
+    expect(items.find(i => i.id === 200)!.store_count).toBe(1);
+  });
+
+  it('skips a listing with no item rather than inventing one', () => {
+    // Every product has an item. A null here means something is wrong, and a
+    // phantom item on the dashboard would hide it.
+    expect(groupIntoItems([listing({ item_id: null })], 'CHF')).toHaveLength(0);
+  });
+
+  it('takes the display name from the primary listing', () => {
+    const items = groupIntoItems([
+      listing({ id: 2, is_primary: false, item_name: 'Ignored', name: 'Ignored' }),
+      listing({ id: 1, is_primary: true, item_name: 'Sony WH-1000XM5' }),
+    ], 'CHF');
+    expect(items[0].name).toBe('Sony WH-1000XM5');
+  });
+
+  it('falls back to the URL when an item and its listing are both unnamed', () => {
+    const items = groupIntoItems([listing({ item_name: null, name: null, url: 'https://shop.example/p/9' })], 'CHF');
+    expect(items[0].name).toBe('https://shop.example/p/9');
+  });
+});
+
+describe('best price', () => {
+  it('is the cheapest comparable store, and names it', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 299 }),
+      listing({ id: 2, is_primary: false, converted_price: 249.5 }),
+      listing({ id: 3, is_primary: false, converted_price: 310 }),
+    ], 'CHF');
+    expect(items[0].best_price).toBe(249.5);
+    expect(items[0].best_price_listing_id).toBe(2);
+    expect(items[0].best_price_currency).toBe('CHF');
+  });
+
+  it('excludes a store whose currency could not be converted', () => {
+    // converted_price is null when no exchange rate resolved. Comparing the
+    // raw number instead would rank across currencies.
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 299 }),
+      listing({ id: 2, is_primary: false, current_price: 10, currency: 'XYZ', converted_price: null }),
+    ], 'CHF');
+    expect(items[0].best_price).toBe(299);
+    expect(items[0].comparable_count).toBe(1);
+    expect(items[0].excluded_count).toBe(1);
+  });
+
+  it('excludes a store with no price scraped yet', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 299 }),
+      listing({ id: 2, is_primary: false, current_price: null, converted_price: null }),
+    ], 'CHF');
+    expect(items[0].comparable_count).toBe(1);
+    expect(items[0].excluded_count).toBe(1);
+  });
+
+  it('reports no best price at all when nothing is comparable', () => {
+    // Rather than picking one arbitrarily so the card has a number on it.
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: null }),
+      listing({ id: 2, is_primary: false, converted_price: null }),
+    ], 'CHF');
+    expect(items[0].best_price).toBeNull();
+    expect(items[0].best_price_listing_id).toBeNull();
+    expect(items[0].best_price_currency).toBeNull();
+    expect(items[0].excluded_count).toBe(2);
+  });
+
+  it('names no currency when there is no price to attach one to', () => {
+    // An amount rendered beside a currency we never used would be a lie.
+    const items = groupIntoItems([listing({ converted_price: null })], 'CHF');
+    expect(items[0].best_price_currency).toBeNull();
+  });
+
+  it('treats zero as a real price', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 0 }),
+      listing({ id: 2, is_primary: false, converted_price: 50 }),
+    ], 'CHF');
+    expect(items[0].best_price).toBe(0);
+    expect(items[0].comparable_count).toBe(2);
+  });
+
+  it('handles numeric columns arriving as strings, as pg returns them', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: '299.00' }),
+      listing({ id: 2, is_primary: false, converted_price: '249.50' }),
+    ], 'CHF');
+    expect(items[0].best_price).toBe(249.5);
+    expect(items[0].best_price_listing_id).toBe(2);
+  });
+});
+
+describe('price spread', () => {
+  it('is the gap between cheapest and dearest', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 299 }),
+      listing({ id: 2, is_primary: false, converted_price: 249.5 }),
+    ], 'CHF');
+    expect(items[0].price_spread).toBe(49.5);
+  });
+
+  it('is null for a single store, because one price is not a comparison', () => {
+    expect(groupIntoItems([listing()], 'CHF')[0].price_spread).toBeNull();
+  });
+
+  it('is null when only one store could be compared', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 299 }),
+      listing({ id: 2, is_primary: false, converted_price: null }),
+    ], 'CHF');
+    expect(items[0].price_spread).toBeNull();
+  });
+
+  it('rounds to money rather than exposing float noise', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 10.1 }),
+      listing({ id: 2, is_primary: false, converted_price: 20.2 }),
+    ], 'CHF');
+    expect(items[0].price_spread).toBe(10.1);
+  });
+});
+
+describe('listing order', () => {
+  it('puts the cheapest comparable store first', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 299 }),
+      listing({ id: 2, is_primary: false, converted_price: 249.5 }),
+      listing({ id: 3, is_primary: false, converted_price: 260 }),
+    ], 'CHF');
+    expect(items[0].listings.map(l => l.id)).toEqual([2, 3, 1]);
+  });
+
+  it('keeps uncomparable stores, at the end', () => {
+    // Left out of the comparison is not the same as no longer tracked.
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: null }),
+      listing({ id: 2, is_primary: false, converted_price: 249.5 }),
+    ], 'CHF');
+    expect(items[0].listings.map(l => l.id)).toEqual([2, 1]);
+    expect(items[0].store_count).toBe(2);
+  });
+});
+
+describe('stock', () => {
+  it('is in stock when any store has it', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, stock_status: 'out_of_stock' }),
+      listing({ id: 2, is_primary: false, stock_status: 'in_stock' }),
+    ], 'CHF');
+    expect(items[0].any_in_stock).toBe(true);
+  });
+
+  it('is out of stock only when no store has it', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, stock_status: 'out_of_stock' }),
+      listing({ id: 2, is_primary: false, stock_status: 'not_available' }),
+    ], 'CHF');
+    expect(items[0].any_in_stock).toBe(false);
+  });
+});
+
+describe('alert settings come from the item', () => {
+  it('are carried onto the card', () => {
+    const items = groupIntoItems([listing({ target_price: 249.99, notify_back_in_stock: true })], 'CHF');
+    expect(items[0].target_price).toBe(249.99);
+    expect(items[0].notify_back_in_stock).toBe(true);
+  });
+});
+
+describe('edge cases', () => {
+  it('returns nothing for no products', () => {
+    expect(groupIntoItems([], 'CHF')).toEqual([]);
+  });
+
+  it('does not crash when the user has no preferred currency', () => {
+    const items = groupIntoItems([listing()], null);
+    expect(items[0].best_price).toBe(299);
+    expect(items[0].best_price_currency).toBeNull();
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -11,7 +11,7 @@ export const queryKeys = {
   adminUsers: ['admin', 'users'] as const,
   adminTokens: ['admin', 'system-tokens'] as const,
   adminRetailers: ['admin', 'retailers'] as const,
-  products: { all: ['products'] as const, detail: (id: number) => ['products', id] as const },
+  products: { all: ['products'] as const, items: ['products', 'items'] as const, detail: (id: number) => ['products', id] as const },
   discoveryStatus: ['settings', 'discovery-status'] as const,
   profile: ['profile'] as const,
   currencies: ['settings', 'currencies'] as const,
@@ -34,6 +34,17 @@ const PRODUCT_DETAIL_POLL_INTERVAL = 30_000;
 export const productListQuery = () => queryOptions({
   queryKey: queryKeys.products.all,
   queryFn: ({ signal }) => ProductService.getAll({ signal }),
+  staleTime: PRODUCT_POLL_INTERVAL,
+  refetchInterval: PRODUCT_POLL_INTERVAL,
+});
+
+/**
+ * The grouped view (issue #143). Same poll interval as the flat list, so
+ * switching between them does not change how fresh the numbers are.
+ */
+export const itemListQuery = () => queryOptions({
+  queryKey: queryKeys.products.items,
+  queryFn: ({ signal }) => ProductService.getItems({ signal }),
   staleTime: PRODUCT_POLL_INTERVAL,
   refetchInterval: PRODUCT_POLL_INTERVAL,
 });

--- a/frontend/src/features/products/components/ItemCard/ItemCard.css
+++ b/frontend/src/features/products/components/ItemCard/ItemCard.css
@@ -1,0 +1,145 @@
+/*
+ * The grouped dashboard card (issue #143).
+ *
+ * Uses container queries rather than viewport breakpoints, matching
+ * ProductCard: the card adapts to the space it is given, which is what keeps it
+ * working in a sidebar layout as well as a full-width grid.
+ */
+.item-card {
+  container-type: inline-size;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.item-card-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.item-card-image {
+  width: 3rem;
+  height: 3rem;
+  flex: 0 0 auto;
+  object-fit: contain;
+  border-radius: 0.375rem;
+  background: var(--background);
+}
+
+.item-card-image-empty {
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+}
+
+.item-card-heading {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.item-card-name {
+  font-weight: 600;
+  /* The name is the identity of the card, so it wraps rather than truncating
+     to a single ambiguous line, but stops before it dominates. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.item-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.item-card-stock.in { color: var(--secondary, #10b981); }
+.item-card-stock.out { color: var(--text-muted); }
+
+.item-card-price {
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.item-card-price-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  /* Prices line up across cards in a grid. */
+  font-variant-numeric: tabular-nums;
+}
+
+.item-card-price-label,
+.item-card-price-absent {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.item-card-price-absent { font-style: italic; }
+
+.item-card-note {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.item-card-spread {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.item-card-listings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.item-listing {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  color: inherit;
+  text-decoration: none;
+  background: var(--background);
+}
+
+.item-listing:hover { border-color: var(--primary); }
+
+/* The cheapest store, which is the one the user is most likely to act on. */
+.item-listing.is-best {
+  border-left: 2px solid var(--secondary, #10b981);
+  font-weight: 600;
+}
+
+.item-listing-store {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-listing-price { font-variant-numeric: tabular-nums; }
+
+.item-listing-absent {
+  color: var(--text-muted);
+  font-style: italic;
+  font-weight: 400;
+}
+
+/* A single store makes the per-store list redundant with the headline price. */
+@container (max-width: 22rem) {
+  .item-card-head { flex-wrap: wrap; }
+  .item-card-price { text-align: left; width: 100%; }
+}

--- a/frontend/src/features/products/components/ItemCard/ItemCard.tsx
+++ b/frontend/src/features/products/components/ItemCard/ItemCard.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Link } from '@tanstack/react-router';
+import { ItemWithListings } from '../../../../types/api';
+import { formatPrice } from '../../../../utils/format';
+import Icon from '../../../../components/Icon';
+import './ItemCard.css';
+
+interface ItemCardProps {
+  item: ItemWithListings;
+  userLocale?: string;
+}
+
+/**
+ * One item: the thing you want to buy, with the stores that sell it (#143).
+ *
+ * The card leads with the best price because that is the question the grouped
+ * view exists to answer. Everything else on it qualifies that number -- which
+ * store it came from, how many stores it was chosen between, and how many could
+ * not be compared.
+ */
+const ItemCard: React.FC<ItemCardProps> = ({ item, userLocale }) => {
+  return (
+    <div className="item-card">
+      <div className="item-card-head">
+        {item.image_url ? (
+          <img className="item-card-image" src={item.image_url} alt="" loading="lazy" />
+        ) : (
+          <div className="item-card-image item-card-image-empty"><Icon name="package" /></div>
+        )}
+
+        <div className="item-card-heading">
+          <div className="item-card-name" title={item.name}>{item.name}</div>
+          <div className="item-card-meta">
+            <span className={`item-card-stock ${item.any_in_stock ? 'in' : 'out'}`}>
+              {item.any_in_stock ? 'In stock' : 'Not in stock'}
+            </span>
+            <span className="item-card-stores">
+              {item.store_count === 1 ? '1 store' : `${item.store_count} stores`}
+            </span>
+          </div>
+        </div>
+
+        <div className="item-card-price">
+          {item.best_price !== null ? (
+            <>
+              <div className="item-card-price-value">
+                {formatPrice(item.best_price, item.best_price_currency, userLocale)}
+              </div>
+              {/*
+                Only claim "best" when there was actually a choice. With one
+                comparable store it is just the price.
+              */}
+              {item.comparable_count > 1 && (
+                <div className="item-card-price-label">
+                  best of {item.comparable_count}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="item-card-price-absent">No price yet</div>
+          )}
+        </div>
+      </div>
+
+      {/*
+        Said out loud rather than hidden: a card that silently compared 2 of 4
+        stores would be claiming more than we can support. This happens when a
+        store has not been scraped yet, or its currency could not be converted.
+      */}
+      {item.excluded_count > 0 && item.store_count > 1 && (
+        <div className="item-card-note">
+          <Icon name="alertTriangle" />
+          {item.excluded_count === 1
+            ? '1 store could not be compared, so it is not included above'
+            : `${item.excluded_count} stores could not be compared, so they are not included above`}
+        </div>
+      )}
+
+      {item.price_spread !== null && item.price_spread > 0 && (
+        <div className="item-card-spread">
+          {formatPrice(item.price_spread, item.best_price_currency, userLocale)} between the cheapest and dearest store
+        </div>
+      )}
+
+      <div className="item-card-listings">
+        {item.listings.map(listing => (
+          <Link
+            key={listing.id}
+            to="/products/$productId"
+            params={{ productId: String(listing.id) }}
+            className={`item-listing ${listing.id === item.best_price_listing_id ? 'is-best' : ''}`}
+          >
+            <span className="item-listing-store">
+              {listing.retailer_name || hostOf(listing.url)}
+            </span>
+            <span className="item-listing-price">
+              {listing.converted_price !== null && listing.converted_price !== undefined
+                ? formatPrice(listing.converted_price, item.best_price_currency ?? listing.currency, userLocale)
+                : <span className="item-listing-absent">not compared</span>}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/** A readable store name for a listing whose retailer has no config yet. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+export default ItemCard;

--- a/frontend/src/features/products/components/ItemCard/index.ts
+++ b/frontend/src/features/products/components/ItemCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ItemCard';

--- a/frontend/src/features/products/pages/dashboard/Dashboard.css
+++ b/frontend/src/features/products/pages/dashboard/Dashboard.css
@@ -422,3 +422,47 @@
     transform: translateY(0);
   }
 }
+
+/*
+ * The grouped/flat view toggle (issue #143).
+ *
+ * "All stores" lists every retailer listing, which is the behaviour that
+ * predates items and stays the default. "By product" groups them.
+ */
+.dashboard-view-toggle {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.2rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--background);
+}
+
+.view-toggle-btn {
+  padding: 0.3rem 0.75rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.view-toggle-btn:hover:not(.active) { color: var(--text); }
+
+.view-toggle-btn.active {
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+}
+
+/*
+ * Item cards sit in the same intrinsic grid as product cards, so the two views
+ * have the same rhythm and switching between them does not reflow the page.
+ */
+.items-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 22rem), 1fr));
+  gap: 1rem;
+}

--- a/frontend/src/features/products/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/products/pages/dashboard/DashboardPage.tsx
@@ -7,9 +7,39 @@ import ConfirmationModal from '../../../../components/ConfirmationModal';
 import { useDashboardState } from '../../hooks/useDashboardState';
 import DashboardControls from './DashboardControls';
 import ProductList from './ProductList';
+import ItemList from './ItemList';
 import './Dashboard.css';
 
+type DashboardView = 'items' | 'all';
+
+/**
+ * Which view the dashboard opens on, remembered per browser (issue #143).
+ *
+ * Flat is the default, not grouped: today every item has exactly one listing,
+ * so the grouped view has nothing extra to show until a user attaches a second
+ * store. It earns the default once that exists.
+ */
+const VIEW_STORAGE_KEY = 'pricestalker.dashboard.view';
+
+function loadView(): DashboardView {
+  try {
+    return localStorage.getItem(VIEW_STORAGE_KEY) === 'items' ? 'items' : 'all';
+  } catch {
+    // Private windows and blocked site data throw on access rather than
+    // returning null, and a dashboard that will not render is worse than one
+    // that forgets a preference.
+    return 'all';
+  }
+}
+
 const Dashboard: React.FC = () => {
+  const [view, setView] = React.useState<DashboardView>(loadView);
+
+  const changeView = (next: DashboardView) => {
+    setView(next);
+    try { localStorage.setItem(VIEW_STORAGE_KEY, next); } catch { /* preference is optional */ }
+  };
+
   const {
     products,
     isLoading,
@@ -114,6 +144,30 @@ const Dashboard: React.FC = () => {
                   />
                 )}
 
+                {!isLoading && products.length > 0 && (
+                  <div className="dashboard-view-toggle" role="group" aria-label="Dashboard view">
+                    <button
+                      type="button"
+                      className={`view-toggle-btn ${view === 'all' ? 'active' : ''}`}
+                      aria-pressed={view === 'all'}
+                      onClick={() => changeView('all')}
+                    >
+                      All stores
+                    </button>
+                    <button
+                      type="button"
+                      className={`view-toggle-btn ${view === 'items' ? 'active' : ''}`}
+                      aria-pressed={view === 'items'}
+                      onClick={() => changeView('items')}
+                    >
+                      By product
+                    </button>
+                  </div>
+                )}
+
+                {view === 'items' ? (
+                  <ItemList searchQuery={searchQuery} activeCategory={activeCategory} />
+                ) : (
                 <ProductList
                   products={filteredAndSortedProducts}
                   isLoading={isLoading}
@@ -127,6 +181,7 @@ const Dashboard: React.FC = () => {
                   hasAnyProducts={products.length > 0}
                   onSelect={(id) => navigate({ to: '/products/$productId', params: { productId: String(id) } })}
                 />
+                )}
           </>}
         </main>
       </div>

--- a/frontend/src/features/products/pages/dashboard/ItemList.tsx
+++ b/frontend/src/features/products/pages/dashboard/ItemList.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import ItemCard from '../../components/ItemCard';
+import LoadingSpinner from '../../../../components/LoadingSpinner';
+import Icon from '../../../../components/Icon';
+import { itemListQuery } from '../../../../api/queries';
+import { useAuth } from '../../../auth';
+
+interface ItemListProps {
+  /** Applied to the item name, mirroring the flat view's search. */
+  searchQuery: string;
+  activeCategory: string | null;
+}
+
+/**
+ * The grouped dashboard (issue #143): one card per item rather than per
+ * retailer listing.
+ *
+ * Fetches separately from the flat list rather than grouping client-side. The
+ * best price depends on exchange rates the server already resolves for the flat
+ * view, and recomputing that in the browser would be a second implementation
+ * of the rule about which listings may be compared.
+ */
+const ItemList: React.FC<ItemListProps> = ({ searchQuery, activeCategory }) => {
+  const { user } = useAuth();
+  const itemsQuery = useQuery(itemListQuery());
+
+  if (itemsQuery.isError) {
+    return (
+      <div className="alert alert-error">
+        <span>Failed to load items. Please try again.</span>
+        <button type="button" className="btn btn-secondary" onClick={() => void itemsQuery.refetch()}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (itemsQuery.isLoading) return <LoadingSpinner centered />;
+
+  const items = (itemsQuery.data ?? []).filter(item => {
+    const matchesSearch = !searchQuery || item.name.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesCategory = !activeCategory || (item.category || '').split(',').map(c => c.trim()).includes(activeCategory);
+    return matchesSearch && matchesCategory;
+  });
+
+  if (items.length === 0) {
+    return (
+      <div className="products-empty">
+        <div className="products-empty-icon"><Icon name="package" /></div>
+        <div>{searchQuery || activeCategory ? 'No items match this filter' : 'Nothing tracked yet'}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="items-list">
+      {items.map(item => (
+        <ItemCard key={item.id} item={item} userLocale={user?.locale ?? undefined} />
+      ))}
+    </div>
+  );
+};
+
+export default ItemList;

--- a/frontend/src/features/products/services/ProductService.ts
+++ b/frontend/src/features/products/services/ProductService.ts
@@ -1,5 +1,6 @@
 import { api, type RequestOptions } from '../../../api/client';
 import { 
+  ItemWithListings,
   Product, 
   ProductWithStats, 
   CreateProductResponse, 
@@ -12,6 +13,8 @@ import {
 
 export const ProductService = {
   getAll: (options?: RequestOptions) => api.get<Product[]>('/products', options),
+  /** The same listings, grouped into items (issue #143). */
+  getItems: (options?: RequestOptions) => api.get<ItemWithListings[]>('/products/items', options),
 
   getById: (id: number, options?: RequestOptions) => api.get<ProductWithStats>(`/products/${id}`, options),
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -379,3 +379,31 @@ export interface TestRetailerConfigResult {
   error?: string;
   priceCandidates?: PriceCandidate[];
 }
+
+/**
+ * An item as the grouped dashboard shows it: the thing you want to buy, with
+ * every store selling it (issue #143).
+ *
+ * Mirrors backend ItemWithListings. `best_price` is in the user's own currency
+ * and is null when no store had a price we could convert -- see
+ * `excluded_count`, which exists so the UI can say "cheapest of 2 of your 4
+ * stores" rather than claiming more than we can support.
+ */
+export interface ItemWithListings {
+  id: number;
+  name: string;
+  image_url: string | null;
+  category: string | null;
+  target_price: number | null;
+  price_drop_threshold: number | null;
+  notify_back_in_stock: boolean;
+  listings: Product[];
+  store_count: number;
+  best_price: number | null;
+  best_price_listing_id: number | null;
+  best_price_currency: string | null;
+  price_spread: number | null;
+  comparable_count: number;
+  excluded_count: number;
+  any_in_stock: boolean;
+}


### PR DESCRIPTION
Phase 2 of #143. One card per item showing the best price across the stores selling it, behind a toggle beside the existing flat list.

## Grouped from the flat query, not a second one

Two reasons: the two views must agree about every number on screen, and the surest way to guarantee that is for both to come from one place. And the exchange-rate triangulation is the fiddliest SQL in the repository — a second copy is a second thing to get wrong.

The interesting logic then lives in a pure function, which is why it has 25 tests rather than needing a database to exercise.

## What "best price" refuses to mean

This is the actual decision. Only listings whose price could be expressed in the user's own currency take part. `converted_price` is already that figure — the price when currencies match, the converted amount when a rate resolved, `null` when none could be found — so a store priced in a currency we cannot convert is **excluded rather than compared raw**.

Ranking 49.99 EUR against 49.99 CHF and declaring a winner is worse than declining to, because the user acts on that number.

`excluded_count` exists so the card can say so out loud. *"Cheapest of 2 of your 4 stores"* is honest; *"cheapest"* alone would claim more than we can support. The uncomparable listings still appear, at the end — left out of a comparison is not the same as no longer tracked.

## Flat stays the default

Today every item has exactly one listing, so the grouped view has nothing extra to show until phase 5 lets a user attach a second store. It earns the default then. The preference is remembered in `localStorage`, wrapped in try/catch — a private window throws on access rather than returning null, and a dashboard that will not render is worse than one that forgets a preference.

## Verification

**Against a restore of the real production database.** All 21 items come back with a comparable price in CHF, and every invariant holds:

```
every item has >=1 listing   : true
store_count matches listings : true
comparable + excluded = stores: true
spread null for single store : true
best price is the min listing: true
```

Then the case the feature actually exists for, by attaching two more stores to one item:

```
item: N4
  stores 3, comparable 2, excluded 1, spread 19, best CHF 99.00

  cheaper.example    CHF  99.00   <- best
  www.digitec.ch     CHF 118.00
  weird.example      not comparable (XYZ 42)
```

**The XYZ store at 42 would have won a naive comparison against CHF 99.** It is excluded instead, and the card says one store could not be compared. That is the rule above, doing the thing it exists for.

526 backend tests (up from 504), 13 frontend, both builds, emoji lint, `git diff --check`.

## Next

3. item page with the multi-series chart
4. notifications naming which store triggered
5. attach a second store, then SearXNG multi-select

Refs #143
