### PR TITLE
ci: stop overlapping publishes racing for the beta tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,26 @@ on:
       - '.github/workflows/**'
   workflow_dispatch:
 
+# `beta` is a moving tag: whichever run pushes last owns it. Without this, two
+# overlapping pushes to main race, and the *older* commit can win.
+#
+# That is not hypothetical. On 2026-09-05 a merge and the release commit that
+# followed it were building at the same time:
+#
+#   release commit (2.1.0-beta.7)  publish-frontend  09:21:22 -> 09:22:35
+#   the merge before it (beta.6)   publish-frontend  09:21:53 -> 09:23:05
+#
+# The older build finished thirty seconds later and left `beta` pointing at it,
+# so production deployed a frontend one version behind its own backend.
+#
+# Grouping per ref serialises main against itself and cancels the superseded
+# run: a build for a commit that is no longer the tip has nothing useful to
+# publish. Tags each get their own group and are never cancelled -- those
+# publish immutable version tags, and every one of them has to exist.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `beta` image tag can no longer end up pointing at an older commit than the
+  tip of `main`. Two pushes building at the same time raced for the tag, and the
+  one that finished last won regardless of which commit it was built from --
+  which put a frontend one version behind its own backend into production.
+
 ## [2.1.0-beta.7] - 2026-09-05
 
 ### Added


### PR DESCRIPTION
Found by the version line from #153, on its first deploy — which is exactly the case it was built to surface.

## What happened

`beta` is a moving tag, so whichever run pushes last owns it. With no `concurrency` group, two overlapping pushes to `main` race, and **the older commit can win**:

```
release commit (2.1.0-beta.7)  publish-frontend  09:21:22 -> 09:22:35
the merge before it (beta.6)   publish-frontend  09:21:53 -> 09:23:05   <- 30s later, wins
```

Merging #153 and pushing the release commit that followed put two builds in flight at once. The older one finished last and left `beta` pointing at it.

Verified directly against the registry rather than inferred:

```
frontend:beta          bundle contains -> 2.1.0-beta.6    (wrong)
frontend:2.1.0-beta.7  bundle contains -> 2.1.0-beta.7    (right)
```

Production then ran a frontend on beta.6 against a backend on beta.7 — from an image tag that had every appearance of being current. The immutable version tag was correct throughout; only the moving one was wrong, which is what made it invisible.

## The fix

```yaml
concurrency:
  group: publish-${{ github.ref }}
  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
```

Per-ref grouping serialises `main` against itself and cancels the superseded run — a build for a commit that is no longer the tip has nothing useful to publish. Tags each get their own group and are **never** cancelled: those publish immutable version tags and every one of them has to exist.