### PR TITLE
feat(items): link a store to a product you already track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- You can mark a store as selling a product you already track (#143). On a
+  product's page, **Same As Another Product** links the two, and from then on
+  they appear as one entry in the By product view with their prices compared
+  against each other. **Separate From Product** undoes it.
+- Linking tells you when it replaces alert settings, rather than leaving you to
+  discover it when an alert stops arriving: the product you link *to* owns the
+  target price and notification settings for both.
+
 ### Fixed
 
 - The `beta` image tag can no longer end up pointing at an older commit than the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,12 +232,24 @@ file and none are found. Do not change the backend build to bundle.
 
 - `pnpm --filter pricestalker-frontend run build` — passes, and typechecks.
 - `pnpm --filter pricestalker-backend test` and `pnpm --filter pricestalker-backend run build` — pass.
+- `pnpm --filter pricestalker-frontend test` — the unit tests.
+- `pnpm --filter pricestalker-frontend run test:routes` — the Playwright suite,
+  which CI runs and which is easy to forget because the other commands pass
+  without it. **Build the frontend first.** Playwright serves the prebuilt
+  `dist` via `vite preview` and reuses a running server outside CI, so a stale
+  bundle will happily pass tests for code you have just changed.
 - `pnpm run lint` (the emoji check, rule 1) passes.
 - New migrations tested against a real Postgres, not just `tsc`.
 - Verify against the **built bundle / running app**, not only the source. Three
   separate bugs here were invisible in source and only showed up in the compiled
   output or against real data (escaped emoji, null locale, unseeded reference
   tables).
+- **Never assume the shape of an API response in a component.** The e2e suite
+  answers unmocked endpoints with `{}`, and so does a misconfigured proxy in
+  production. `data?.find(...)` on an object throws and takes its whole section
+  down; `Array.isArray(data) ? data : []` renders without it. The ErrorBoundary
+  will catch the throw, but a section that renders slightly reduced beats one
+  that does not render.
 - Update `CHANGELOG.md` for any user-facing change. Add an entry under
   `## [Unreleased]` using `### Added`, `### Fixed`, or `### Changed`. The file
   follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — match the

--- a/backend/src/routes/products/crud.ts
+++ b/backend/src/routes/products/crud.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import { AuthRequest } from '../../middleware/auth';
 import { productAddService, productHistoryService } from '../../services/domain/product';
+import { itemRepository } from '../../models';
 import { asyncHandler, parseIdParam, callerIsAdmin } from '../../utils/system/route-helpers';
 
 const router = Router();
@@ -23,6 +24,39 @@ router.get('/items', asyncHandler(async (req: AuthRequest, res: Response) => {
   const items = await productHistoryService.getUserItems(req.userId!);
   res.json(items);
 }, 'Product', 'Products', 'Failed to fetch items'));
+
+/**
+ * Links a store you already track to another product -- "these two are the
+ * same thing" (issue #143).
+ *
+ * Declared before `/:id` for the same reason as `/items`: Express matches in
+ * order.
+ */
+router.post('/items/:itemId/listings', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const itemId = parseIdParam(req, 'itemId');
+  if (itemId === null) {
+    res.status(400).json({ error: 'Invalid product id' });
+    return;
+  }
+  const productId = Number(req.body?.productId);
+  if (!Number.isInteger(productId) || productId <= 0) {
+    res.status(400).json({ error: 'A productId is required' });
+    return;
+  }
+  const result = await itemRepository.attachListing(productId, itemId, req.userId!);
+  res.json(result);
+}, 'Product', 'Products', 'Failed to link the store'));
+
+/** Undoes the above: gives a store its own product entry again. */
+router.post('/:id/detach', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const productId = parseIdParam(req);
+  if (productId === null) {
+    res.status(400).json({ error: 'Invalid store id' });
+    return;
+  }
+  const item = await itemRepository.detachListing(productId, req.userId!);
+  res.json(item);
+}, 'Product', 'Products', 'Failed to separate the store'));
 
 router.post('/', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { url } = req.body;

--- a/backend/src/services/domain/product/repositories/item.repository.ts
+++ b/backend/src/services/domain/product/repositories/item.repository.ts
@@ -97,6 +97,148 @@ export const itemRepository = {
   },
 
   /**
+   * Moves a listing onto another item -- "these two are the same thing"
+   * (issue #143).
+   *
+   * The listing keeps its own URL, schedule, scrape history and prices. What
+   * changes is which item it belongs to, and therefore which alert settings
+   * apply to it: the target item's, not the ones it carried before. That is the
+   * point of the move, but it is a real loss if the old settings were the ones
+   * the user wanted, so the caller is told what was discarded.
+   *
+   * The moved listing is never primary. The target item already has one, and
+   * two primaries is the state the unique index exists to prevent.
+   */
+  attachListing: async (
+    productId: number,
+    itemId: number,
+    userId: number
+  ): Promise<{ movedFromItemId: number; discardedAlertSettings: Partial<Item> | null }> => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Both sides must belong to the caller. Checked in one place rather than
+      // trusting the route, because an id from a request body is not a claim
+      // about ownership.
+      const target = await client.query(`SELECT id FROM items WHERE id = $1 AND user_id = $2`, [itemId, userId]);
+      if (target.rowCount === 0) {
+        const err = new Error('Item not found');
+        (err as any).statusCode = 404;
+        throw err;
+      }
+
+      const product = await client.query(
+        `SELECT p.id, p.item_id, i.target_price, i.price_drop_threshold, i.notify_back_in_stock
+         FROM products p LEFT JOIN items i ON i.id = p.item_id
+         WHERE p.id = $1 AND p.user_id = $2`,
+        [productId, userId]
+      );
+      if (product.rowCount === 0) {
+        const err = new Error('Product not found');
+        (err as any).statusCode = 404;
+        throw err;
+      }
+
+      const previousItemId: number | null = product.rows[0].item_id;
+      if (previousItemId === itemId) {
+        const err = new Error('This store is already part of that product');
+        (err as any).statusCode = 409;
+        throw err;
+      }
+
+      await client.query(
+        `UPDATE products SET item_id = $1, is_primary = false WHERE id = $2 AND user_id = $3`,
+        [itemId, productId, userId]
+      );
+
+      // The item it came from may now be empty. deleteIfEmpty re-checks rather
+      // than assuming this was its only listing.
+      let discarded: Partial<Item> | null = null;
+      if (previousItemId !== null) {
+        const old = product.rows[0];
+        const hadSettings = old.target_price !== null || old.price_drop_threshold !== null || old.notify_back_in_stock;
+        const removed = await client.query(
+          `DELETE FROM items WHERE id = $1 AND NOT EXISTS (SELECT 1 FROM products WHERE item_id = $1)`,
+          [previousItemId]
+        );
+        // Only report a loss if the settings actually went with the deleted
+        // item. If other listings still hold it, nothing was discarded.
+        if (hadSettings && (removed.rowCount ?? 0) > 0) {
+          discarded = {
+            target_price: old.target_price,
+            price_drop_threshold: old.price_drop_threshold,
+            notify_back_in_stock: old.notify_back_in_stock,
+          };
+        }
+      }
+
+      await client.query('COMMIT');
+      return { movedFromItemId: previousItemId as number, discardedAlertSettings: discarded };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  },
+
+  /**
+   * Gives a listing its own item again, undoing an attach.
+   *
+   * The new item takes the listing's own name, image and category, so a
+   * detached store reads as the thing it actually is rather than inheriting a
+   * label chosen for a different grouping. Alert settings start empty: the ones
+   * on the item it is leaving belong to the remaining listings.
+   */
+  detachListing: async (productId: number, userId: number): Promise<Item> => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const product = await client.query(
+        `SELECT id, item_id, name, url, image_url, category FROM products WHERE id = $1 AND user_id = $2`,
+        [productId, userId]
+      );
+      if (product.rowCount === 0) {
+        const err = new Error('Product not found');
+        (err as any).statusCode = 404;
+        throw err;
+      }
+
+      const row = product.rows[0];
+      const siblings = await client.query(
+        `SELECT count(*)::int AS n FROM products WHERE item_id = $1 AND id <> $2`,
+        [row.item_id, productId]
+      );
+      if (siblings.rows[0].n === 0) {
+        // Already the only listing, so it is already its own item. Refusing is
+        // clearer than silently churning the row for no visible effect.
+        const err = new Error('This store is the only one for that product, so there is nothing to separate it from');
+        (err as any).statusCode = 409;
+        throw err;
+      }
+
+      const created = await client.query(
+        `INSERT INTO items (user_id, name, image_url, category) VALUES ($1, $2, $3, $4) RETURNING *`,
+        [userId, String(row.name || row.url).slice(0, 255), row.image_url, row.category]
+      );
+      await client.query(
+        `UPDATE products SET item_id = $1, is_primary = true WHERE id = $2`,
+        [created.rows[0].id, productId]
+      );
+
+      await client.query('COMMIT');
+      return created.rows[0];
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  },
+
+  /**
    * Deletes an item once its last listing has gone.
    *
    * An item with no listings has nothing to check and nothing to show, so

--- a/frontend/e2e/routes.spec.ts
+++ b/frontend/e2e/routes.spec.ts
@@ -35,6 +35,10 @@ test.beforeEach(async ({ page }) => {
         oidc_provider_name: null,
       },
       '/api/products': [product],
+      // Present so the grouped view and the linking action see the shape they
+      // expect. Without it the catch-all below answers `{}`, which is not the
+      // list they are typed for.
+      '/api/products/items': [],
       '/api/profile': { ...authenticatedUser, categories: ['Games'] },
       '/api/settings/currencies': [],
       '/api/settings/notifications': {},

--- a/frontend/src/features/products/components/LinkToItemModal/LinkToItemModal.css
+++ b/frontend/src/features/products/components/LinkToItemModal/LinkToItemModal.css
@@ -1,0 +1,84 @@
+.link-item-modal {
+  max-width: 34rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.link-item-title {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.link-item-subtitle {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.link-item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  /* Bounded so a long list scrolls inside the modal rather than pushing the
+     cancel button off the screen. */
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.link-item-option {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--background);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.link-item-option:hover:not(:disabled) { border-color: var(--primary); }
+.link-item-option:disabled { opacity: 0.6; cursor: default; }
+
+.link-item-option-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.link-item-option-meta {
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.link-item-empty {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.link-item-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.link-item-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}

--- a/frontend/src/features/products/components/LinkToItemModal/LinkToItemModal.tsx
+++ b/frontend/src/features/products/components/LinkToItemModal/LinkToItemModal.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { itemListQuery } from '../../../../api/queries';
+import { ItemWithListings } from '../../../../types/api';
+import { formatPrice } from '../../../../utils/format';
+import LoadingSpinner from '../../../../components/LoadingSpinner';
+import Icon from '../../../../components/Icon';
+import { useAuth } from '../../../auth';
+import './LinkToItemModal.css';
+
+interface LinkToItemModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** The store being linked. */
+  productId: number;
+  productName: string;
+  onConfirm: (itemId: number) => Promise<void>;
+}
+
+/**
+ * Picks which product a store belongs to -- "these two are the same thing"
+ * (issue #143).
+ *
+ * Lists products the user already tracks. The store's own product is excluded,
+ * because linking something to where it already is is not a choice worth
+ * offering.
+ */
+const LinkToItemModal: React.FC<LinkToItemModalProps> = ({
+  isOpen, onClose, productId, productName, onConfirm,
+}) => {
+  const { user } = useAuth();
+  const [search, setSearch] = useState('');
+  const [pending, setPending] = useState<number | null>(null);
+  const itemsQuery = useQuery({ ...itemListQuery(), enabled: isOpen });
+
+  const candidates = useMemo(() => {
+    const all: ItemWithListings[] = itemsQuery.data ?? [];
+    return all
+      // Exclude the product this store already belongs to.
+      .filter(item => !item.listings.some(l => l.id === productId))
+      .filter(item => !search || item.name.toLowerCase().includes(search.toLowerCase()));
+  }, [itemsQuery.data, productId, search]);
+
+  if (!isOpen) return null;
+
+  const choose = async (itemId: number) => {
+    setPending(itemId);
+    try {
+      await onConfirm(itemId);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal link-item-modal" onClick={e => e.stopPropagation()}>
+        <h2 className="link-item-title">Which product is this the same as?</h2>
+        <p className="link-item-subtitle">
+          <strong>{productName}</strong> becomes another store for whichever product you pick, and
+          they share one price comparison and one set of alerts from then on.
+        </p>
+
+        <input
+          type="text"
+          className="form-control"
+          placeholder="Search your products"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          autoFocus
+        />
+
+        {itemsQuery.isLoading ? (
+          <LoadingSpinner centered />
+        ) : itemsQuery.isError ? (
+          <div className="link-item-empty">Your products could not be loaded.</div>
+        ) : candidates.length === 0 ? (
+          <div className="link-item-empty">
+            {search
+              ? 'Nothing matches that.'
+              : 'You are not tracking anything else yet, so there is nothing to link this to.'}
+          </div>
+        ) : (
+          <div className="link-item-list">
+            {candidates.map(item => (
+              <button
+                key={item.id}
+                type="button"
+                className="link-item-option"
+                onClick={() => void choose(item.id)}
+                disabled={pending !== null}
+              >
+                <span className="link-item-option-name">{item.name}</span>
+                <span className="link-item-option-meta">
+                  {item.store_count === 1 ? '1 store' : `${item.store_count} stores`}
+                  {item.best_price !== null && (
+                    <> &middot; {formatPrice(item.best_price, item.best_price_currency, user?.locale ?? undefined)}</>
+                  )}
+                </span>
+                {pending === item.id && <LoadingSpinner size="1rem" />}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="link-item-footer">
+          {/*
+            Said before the choice rather than after: the alert settings on this
+            store's current product are dropped when it joins another, and
+            finding that out when an alert stops arriving would be worse.
+          */}
+          <div className="link-item-note">
+            <Icon name="alertTriangle" />
+            Any target price or alert set on <strong>{productName}</strong> alone is replaced by the
+            settings of the product you choose.
+          </div>
+          <button className="btn btn-secondary" onClick={onClose} disabled={pending !== null}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkToItemModal;

--- a/frontend/src/features/products/components/LinkToItemModal/LinkToItemModal.tsx
+++ b/frontend/src/features/products/components/LinkToItemModal/LinkToItemModal.tsx
@@ -34,10 +34,10 @@ const LinkToItemModal: React.FC<LinkToItemModalProps> = ({
   const itemsQuery = useQuery({ ...itemListQuery(), enabled: isOpen });
 
   const candidates = useMemo(() => {
-    const all: ItemWithListings[] = itemsQuery.data ?? [];
+    const all: ItemWithListings[] = Array.isArray(itemsQuery.data) ? itemsQuery.data : [];
     return all
       // Exclude the product this store already belongs to.
-      .filter(item => !item.listings.some(l => l.id === productId))
+      .filter(item => !item.listings?.some(l => l.id === productId))
       .filter(item => !search || item.name.toLowerCase().includes(search.toLowerCase()));
   }, [itemsQuery.data, productId, search]);
 

--- a/frontend/src/features/products/components/LinkToItemModal/index.ts
+++ b/frontend/src/features/products/components/LinkToItemModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LinkToItemModal';

--- a/frontend/src/features/products/pages/dashboard/ItemList.tsx
+++ b/frontend/src/features/products/pages/dashboard/ItemList.tsx
@@ -38,7 +38,9 @@ const ItemList: React.FC<ItemListProps> = ({ searchQuery, activeCategory }) => {
 
   if (itemsQuery.isLoading) return <LoadingSpinner centered />;
 
-  const items = (itemsQuery.data ?? []).filter(item => {
+  // Array.isArray rather than a null check: an unexpected response shape must
+  // render as "nothing to show" rather than throwing out of the dashboard.
+  const items = (Array.isArray(itemsQuery.data) ? itemsQuery.data : []).filter(item => {
     const matchesSearch = !searchQuery || item.name.toLowerCase().includes(searchQuery.toLowerCase());
     const matchesCategory = !activeCategory || (item.category || '').split(',').map(c => c.trim()).includes(activeCategory);
     return matchesSearch && matchesCategory;

--- a/frontend/src/features/products/pages/product-detail/OverviewSection.tsx
+++ b/frontend/src/features/products/pages/product-detail/OverviewSection.tsx
@@ -30,7 +30,13 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
   // Whether this store shares a product with others decides which action is
   // offered: link, or separate. Derived from the grouped data rather than
   // tracked separately, so it cannot disagree with what the dashboard shows.
-  const owningItem = itemsQuery.data?.find(item => item.listings.some(l => l.id === product?.id));
+  // Array.isArray, not just a null check: this decorates the page with a
+  // grouping action, and a response that is not the expected shape -- a proxy
+  // error page, a misconfigured deployment -- must not take the whole overview
+  // down with it. The ErrorBoundary would catch it, but a section that renders
+  // without the extra button is a better outcome than one that does not render.
+  const items = Array.isArray(itemsQuery.data) ? itemsQuery.data : [];
+  const owningItem = items.find(item => item.listings?.some(l => l.id === product?.id));
   const sharesProduct = (owningItem?.store_count ?? 1) > 1;
 
   const refreshEverything = () => {

--- a/frontend/src/features/products/pages/product-detail/OverviewSection.tsx
+++ b/frontend/src/features/products/pages/product-detail/OverviewSection.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { ProductImage, ProductPriceStatus } from './ProductInfo';
 import ProductHeader from './ProductHeader';
 import ProductMetadata from './ProductMetadata';
 import ProductActions from './ProductActions';
+import LinkToItemModal from '../../components/LinkToItemModal';
+import { itemListQuery, queryKeys } from '../../../../api/queries';
+import { ProductService } from '../../services/ProductService';
+import { queryClient } from '../../../../api/queryClient';
+import { useToast } from '../../../../context/ToastContext';
 
 interface OverviewSectionProps {
   product: any;
@@ -17,6 +23,50 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
   state,
   REFRESH_INTERVALS 
 }) => {
+  const { showToast } = useToast();
+  const [isLinking, setIsLinking] = useState(false);
+  const itemsQuery = useQuery(itemListQuery());
+
+  // Whether this store shares a product with others decides which action is
+  // offered: link, or separate. Derived from the grouped data rather than
+  // tracked separately, so it cannot disagree with what the dashboard shows.
+  const owningItem = itemsQuery.data?.find(item => item.listings.some(l => l.id === product?.id));
+  const sharesProduct = (owningItem?.store_count ?? 1) > 1;
+
+  const refreshEverything = () => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.products.all });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.products.items });
+  };
+
+  const handleLink = async (itemId: number) => {
+    try {
+      const result = await ProductService.attachToItem(itemId, product.id);
+      setIsLinking(false);
+      refreshEverything();
+      // Say what was lost. The alternative is the user discovering it when an
+      // alert they had set stops arriving.
+      const lost = result?.discardedAlertSettings;
+      showToast(
+        lost
+          ? 'Linked. The alert settings this store had on its own were replaced by the ones on the product you chose.'
+          : 'Linked. These stores are now compared together.',
+        'success'
+      );
+    } catch (err: any) {
+      showToast(err?.response?.data?.error || 'Could not link these products.', 'error');
+    }
+  };
+
+  const handleSeparate = async () => {
+    try {
+      await ProductService.detachFromItem(product.id);
+      refreshEverything();
+      showToast('Separated. This store is tracked on its own again.', 'success');
+    } catch (err: any) {
+      showToast(err?.response?.data?.error || 'Could not separate this store.', 'error');
+    }
+  };
+
   return (
     <div className="product-detail-card">
       <div className="product-detail-content">
@@ -78,6 +128,16 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
             handleResumeMonitoring={state.handleResumeMonitoring}
             isRefreshing={state.isRefreshing}
             isPaused={!!product?.checking_paused}
+            onLinkToProduct={() => setIsLinking(true)}
+            onSeparate={sharesProduct ? () => void handleSeparate() : undefined}
+          />
+
+          <LinkToItemModal
+            isOpen={isLinking}
+            onClose={() => setIsLinking(false)}
+            productId={product?.id}
+            productName={product?.name || 'This store'}
+            onConfirm={handleLink}
           />
         </div>
       </div>

--- a/frontend/src/features/products/pages/product-detail/ProductActions.tsx
+++ b/frontend/src/features/products/pages/product-detail/ProductActions.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import LoadingSpinner from '../../../../components/LoadingSpinner';
 
 interface ProductActionsProps {
+  /** Opens the picker for linking this store to another product (issue #143). */
+  onLinkToProduct: () => void;
+  /**
+   * Set when this store shares a product with others, so it can be separated
+   * again. Undefined when it is the only store, where there is nothing to
+   * separate from.
+   */
+  onSeparate?: () => void;
   handleRefresh: () => Promise<void>;
   handleRescan: () => Promise<void>;
   handleDelete: () => Promise<void>;
@@ -12,6 +20,8 @@ interface ProductActionsProps {
 }
 
 const ProductActions: React.FC<ProductActionsProps> = ({
+  onLinkToProduct,
+  onSeparate,
   handleRefresh,
   handleRescan,
   handleDelete,
@@ -44,6 +54,28 @@ const ProductActions: React.FC<ProductActionsProps> = ({
       <button className="btn btn-rescan" onClick={handleRescan} disabled={isRefreshing} title="Troubleshoot extraction issues by forcing a re-scan and selection modal">
         {isRefreshing ? <LoadingSpinner size="1rem" /> : 'Troubleshoot Price'}
       </button>
+      {/*
+        Grouping actions sit next to the destructive one but before it, because
+        "this is the same as that" is a far more common intent than deleting,
+        and separating is the undo for having linked the wrong pair.
+      */}
+      {onSeparate ? (
+        <button
+          className="btn btn-secondary"
+          onClick={onSeparate}
+          title="Track this store on its own again, instead of alongside the other stores for this product"
+        >
+          Separate From Product
+        </button>
+      ) : (
+        <button
+          className="btn btn-secondary"
+          onClick={onLinkToProduct}
+          title="Mark this store as selling a product you already track, so their prices are compared together"
+        >
+          Same As Another Product
+        </button>
+      )}
       <button className="btn btn-danger" onClick={handleDelete}>Stop Tracking</button>
     </div>
   );

--- a/frontend/src/features/products/services/ProductService.ts
+++ b/frontend/src/features/products/services/ProductService.ts
@@ -16,6 +16,20 @@ export const ProductService = {
   /** The same listings, grouped into items (issue #143). */
   getItems: (options?: RequestOptions) => api.get<ItemWithListings[]>('/products/items', options),
 
+  /**
+   * Links a store you already track to another product -- "these two are the
+   * same thing". Returns what alert settings the move discarded, if any, so the
+   * user can be told rather than finding out when an alert stops arriving.
+   */
+  attachToItem: (itemId: number, productId: number) =>
+    api.post<{ movedFromItemId: number; discardedAlertSettings: { target_price: number | null; price_drop_threshold: number | null; notify_back_in_stock: boolean } | null }>(
+      `/products/items/${itemId}/listings`, { productId }
+    ),
+
+  /** Undoes the above: gives this store its own product entry again. */
+  detachFromItem: (productId: number) =>
+    api.post<{ id: number; name: string }>(`/products/${productId}/detach`, {}),
+
   getById: (id: number, options?: RequestOptions) => api.get<ProductWithStats>(`/products/${id}`, options),
 
   create: (data: {


### PR DESCRIPTION
Phase 5 of #143 — and the one that makes the grouped view worth having. Until now every item had exactly one listing, so **By product** had nothing to group.

## Scope

Linking products **already being tracked**, rather than adding a new URL onto an existing item. That choice matters:

- no changes to the scrape or price-review flow
- fully reversible
- it covers the case a user actually arrives with — two dashboard entries that turn out to be the same thing

Adding a new URL straight onto an item can build on this later: add it normally, then link.

## Alert settings, and saying so

Alert settings follow the item, so linking **replaces** the ones the store carried on its own. That is correct — one set of settings for one product is the entire point — but it is a real loss if those were the settings the user wanted.

So `attachListing` reports what it discarded, the confirmation toast says so, and the modal warns *before* the choice as well. Finding out when an alert stops arriving would be worse than either.

## Guards

In the repository, not the route — an id in a request body is not a claim about ownership:

| attempt | result |
|---|---|
| product belongs to another user | 404 |
| target item belongs to another user | 404 |
| store already on that product | 409 |
| separate a store that is the only one | 409 |

Each refuses with a status code rather than silently doing nothing, and the data was unchanged after every one.

A linked store is **never primary** — the target already has one, and two primaries is the state the unique index exists to prevent. Separating creates a fresh item carrying the store's own name and image, so it reads as the thing it is rather than keeping a label chosen for a different grouping, and starts with empty alert settings because the ones it is leaving belong to the stores that remain.

## Verified against a restore of the production database

Attaching two real products that genuinely are near-duplicates:

```
before   21 items   p4 alone, best CHF 1449.00, no spread

attach   discarded {"target_price":850,...} from p5's old item

after    20 items   2 stores, best CHF 1349.00, spread 100
                    p5  Digitec  CHF 1349.00   <- best
                    p4  Digitec  CHF 1449.00

detach   21 items   back exactly as it started
```

That CHF 100 gap is the feature doing its job on real data.

533 backend tests, 13 frontend, both builds, emoji lint, `git diff --check`. No schema change — the item layer from phase 1 already supports N listings.

Refs #143
