### PR TITLE
feat(ui): show the running version under Logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The running version is shown in the user menu, under Logout. If the frontend
+  and backend are somehow on different versions -- which is what a half-finished
+  deploy looks like -- both are shown rather than one being picked.
+
 ## [2.1.0-beta.6] - 2026-09-05
 
 ### Added

--- a/backend/src/app/app.ts
+++ b/backend/src/app/app.ts
@@ -9,6 +9,7 @@ import settingsRoutes from '../routes/settings';
 import profileRoutes from '../routes/profile';
 import adminRoutes from '../routes/admin';
 import notificationRoutes from '../routes/notifications';
+import systemRoutes from '../routes/system';
 import { requestLogger, logger } from '../utils/system/logger';
 import pool from '../config/database';
 
@@ -61,6 +62,7 @@ app.use('/api/settings', settingsRoutes);
 app.use('/api/profile', profileRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/system', systemRoutes);
 
 // Error handling middleware
 app.use(

--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -1,0 +1,24 @@
+import { Router, Response } from 'express';
+import { AuthRequest, authMiddleware } from '../middleware/auth';
+import { asyncHandler } from '../utils/system/route-helpers';
+import { APP_VERSION } from '../utils/system/app-version';
+
+const router = Router();
+
+// Auth is per-router in this app, not global. Without this line the endpoint
+// would be open to anonymous callers, which is the opposite of what the comment
+// below describes.
+router.use(authMiddleware);
+
+/**
+ * What is actually running, for the version line in the user menu.
+ *
+ * Behind authentication deliberately. The version is not secret, but
+ * advertising it to anonymous callers hands an attacker a shortcut to whichever
+ * CVEs apply to this build, and everyone who needs to read it is signed in.
+ */
+router.get('/version', asyncHandler(async (_req: AuthRequest, res: Response) => {
+  res.json({ version: APP_VERSION });
+}, 'System', 'System', 'Failed to read version'));
+
+export default router;

--- a/backend/src/utils/system/app-version.ts
+++ b/backend/src/utils/system/app-version.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * The version of the backend that is actually running.
+ *
+ * Read from package.json once at startup rather than baked in at build time,
+ * so it cannot drift from what was installed. The file is present in the
+ * runtime image because pnpm needs it to resolve the workspace.
+ *
+ * Resolved by walking up from this module rather than from `process.cwd()`:
+ * the working directory depends on how the process was started, and a version
+ * banner that reads "unknown" because someone ran the binary from elsewhere is
+ * exactly the kind of small lie that wastes an afternoon during an incident.
+ */
+function readVersion(): string {
+  // An explicit override wins, for anyone building the image differently.
+  const fromEnv = process.env.APP_VERSION?.trim();
+  if (fromEnv) return fromEnv;
+
+  let dir = __dirname;
+  for (let depth = 0; depth < 6; depth++) {
+    try {
+      const candidate = path.join(dir, 'package.json');
+      if (fs.existsSync(candidate)) {
+        const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+        if (typeof parsed.version === 'string' && parsed.version) return parsed.version;
+      }
+    } catch {
+      // A malformed or unreadable package.json is not worth failing startup
+      // over: this value decorates a menu.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return 'unknown';
+}
+
+/** Resolved once. The file cannot change under a running process. */
+export const APP_VERSION = readVersion();

--- a/backend/tests/unit/app-version.test.ts
+++ b/backend/tests/unit/app-version.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * The version shown in the user menu. It decorates a menu, so nothing here may
+ * throw, and it is read during an incident, so it must not quietly lie.
+ */
+
+const original = process.env.APP_VERSION;
+
+async function load() {
+  vi.resetModules();
+  return import('../../src/utils/system/app-version');
+}
+
+beforeEach(() => vi.resetModules());
+afterEach(() => {
+  if (original === undefined) delete process.env.APP_VERSION;
+  else process.env.APP_VERSION = original;
+  vi.restoreAllMocks();
+});
+
+describe('APP_VERSION', () => {
+  it("reports the backend package's own version", async () => {
+    delete process.env.APP_VERSION;
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+    const { APP_VERSION } = await load();
+    expect(APP_VERSION).toBe(pkg.version);
+  });
+
+  it('does not fall back to the placeholder when a real version exists', async () => {
+    delete process.env.APP_VERSION;
+    const { APP_VERSION } = await load();
+    expect(APP_VERSION).not.toBe('unknown');
+    expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('lets an explicit override win, for images built differently', async () => {
+    process.env.APP_VERSION = '9.9.9-custom';
+    expect((await load()).APP_VERSION).toBe('9.9.9-custom');
+  });
+
+  it('ignores a blank override rather than reporting an empty version', async () => {
+    process.env.APP_VERSION = '   ';
+    expect((await load()).APP_VERSION).not.toBe('');
+    expect((await load()).APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('says "unknown" rather than throwing when the file cannot be read', async () => {
+    // A version banner is not worth failing startup over.
+    delete process.env.APP_VERSION;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => { throw new Error('EACCES'); });
+    expect((await load()).APP_VERSION).toBe('unknown');
+  });
+
+  it('says "unknown" rather than throwing on malformed JSON', async () => {
+    delete process.env.APP_VERSION;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('{ not json' as any);
+    expect((await load()).APP_VERSION).toBe('unknown');
+  });
+
+  it('does not depend on the working directory', async () => {
+    // Resolved by walking up from the module, not from process.cwd(): a version
+    // reading "unknown" because the process was started from elsewhere is the
+    // kind of small lie that wastes an afternoon during an incident.
+    delete process.env.APP_VERSION;
+    const cwd = process.cwd();
+    try {
+      process.chdir('/');
+      expect((await load()).APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { ProductService } from '../features/products/services/ProductService';
-import { ProfileService } from '../features/settings/services/ProfileService';
+import { ProfileService, SystemService } from '../features/settings/services/ProfileService';
 import { NotificationService } from '../features/notifications/services/NotificationService';
 import { SharedService } from '../services/SharedService';
 import { AdminSystemService } from '../features/admin/services/AdminSystemService';
@@ -16,6 +16,7 @@ export const queryKeys = {
   profile: ['profile'] as const,
   currencies: ['settings', 'currencies'] as const,
   notificationSettings: ['settings', 'notifications'] as const,
+  systemVersion: ['system', 'version'] as const,
   adminSystemSettings: ['admin', 'system-settings'] as const,
   priceHistory: (productId: number, days: number) => ['products', productId, 'price-history', days] as const,
   stockHistory: (productId: number, days: number) => ['products', productId, 'stock-history', days] as const,
@@ -60,6 +61,17 @@ export const discoveryStatusQuery = () => queryOptions({
   queryKey: queryKeys.discoveryStatus,
   queryFn: ({ signal }) => ProductService.getSearchStatus({ signal }),
   staleTime: 10 * 60_000,
+});
+
+/**
+ * What the backend is running. Fetched once and cached hard: the version cannot
+ * change without the process restarting, at which point the page reloads anyway.
+ */
+export const systemVersionQuery = () => queryOptions({
+  queryKey: queryKeys.systemVersion,
+  queryFn: ({ signal }) => SystemService.getVersion({ signal }),
+  staleTime: Infinity,
+  retry: false,
 });
 
 export const profileQuery = () => queryOptions({

--- a/frontend/src/features/settings/services/ProfileService.ts
+++ b/frontend/src/features/settings/services/ProfileService.ts
@@ -1,6 +1,11 @@
 import { api, type RequestOptions } from '../../../api/client';
 import { UserProfile, NotificationSettings } from '../../../types/api';
 
+export const SystemService = {
+  /** The version the backend is actually running. */
+  getVersion: (options?: RequestOptions) => api.get<{ version: string }>('/system/version', options),
+};
+
 export const ProfileService = {
   getProfile: (options?: RequestOptions) => api.get<UserProfile>('/profile', options),
 

--- a/frontend/src/layouts/Layout.css
+++ b/frontend/src/layouts/Layout.css
@@ -270,3 +270,20 @@
     display: none;
   }
 }
+
+/*
+ * The running version, under the logout button.
+ *
+ * Deliberately quiet: it is reference information you go looking for when
+ * something is wrong, not something to compete with the menu items above it.
+ */
+.user-dropdown-version {
+  padding: 0.5rem 0.75rem 0.25rem;
+  border-top: 1px solid var(--border);
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  user-select: text;
+}

--- a/frontend/src/layouts/UserDropdown.tsx
+++ b/frontend/src/layouts/UserDropdown.tsx
@@ -1,6 +1,39 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useAuth } from '../features/auth';
+import { useQuery } from '@tanstack/react-query';
+import { systemVersionQuery } from '../api/queries';
+
+/**
+ * What is actually running, under the logout button.
+ *
+ * The backend reports its version at runtime; the frontend knows its own from
+ * build time. Normally they match and one line is shown. When they do not, both
+ * are -- frontend and backend ship as separate images, so a half-finished
+ * deploy leaves them disagreeing, and that is exactly the moment this line is
+ * worth having.
+ *
+ * If the backend cannot be reached the frontend's own version is still shown,
+ * because "unknown" would be less useful than the half we are certain of.
+ */
+const VersionLine: React.FC = () => {
+  const { data } = useQuery(systemVersionQuery());
+  const backend = data?.version;
+  const frontend = __APP_VERSION__;
+  const mismatch = backend && backend !== frontend;
+
+  return (
+    <div className="user-dropdown-version">
+      {mismatch ? (
+        <span title="The frontend and backend are running different versions, which usually means a deploy did not finish.">
+          ui v{frontend} &middot; api v{backend}
+        </span>
+      ) : (
+        <span>v{frontend}</span>
+      )}
+    </div>
+  );
+};
 
 const UserDropdown: React.FC = () => {
   const { user, logout } = useAuth();
@@ -103,6 +136,7 @@ const UserDropdown: React.FC = () => {
             </svg>
             Logout
           </button>
+          <VersionLine />
         </div>
       )}
     </div>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,9 +1,7 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly VITE_API_URL: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
+/**
+ * The frontend's own version, replaced at build time by vite's `define`.
+ * See vite.config.ts.
+ */
+declare const __APP_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 
+/*
+ * The frontend's own version, baked in at build time (issue: show the running
+ * version in the menu).
+ *
+ * The backend reports its version separately at runtime. Both are shown when
+ * they disagree, because frontend and backend ship as separate images and a
+ * partial deploy is exactly the situation where a version line earns its place.
+ */
+const packageVersion = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8')
+).version as string;
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(packageVersion),
+  },
   plugins: [tanstackRouter({ target: 'react', autoCodeSplitting: true }), react()],
   server: {
     port: Number(process.env.VITE_PORT || 8080),


### PR DESCRIPTION
Nothing in the app said what was running, so the only way to tell which build a container was on was to read a manifest digest or shell into it.

The line sits **under Logout** in the user menu, quiet by design — it is reference information you go looking for when something is wrong, not something to compete with the menu items above it.

```
v2.1.0-beta.6
```

## Both halves, when they disagree

Frontend and backend report separately. Normally they match and one line shows. When they don't:

```
ui v2.1.0-beta.6 · api v2.1.0-beta.5
```

They ship as **separate images**, so a half-finished deploy leaves them on different versions — precisely the situation a version line exists for, and picking one to display would hide it. If the backend can't be reached, the frontend's own version still shows, because that beats "unknown".

## Where each number comes from

**Backend** reads `package.json` at startup rather than having a version baked in at build time, so the value cannot drift from what was actually installed. It walks up from the *module* directory rather than `process.cwd()` — the working directory depends on how the process was started, and a version reading "unknown" because someone ran the binary from elsewhere is the kind of small lie that wastes an afternoon during an incident. `APP_VERSION` overrides it for anyone building the image differently.

Nothing here throws. A malformed or unreadable `package.json` yields `"unknown"` rather than failing startup over a menu decoration.

**Frontend** is baked in at build time via Vite `define`, since the browser has no filesystem to read.

## One thing worth flagging

The endpoint is behind `authMiddleware`. I'd written the comment saying so before checking, and auth in this app is **per-router rather than global** — so the new router was open to anonymous callers until I added the line. The version isn't secret, but advertising it anonymously hands an attacker a shortcut to whichever CVEs apply to this build, and everyone who needs to read it is signed in.

## Verification

Against the **built output**, not the source — which is where this class of change fails:

```
frontend bundle contains literal   2.1.0-beta.6   (no unreplaced __APP_VERSION__)
backend from dist/                 2.1.0-beta.6
backend with APP_VERSION override  9.9.9-custom
backend from a different cwd       2.1.0-beta.6
```

533 tests, up from 526 — covering the override, a blank override, unreadable and malformed `package.json`, and the working-directory case.
