### PR TITLE
feat(notifications): say which store an alert is about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alerts say which store they are about, when a product is tracked at more than
+  one (#143). "Price dropped from CHF 299.00 to CHF 249.50 at Digitec" tells you
+  where to go; without it a drop across four stores is not actionable. A
+  `{{store}}` variable is available for custom templates.
+- Products tracked at a single store are unaffected: their alerts read exactly
+  as they did before, because naming the only possible store adds nothing.
+
 ## [2.1.0-beta.8] - 2026-09-05
 
 ### Added

--- a/backend/src/services/domain/product/notifications/alerts.ts
+++ b/backend/src/services/domain/product/notifications/alerts.ts
@@ -2,6 +2,20 @@ import { Product } from '../../../../models';
 import { ScrapedProductWithVoting } from '../../../../types/scraper';
 import { productNotificationOrchestrator } from './orchestrator';
 import { describeUnavailableReason, type UnavailableReason } from '../../../../types/availability';
+import { getStoreContext, hostOf } from '../repositories/store-context';
+
+/**
+ * The store to name in an alert, or undefined when naming it would be noise.
+ *
+ * Only when the product is tracked at more than one shop. With a single store
+ * the alert can only be about that one, so "at Digitec" adds nothing and makes
+ * every existing user's notifications longer for no reason (issue #143).
+ */
+async function storeToName(product: Product): Promise<string | undefined> {
+  const { storeName, storeCount } = await getStoreContext(product.id);
+  if (storeCount < 2) return undefined;
+  return storeName || hostOf(product.url) || undefined;
+}
 
 export class ProductAlertService {
   /**
@@ -105,7 +119,8 @@ export class ProductAlertService {
         currency: scrapedData.price?.currency || undefined,
         oldStockStatus: previousStatus || product.stock_status || undefined,
         newStockStatus: scrapedData.stockStatus,
-        productId: product.id
+        productId: product.id,
+        storeName: await storeToName(product)
       },
       {
         type: 'back_in_stock',
@@ -145,7 +160,8 @@ export class ProductAlertService {
         newPrice: newPriceObj.price,
         currency: newPriceObj.currency,
         threshold: product.price_drop_threshold!,
-        productId: product.id
+        productId: product.id,
+        storeName: await storeToName(product)
       },
       {
         type: 'price_drop',
@@ -178,7 +194,8 @@ export class ProductAlertService {
         newPrice: newPriceObj.price,
         currency: newPriceObj.currency,
         targetPrice: targetPrice,
-        productId: product.id
+        productId: product.id,
+        storeName: await storeToName(product)
       },
       {
         type: 'target_price',
@@ -207,7 +224,8 @@ export class ProductAlertService {
         type: 'price_announced',
         newPrice: newPriceObj.price,
         currency: newPriceObj.currency,
-        productId: product.id
+        productId: product.id,
+        storeName: await storeToName(product)
       },
       {
         type: 'price_announced',

--- a/backend/src/services/domain/product/repositories/store-context.ts
+++ b/backend/src/services/domain/product/repositories/store-context.ts
@@ -1,0 +1,65 @@
+import pool from '../../../../config/database';
+
+/**
+ * Which store a listing belongs to, and whether naming it is worth doing
+ * (issue #143 phase 4).
+ *
+ * "Price dropped at Digitec" is useful when a product is tracked at four
+ * shops and the user has to know which one to open. It is noise when there is
+ * only one shop, where the alert can only possibly be about that one -- so the
+ * store count is resolved alongside the name and the wording adapts.
+ *
+ * Resolved at notification time rather than carried on the product, because a
+ * retailer's display name lives in `retailer_configs` and changes when an
+ * admin renames it.
+ */
+export interface StoreContext {
+  /** Display name for the retailer: its configured name, else its domain. */
+  storeName: string | null;
+  /** How many stores the item has, including this one. */
+  storeCount: number;
+}
+
+export async function getStoreContext(productId: number): Promise<StoreContext> {
+  try {
+    const result = await pool.query(
+      `SELECT
+         COALESCE(rc.name, rc.domain) AS store_name,
+         (SELECT count(*)::int FROM products sib WHERE sib.item_id = p.item_id) AS store_count
+       FROM products p
+       LEFT JOIN LATERAL (
+         SELECT name, domain FROM retailer_configs
+         WHERE p.url LIKE '%' || domain || '%' AND active = true
+         ORDER BY length(domain) DESC
+         LIMIT 1
+       ) rc ON true
+       WHERE p.id = $1`,
+      [productId]
+    );
+
+    const row = result.rows[0];
+    if (!row) return { storeName: null, storeCount: 1 };
+
+    return {
+      // Fall back to the URL's host, so a retailer with no config yet still
+      // reads as a place rather than as nothing.
+      storeName: row.store_name || null,
+      // A product with no item should not make the alert claim there are zero
+      // stores; it is at least the one being alerted about.
+      storeCount: Math.max(1, row.store_count ?? 1),
+    };
+  } catch {
+    // A notification is not worth failing over a decoration. Without a store
+    // name the message reads exactly as it did before this feature.
+    return { storeName: null, storeCount: 1 };
+  }
+}
+
+/** The host of a URL, for a retailer that has no configured name. */
+export function hostOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/services/notifications/events.ts
+++ b/backend/src/services/notifications/events.ts
@@ -82,9 +82,20 @@ export interface EventPresentation {
   fields: EventField[];
 }
 
+/**
+ * " at Digitec", or nothing.
+ *
+ * Only populated when the product is tracked at more than one store, so a
+ * single-store alert reads exactly as it did before this existed.
+ */
+function atStore(payload: NotificationPayload): string {
+  return payload.storeName ? ` at ${payload.storeName}` : '';
+}
+
 export function describeEvent(payload: NotificationPayload): EventPresentation {
   const price = formatMoney(payload.newPrice, payload.currency);
   const previous = humaniseStockStatus(payload.oldStockStatus);
+  const store = atStore(payload);
 
   switch (payload.type) {
     case 'price_drop': {
@@ -97,8 +108,8 @@ export function describeEvent(payload: NotificationPayload): EventPresentation {
         title: 'Price Drop Alert!',
         emoji: '🔔',
         headline: oldPrice && price
-          ? `Price dropped from ${oldPrice} to ${price}${drop ? ` (-${drop})` : ''}`
-          : 'The price has dropped',
+          ? `Price dropped from ${oldPrice} to ${price}${drop ? ` (-${drop})` : ''}${store}`
+          : `The price has dropped${store}`,
         tags: ['moneybag', 'chart_with_downwards_trend'],
         color: 0x10b981,
         fields: [
@@ -114,8 +125,8 @@ export function describeEvent(payload: NotificationPayload): EventPresentation {
         title: 'Target Price Reached!',
         emoji: '🎯',
         headline: price && target
-          ? `Price is now ${price}, at or below your target of ${target}`
-          : 'The price reached your target',
+          ? `Price is now ${price}${store}, at or below your target of ${target}`
+          : `The price reached your target${store}`,
         tags: ['dart', 'white_check_mark'],
         color: 0xf59e0b,
         fields: [
@@ -131,7 +142,10 @@ export function describeEvent(payload: NotificationPayload): EventPresentation {
         emoji: '🎉',
         // A product can come back in stock before a price is extracted. Saying
         // "available at N/A" is worse than not mentioning price.
-        headline: price ? `This item is now available at ${price}` : 'This item is now available',
+        // "available at Digitec for CHF 49.90" rather than two "at"s.
+        headline: price
+          ? `This item is now available${store ? `${store} for ${price}` : ` at ${price}`}`
+          : `This item is now available${store}`,
         detail: previous ? `Previously ${previous}.` : undefined,
         tags: ['package', 'tada'],
         color: 0x6366f1,
@@ -146,8 +160,8 @@ export function describeEvent(payload: NotificationPayload): EventPresentation {
         title: 'Price Announced',
         emoji: '🏷️',
         headline: price
-          ? `A price has been announced: ${price}`
-          : 'A price has been announced',
+          ? `A price has been announced${store}: ${price}`
+          : `A price has been announced${store}`,
         tags: ['label'],
         color: 0x3b82f6,
         fields: [{ name: 'Price', value: price ?? 'unknown', inline: true }],

--- a/backend/src/services/notifications/types.ts
+++ b/backend/src/services/notifications/types.ts
@@ -22,6 +22,14 @@ export interface NotificationPayload {
    * redirect and a soft 404 were all reported as a dead page -- while the
    * in-app history, which does receive the reason, said something different.
    */
+  /**
+   * Which store the alert is about, when naming it helps.
+   *
+   * Set only where a product is tracked at more than one shop: with a single
+   * store the alert can only be about that one, and saying so is clutter. See
+   * repositories/store-context.ts (issue #143).
+   */
+  storeName?: string;
   reason?: string;
   /**
    * Whether monitoring actually stopped. Defaults to true when absent, matching

--- a/backend/src/services/notifications/utils.ts
+++ b/backend/src/services/notifications/utils.ts
@@ -62,6 +62,9 @@ export function interpolateTemplate(template: string, payload: NotificationPaylo
     // assemble one and get the unknown-currency case wrong.
     'price': formatMoney(payload.newPrice, payload.currency) ?? 'unavailable',
     'reason': payload.reason || '',
+    // Empty for a single-store product, so a template using it reads naturally
+    // either way rather than rendering a stray label.
+    'store': payload.storeName || '',
   };
 
   let result = template;

--- a/backend/tests/unit/notification-store-naming.test.ts
+++ b/backend/tests/unit/notification-store-naming.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { describeEvent } from '../../src/services/notifications/events';
+import { interpolateTemplate } from '../../src/services/notifications/utils';
+import type { NotificationPayload } from '../../src/services/notifications/types';
+
+/**
+ * When a product is tracked at several shops, an alert has to say which one --
+ * "the price dropped" is not actionable if you do not know where to go
+ * (issue #143 phase 4, asked for directly on the issue).
+ *
+ * The other half matters just as much: with a single store the alert can only
+ * be about that one, so naming it is clutter, and every existing user's
+ * notifications must read exactly as they did before.
+ */
+
+const base: NotificationPayload = {
+  productName: 'Sony WH-1000XM5',
+  productUrl: 'https://digitec.ch/p/1',
+  type: 'price_drop',
+  oldPrice: 299,
+  newPrice: 249.5,
+  currency: 'CHF',
+};
+
+describe('naming the store when there are several', () => {
+  it('says which shop the price dropped at', () => {
+    expect(describeEvent({ ...base, storeName: 'Digitec' }).headline)
+      .toBe('Price dropped from CHF 299.00 to CHF 249.50 (-CHF 49.50) at Digitec');
+  });
+
+  it('says which shop hit the target', () => {
+    const event = describeEvent({ ...base, type: 'target_price', targetPrice: 250, storeName: 'Amazon' });
+    expect(event.headline).toContain('at Amazon');
+    expect(event.headline).toContain('at or below your target');
+  });
+
+  it('says which shop has it back in stock, without two "at"s', () => {
+    const event = describeEvent({ ...base, type: 'back_in_stock', storeName: 'Galaxus' });
+    expect(event.headline).toBe('This item is now available at Galaxus for CHF 249.50');
+    expect(event.headline).not.toMatch(/at .* at /);
+  });
+
+  it('says which shop announced a price', () => {
+    expect(describeEvent({ ...base, type: 'price_announced', storeName: 'Digitec' }).headline)
+      .toBe('A price has been announced at Digitec: CHF 249.50');
+  });
+
+  it('still names the shop when the price itself is missing', () => {
+    const event = describeEvent({ ...base, type: 'back_in_stock', newPrice: undefined, storeName: 'Digitec' });
+    expect(event.headline).toBe('This item is now available at Digitec');
+  });
+});
+
+describe('a single-store product reads exactly as before', () => {
+  // Every existing user has single-store products. Their notifications must
+  // not grow a clause because a feature they do not use now exists.
+  it.each(['price_drop', 'target_price', 'back_in_stock', 'price_announced'] as const)(
+    '%s says nothing about a store',
+    (type) => {
+      const event = describeEvent({ ...base, type, targetPrice: 250 });
+      expect(event.headline).not.toContain(' at Digitec');
+      expect(event.headline).not.toMatch(/\bat undefined\b/);
+      expect(event.headline).not.toMatch(/\bat null\b/);
+      expect(event.headline).not.toMatch(/\s{2,}/);
+    }
+  );
+
+  it('produces the same price-drop wording it always did', () => {
+    expect(describeEvent(base).headline)
+      .toBe('Price dropped from CHF 299.00 to CHF 249.50 (-CHF 49.50)');
+  });
+
+  it('produces the same back-in-stock wording it always did', () => {
+    expect(describeEvent({ ...base, type: 'back_in_stock' }).headline)
+      .toBe('This item is now available at CHF 249.50');
+  });
+});
+
+describe('the {{store}} template variable', () => {
+  it('resolves to the store name', () => {
+    expect(interpolateTemplate('{{product_name}} @ {{store}}', { ...base, storeName: 'Digitec' }))
+      .toBe('Sony WH-1000XM5 @ Digitec');
+  });
+
+  it('is empty rather than "undefined" for a single-store product', () => {
+    // A template using it must read naturally either way rather than rendering
+    // a stray label.
+    expect(interpolateTemplate('[{{store}}]', base)).toBe('[]');
+  });
+});


### PR DESCRIPTION
Phase 4 of #143, and the half @GeilerGelber asked for directly:

> I would like to be notified when the product reaches a certain price in **any** of the stores… so I am notified that the product hit that price in **Store B**.

The first half already worked — alert settings live on the item, so any store hitting the target fires it. What was missing is the message saying *which* one, and without that a drop across four stores is not actionable.

```
Price dropped from CHF 299.00 to CHF 249.50 (-CHF 49.50) at Digitec
```

## Only when there is more than one store

With a single store the alert can only be about that one, so naming it adds nothing and would make **every existing user’s** notifications longer for a feature they are not using.

That is the case worth protecting, so the tests assert the old wording *verbatim* rather than merely asserting no store appears:

```
Price dropped from CHF 299.00 to CHF 249.50 (-CHF 49.50)
This item is now available at CHF 249.50
```

## Details worth knowing

- **Resolved at notification time**, not carried on the product — a retailer’s display name lives in `retailer_configs` and changes when an admin renames it.
- Falls back to the **URL host** for a retailer with no config, and to **no name at all** if the lookup fails. A notification is not worth failing over a decoration, and without a name the message reads exactly as before.
- Back in stock reads *"available at Digitec **for** CHF 249.50"*, not *"available at Digitec **at** CHF 249.50"*. A test asserts there are not two "at"s — the kind of thing that reads fine in code and badly on a phone.
- `{{store}}` is available to custom templates, **empty** for a single-store product so a template using it reads naturally either way.

## Verification

Against a restore of the production database:

```
single-store product p1 (UltraGear 45GX950A-B)
  {"storeName":"Digitec","storeCount":1}  -> names nothing
same product, second listing attached
  {"storeName":"Digitec","storeCount":2}  -> names "Digitec"
product id that does not exist
  {"storeName":null,"storeCount":1}       -> safe default, no throw
```

546 tests, up from 533. Both builds, Playwright, emoji lint, `git diff --check`.

Refs #143