### PR TITLE
docs: correct the schema, webhook and user guides against what ships

### DIFF
--- a/docs/admin/user_notifications.md
+++ b/docs/admin/user_notifications.md
@@ -42,30 +42,58 @@ You can configure and test your notification channels under **User Settings → 
 ### Custom Webhook
 For integrations with Home Assistant, Apprise, n8n, Zapier, or custom APIs, select **Custom Webhook** in Settings → Notifications:
 * **URL**: The endpoint of the receiver.
-* **HTTP Method**: Choose `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`.
-* **Headers**: Optional JSON object of header key-value pairs (e.g. `{"Authorization": "Bearer ..."}`). The `Content-Type` header defaults to `application/json` for non-GET requests if omitted.
-* **Body Template**: Optional. Leave blank to send PriceStalker's default JSON payload structure. If defined, variables enclosed in `{}` will be substituted:
+* **Headers**: Optional JSON object of header key-value pairs (e.g. `{"Authorization": "Bearer ..."}`). `Content-Type: application/json` is sent by default.
+* **Body Template**: Optional. Leave blank to send PriceStalker's default JSON payload, below. If you supply one, variables in **double** braces are substituted — `{{product_name}}`, not `{product_name}`. Single braces are left untouched.
 
-| Token | Meaning |
-|-------|---------|
-| `{title}` / `{product_name}` | Product name |
-| `{type}` | Alert event type (e.g. `price_drop`, `target_price`, `back_in_stock`, `unavailable`, `resumed`) |
-| `{url}` | Product URL |
-| `{currency}` | ISO currency code |
-| `{price}` | Current price formatted with currency |
-| `{new_price}` / `{current_price}` | Raw numeric current price |
-| `{old_price}` | Previous price (when applicable) |
-| `{threshold}` | Configured price drop threshold |
-| `{target_price}` | Configured target price |
-| `{reason}` | Detailed explanation (e.g. for unavailable alerts or stock transitions) |
-| `{timestamp}` | ISO-8601 message timestamp |
+The request is always a `POST`. (v1 had a configurable method; v2 does not.)
+
+**Default payload**, sent when no body template is set:
+
+```json
+{
+  "event": "price_drop",
+  "product": "Sony WH-1000XM5",
+  "productId": 409,
+  "url": "https://shop.example/p/1",
+  "price": 249.99,
+  "oldPrice": 299.00,
+  "targetPrice": 250.00,
+  "currency": "CHF",
+  "oldStockStatus": "out_of_stock",
+  "newStockStatus": "in_stock",
+  "reason": null,
+  "paused": null,
+  "timestamp": "2026-09-05T09:20:00.000Z"
+}
+```
+
+`event` is one of `price_drop`, `target_price`, `back_in_stock`, `price_announced`, `not_available`, `product_restored`. Any field that does not apply to an event is `null` — including `currency`, which is `null` rather than a guessed `USD` when the scrape could not resolve one.
 
 * *Tip: Hit **Send Test** to send a test payload. Webhook.site is an excellent tool for testing webhook payloads.*
 
 ---
 
 ## 2. Customizable Message Templates
-Under your notification channel configurations, you can customize the message formats across channels. Shared template variables (`{{product_name}}`, `{{price}}`, `{{current_price}}`, `{{old_price}}`, `{{url}}`, `{{reason}}`) are resolved dynamically for each event.
+Under your notification channel configurations, you can customize the message formats across channels. The full set of variables, resolved for every channel and every event:
+
+| Variable | Meaning |
+|---|---|
+| `{{product_name}}` | Product name |
+| `{{product_url}}` | Product URL (**not** `{{url}}`) |
+| `{{product_id}}` | Numeric id, or `N/A` |
+| `{{price}}` | Current price with its currency attached, e.g. `CHF 49.90`, or `unavailable` |
+| `{{current_price}}` | Current price as a bare number, e.g. `49.90`, or `unavailable` |
+| `{{old_price}}` | Previous price as a bare number, or `unavailable` |
+| `{{currency}}` | ISO code, or empty when the scrape could not resolve one |
+| `{{currency_symbol}}` | Symbol where one is recognised, otherwise empty |
+| `{{type}}` | Event, de-underscored, e.g. `back in stock` |
+| `{{old_stock_status}}` / `{{new_stock_status}}` | Stock either side of the change, e.g. `Out of stock` |
+| `{{reason}}` | Why a product could not be read, on unavailable alerts |
+
+One template covers **every** event, so wording it around a price drop reads
+oddly on a back-in-stock or unavailable alert. Use `{{type}}` and
+`{{new_stock_status}}` to describe what happened, or leave the field empty to
+get wording chosen per event.
 
 ---
 

--- a/docs/developer/DATABASE.md
+++ b/docs/developer/DATABASE.md
@@ -39,18 +39,57 @@ Stores user profile information, authentication hashes, locale/currency settings
  - *(Note: AI provider settings and API keys are stored instance-wide in `system_settings`, not in `users`)*.
 
 ### 2. `products`
-The central registry of tracked items across all users.
+One retailer's listing of something: a URL, its own schedule, its own scrape and
+price history. **Not** the thing the user is tracking — that is `items`, below,
+and every product belongs to exactly one.
 * **Key Fields**:
  - `url` & `name`
+ - `item_id`: The canonical item this listing belongs to. Never null in practice.
+ - `is_primary`: Whether this listing supplies the item's identity. At most one
+   per item, enforced by the partial unique index `products_one_primary_per_item`.
  - `refresh_interval`: Frequency (seconds) for scheduled checks.
+ - `next_check_at`: When the scheduler will next pick it up. Bounded at 1.5x
+   `refresh_interval`; see `utils/system/scheduler-helpers.ts`.
  - `stock_status`: Current availability (`in_stock`, `out_of_stock`, `pre_order`, `member_only`, `not_available`, `unknown`).
- - `unavailable_reason`: Specific explanation when a page cannot be reached (e.g. `404/410`, `Bot wall`, `Timeout`).
- - `consecutive_unavailable_count`: Consecutive count of failed scrapes used for de-bouncing before marking unavailable.
- - `paused_by`: Tracks whether monitoring was paused by `user` or `system`.
- - `price_drop_threshold` & `target_price`: Alert targets.
+ - `unavailable_reason`: Specific explanation when a page cannot be reached. See `types/availability.ts` for the codes.
+ - `page_gone_streak`: Consecutive *definitive* failures (404/410/soft-404), used to de-bounce before marking a product unavailable.
+ - `failure_streak` & `last_failure_at`: Consecutive *transient* failures (timeout, DNS, bot challenge). Tracked separately because a transient failure is evidence about the network, not about the product, and never pauses monitoring.
+ - `checking_paused` & `auto_paused`: Whether monitoring is stopped, and whether the system stopped it rather than the user. The system only resumes what the system paused.
  - `preferred_extraction_method`: Stores the winning consensus extraction type.
  - `anchor_price`: Benchmark price used to detect anomalous consensus pricing drift.
  - `needs_price_review`: Boolean flag indicating manual verification required.
+* **Dead columns, do not read**: `target_price`, `price_drop_threshold` and
+  `notify_back_in_stock` still exist here but moved to `items` in migration 020.
+  They are retained only so that migration can be rolled back, and a later
+  migration drops them. Reading them yields whatever they held before the move.
+
+### 2a. `items`
+The canonical thing a user wants to buy, which may be sold by several
+retailers. Introduced by migration `020_canonical_items` (issue #143), which
+renamed the previously unused `product_groups`.
+
+A product tracked at a single retailer is an item with one listing — grouping is
+not optional, so that alert settings have exactly one home rather than living on
+two tables with a rule about which wins.
+
+**Naming**: the UI says "Product" for an item and "Store" for a listing, because
+that is how people think about it. The database says `items` and `products`
+because those are unambiguous to read. The mismatch is deliberate — see CLAUDE.md.
+
+* **Key Fields**:
+ - `name`, `image_url`, `category`: How the item is displayed. Seeded from the primary listing.
+ - `user_id`: Owner. `ON DELETE CASCADE` from `users`.
+ - `target_price`, `price_drop_threshold`, `notify_back_in_stock`: Alert settings.
+   These describe intent about the thing ("tell me when anyone has this under
+   50"), not about one shop's page, which is why they live here.
+* **Constraints**: `products.item_id` references this `ON DELETE SET NULL`, so
+  deleting an item ungroups its listings rather than destroying their history.
+  `idx_products_item_id` supports fetching every listing for an item.
+* **Reading a product's alert settings**: join through
+  `ITEM_ALERT_COLUMNS` / `ITEM_ALERT_JOIN` and map rows with
+  `withItemAlertSettings` (`repositories/item-alert-settings.ts`). The aliases
+  exist because selecting `i.target_price` beside `p.*` yields two columns of the
+  same name, and which one the driver keeps is undocumented.
 
 ### 3. `retailer_configs`
 Houses the extraction selectors and custom routing rules. **Strictly no retailer logic is hardcoded in backend services.**

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -23,7 +23,50 @@ when you want to check a product before its next scheduled refresh.
 
 ---
 
-## 2. How the Scraper Reads a Product Page
+## 2. Tracking One Product at Several Stores
+
+If the same thing is sold by more than one retailer, you can track each store
+and have PriceStalker compare them.
+
+**Linking two stores.** Add each retailer's page as you would any product, then
+open one of them and choose **Same As Another Product**. Pick the product it is
+the same as, and from then on the two appear as a single entry. **Separate From
+Product** undoes it at any time; nothing is deleted either way, and each store
+keeps its own price history.
+
+Nothing is grouped automatically. Only you know that two pages are the same
+physical item, and guessing wrong would silently merge two things you wanted to
+watch separately.
+
+**Seeing them together.** The dashboard has two views:
+
+* **All stores** — every retailer listing separately. This is the default and is
+  how PriceStalker has always worked.
+* **By product** — one card per product, showing the best price across its
+  stores, the gap between the cheapest and dearest, and each store underneath.
+
+Your choice is remembered.
+
+**How the best price is chosen.** Prices are converted to your preferred
+currency before being compared. A store whose currency could not be resolved is
+**left out of the comparison**, and the card says how many were excluded — for
+example "best of 2" when you are tracking four stores. Comparing an amount in
+one currency against an amount in another and calling one cheaper would be
+misleading, and it is a number you would act on.
+
+**Alerts belong to the product, not the store.** One target price covers every
+store, and a drop at any of them triggers it. This means linking replaces
+whatever alert settings the store had on its own with the ones on the product
+you link it to — you are warned before confirming, and told afterwards if
+anything was replaced.
+
+**Adding a store to something you already track**: add the new URL as a normal
+product first, then link it. Pasting a URL directly onto an existing product is
+not supported yet.
+
+---
+
+## 3. How the Scraper Reads a Product Page
 
 For most retailers, PriceStalker reads the page using a fast standard web
 request. It then removes unrelated page content and looks for the product
@@ -41,7 +84,7 @@ read the page correctly.
 
 ---
 
-## 3. Data Extraction (The Cascade)
+## 4. Data Extraction (The Cascade)
 Once the HTML is downloaded, the system denoises the page—stripping out heavy scripts, footers, headers, and navigation menus to keep only the core product content. It then checks for prices in a **7-layered cascade**:
 1. **Structural Metadata** (JSON-LD data formatted for search engines like Google).
 2. **Deal Selectors** (Temporary deals/sale prices).
@@ -66,7 +109,7 @@ enough evidence to distinguish them.
 
 ---
 
-## 4. When a Page Is Unavailable
+## 5. When a Page Is Unavailable
 
 PriceStalker distinguishes between temporary network glitches and pages that appear
 to have gone away:
@@ -79,7 +122,7 @@ to have gone away:
   * **Resume Monitoring**: Re-activates automatic background checks for a paused product.
   * **Automatic recovery**: If an automatically paused product becomes available again on a subsequent check, monitoring resumes automatically and a back-online notification is sent. (Products paused manually by you remain paused until you choose to resume them).
 
-## 5. Where AI Fits In (Enhanced, but Optional)
+## 6. Where AI Fits In (Enhanced, but Optional)
 PriceStalker is built to be resilient, even without AI. However, enabling the AI Engine unlocks powerful benefits:
 
 ### AI Auto-Mapping
@@ -91,7 +134,7 @@ PriceStalker is built to be resilient, even without AI. However, enabling the AI
 
 ---
 
-## 6. Price Consensus & The Voting Modal
+## 7. Price Consensus & The Voting Modal
 Sometimes, different elements on a page list different prices (e.g., a "Buy Now" price vs. "Save $10" deal tags). PriceStalker handles this gracefully:
 
 * **Consensus Engine**: The system groups all extracted price candidates and tallies them up using a weighting scale. High-priority paths (like JSON-LD) carry more weight than generic HTML scans.
@@ -100,13 +143,13 @@ Sometimes, different elements on a page list different prices (e.g., a "Buy Now"
 
 ---
 
-## 7. The Learning Loop
+## 8. The Learning Loop
 When you manually select the correct price in the Voting Modal (or when a scrape is successful), PriceStalker learns from it:
 * It analyzes which rule successfully found that price.
 * It promotes that rule to the top priority for that store.
 * It tracks rule failure rates. If a rule fails too many times consecutively, it is automatically demoted or evicted.
 
-## 8. Refreshes, Notifications, and Troubleshooting
+## 9. Refreshes, Notifications, and Troubleshooting
 
 Products are checked according to their configured refresh interval. A product
 may not be checked immediately after it is added because the scheduler spreads
@@ -129,7 +172,7 @@ If a product needs attention:
 * **The page is incomplete or blocked**: an administrator may need to enable
   the browser scraper or update the retailer rules.
 
-## 9. Currency and privacy
+## 10. Currency and privacy
 
 PriceStalker can display prices in your preferred currency using its configured
 exchange-rate data. The original retailer currency remains part of the price
@@ -149,6 +192,15 @@ requirements.
   member-only, unavailable, or unknown.
 * **Price candidate**: A possible price found on the page before PriceStalker
   chooses or asks you to confirm the result.
+
+---
+
+## Which version am I running?
+
+The version is shown in the user menu, under **Logout**. Normally one number
+appears. If the interface and the API are somehow on different versions — which
+is what a half-finished deploy looks like — both are shown, and that is worth
+reporting.
 
 ---
 


### PR DESCRIPTION
Audited the docs against the code after this cycle. Three files were wrong in ways that would cost a reader real time.

## `developer/DATABASE.md` — documented columns that do not exist

Checked against the production database:

| documented | reality |
|---|---|
| `consecutive_unavailable_count` | **does not exist** — it is `page_gone_streak` |
| `paused_by` | **does not exist** — it is `checking_paused` + `auto_paused` |
| `target_price` / `price_drop_threshold` on `products` | **moved to `items`** in migration 020; the columns left behind are dead |
| `items` | **not documented at all** |

The alert-column one is the worst kind of wrong: those columns still exist, so reading them returns a plausible answer rather than an error. They are retained only so migration 020 can roll back.

`items` is now documented — why grouping is not optional, why the UI and database deliberately use different words, and that reading a product’s alert settings means joining through `ITEM_ALERT_COLUMNS` rather than selecting the columns directly.

## `admin/user_notifications.md` — the webhook section was unusable

It said body-template variables are *"enclosed in `{}`"*. The engine matches **double** braces, so anyone following this wrote `{price}` and received a literal `{price}`.

The token table listed names that are not variables at all — `{title}`, `{new_price}`, `{threshold}`, `{timestamp}` — and section 2 named `{{url}}`, which does not exist; it is `{{product_url}}`.

It also documented an **HTTP method selector that does not exist**. v2’s sender is POST-only, as `000_v1_compat.ts` notes when explaining that v1’s `webhook_method` has no equivalent.

Replaced with the twelve variables the engine actually resolves, and the real default payload including the fields added in #92 (stock transition, target price, reason) — with a note that an unresolved currency is `null`, not a guessed `USD`.

## `user/README.md` — the new feature was undocumented

No mention of tracking one product at several stores, shipped in beta.6 and beta.8. Adds linking and separating, the two dashboard views, why a store in an unconvertible currency is excluded rather than compared raw, and that alerts belong to the product. Says plainly that pasting a URL straight onto an existing product **is not supported yet**, rather than leaving someone to hunt for it.

Also records where to find the running version and what differing numbers mean.

## Checked and found clean

No doc still names the pre-#93 notification types (`stock_alert`, `system_alert`, "Tracking Issue"). None describes the Perth-hardcoded log timestamps fixed in #146. `AGENTS.md` is a symlink to `CLAUDE.md`, updated alongside the work.

Docs only — no code change.