### PR TITLE
fix(items): compare stores on the default currency, and handle ties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The By product view compares stores again when your currency is set to
+  Automatic, which is the default every account starts on (#160). Prices are
+  compared in the currency the stores share, so two shops both selling in AUD
+  are compared in AUD. Previously every store was reported as impossible to
+  compare, so the feature did nothing on a fresh install.
+- Stores that tie for the lowest price are all marked as best, instead of one
+  being picked arbitrarily (#161). When every store is at the same price the
+  card says so rather than claiming one is cheapest.
+
 ### Added
 
 - Alerts say which store they are about, when a product is tracked at more than

--- a/backend/src/models/types/item-view.ts
+++ b/backend/src/models/types/item-view.ts
@@ -24,9 +24,27 @@ export interface ItemWithListings extends Item {
    * 49.99 CHF and declaring a winner is worse than declining to.
    */
   best_price: number | null;
-  /** Which listing supplies `best_price`, so the UI can name the store. */
-  best_price_listing_id: number | null;
-  /** The currency `best_price` is expressed in: the user's preferred one. */
+  /**
+   * Every listing at the best price — plural because ties are common (issue
+   * #161). Two shops at $379 are both the cheapest, and crowning whichever
+   * happened to sort first tells the user something untrue.
+   */
+  best_price_listing_ids: number[];
+
+  /**
+   * True when every comparable store is at the same price. The UI says so
+   * rather than claiming a winner: "best of 3" is misleading when all three
+   * are identical.
+   */
+  all_tied: boolean;
+  /**
+   * The currency `best_price` is expressed in.
+   *
+   * The user's preferred currency when they have one. When they do not -- the
+   * "Automatic" default, `users.currency IS NULL` -- it is the currency the
+   * stores themselves share, so a comparison still happens rather than
+   * everything being excluded (issue #160).
+   */
   best_price_currency: string | null;
 
   /**

--- a/backend/src/services/domain/product/utils/group-into-items.ts
+++ b/backend/src/services/domain/product/utils/group-into-items.ts
@@ -8,18 +8,30 @@ import { ItemWithListings, ProductWithSparkline } from '../../../../models/types
  * surest way to guarantee that is for both to come from one place -- it also
  * avoids a second copy of the exchange rate triangulation.
  *
- * ## What "best price" means, and what it refuses to mean
+ * ## Which price is compared, and in what currency
  *
- * Only listings whose price could be expressed in the user's own currency are
- * compared. `converted_price` is that figure: equal to the price when the
- * currencies already match, the converted amount when a rate resolved, and null
- * when no rate could be found.
+ * When the user has a preferred currency, `converted_price` is the figure to
+ * compare: the price when the currencies already match, the converted amount
+ * when a rate resolved, and null when no rate could be found.
  *
- * A listing with a price but no usable rate is therefore excluded rather than
- * compared raw. Ranking 49.99 EUR against 49.99 CHF and declaring a winner is
- * worse than declining to -- the user acts on that number. `excluded_count`
- * exists so the UI can say "cheapest of 2 of your 4 stores" instead of
- * "cheapest", which would be a claim we cannot support.
+ * When they do not -- `users.currency IS NULL`, which is the "Automatic"
+ * default every new account starts on -- `converted_price` is null for *every*
+ * listing, because the SQL compares against a null currency and the rate join
+ * never fires. The first version of this treated that as "nothing is
+ * comparable" and told a new user with two shops in one currency that neither
+ * could be compared (issue #160).
+ *
+ * So with no preferred currency the stores' own shared currency is used
+ * instead. Two AUD shops compare in AUD, which is what the user means by
+ * "Automatic". Listings in a different currency are still excluded, because
+ * without a rate there is genuinely nothing to compare them with.
+ *
+ * ## What "best price" refuses to mean
+ *
+ * A listing that cannot be expressed in the comparison currency is excluded
+ * rather than compared raw. Ranking 49.99 EUR against 49.99 CHF and declaring
+ * a winner is worse than declining to -- the user acts on that number.
+ * `excluded_count` exists so the UI can say "cheapest of 2 of your 4 stores".
  */
 export function groupIntoItems(
   products: ProductWithSparkline[],
@@ -40,28 +52,34 @@ export function groupIntoItems(
   const items: ItemWithListings[] = [];
 
   for (const [itemId, listings] of byItem) {
-    const comparable = listings.filter(l => isComparable(l));
-    const prices = comparable.map(l => Number(l.converted_price));
+    // The primary listing supplies anything the item itself is missing, which
+    // is how a freshly migrated item that never had its own name displays
+    // sensibly.
+    const primary = listings.find(l => (l as any).is_primary) ?? listings[0];
+
+    const currency = comparisonCurrency(listings, primary, preferredCurrency);
+    const priceOf = (l: ProductWithSparkline) => comparablePrice(l, preferredCurrency, currency);
+
+    const comparable = listings.filter(l => priceOf(l) !== null);
+    const prices = comparable.map(l => priceOf(l) as number);
 
     const best = prices.length > 0 ? Math.min(...prices) : null;
     const worst = prices.length > 0 ? Math.max(...prices) : null;
-    const bestListing = best === null
-      ? null
-      : comparable.find(l => Number(l.converted_price) === best) ?? null;
+
+    // Every listing at the best price, not just the first one found. Two shops
+    // at the same price are both the cheapest (issue #161).
+    const bestIds = best === null ? [] : comparable.filter(l => priceOf(l) === best).map(l => l.id);
+
+    const spread = prices.length >= 2 && worst !== null && best !== null ? round2(worst - best) : null;
 
     // Ordered cheapest first, then the ones that could not be compared. The
     // store a user acts on is the cheapest one, so it goes at the top; the rest
     // still appear, because a listing left out of the comparison is not a
     // listing the user has stopped tracking.
     const ordered = [
-      ...comparable.slice().sort((a, b) => Number(a.converted_price) - Number(b.converted_price)),
-      ...listings.filter(l => !isComparable(l)),
+      ...comparable.slice().sort((a, b) => (priceOf(a) as number) - (priceOf(b) as number)),
+      ...listings.filter(l => priceOf(l) === null),
     ];
-
-    // The primary listing supplies anything the item itself is missing, which
-    // is how a freshly migrated item that never had its own name displays
-    // sensibly.
-    const primary = listings.find(l => (l as any).is_primary) ?? listings[0];
 
     items.push({
       id: itemId,
@@ -79,16 +97,16 @@ export function groupIntoItems(
       store_count: listings.length,
 
       best_price: best,
-      best_price_listing_id: bestListing?.id ?? null,
+      best_price_listing_ids: bestIds,
       // Null rather than a guessed code when nothing was comparable, so the UI
       // never renders an amount beside a currency we did not actually use.
-      best_price_currency: best === null ? null : (preferredCurrency ?? null),
+      best_price_currency: best === null ? null : currency,
 
-      // A spread needs two points. One store is not a comparison.
-      price_spread: prices.length >= 2 && worst !== null && best !== null
-        ? round2(worst - best)
-        : null,
+      // Every comparable store at the same price. Saying "best of 3" then would
+      // claim a difference that does not exist.
+      all_tied: comparable.length > 1 && spread === 0,
 
+      price_spread: spread,
       comparable_count: comparable.length,
       excluded_count: listings.length - comparable.length,
 
@@ -100,15 +118,47 @@ export function groupIntoItems(
 }
 
 /**
- * Whether a listing can take part in a price comparison.
+ * The currency prices are compared in for one item.
  *
- * `converted_price` is null when the scrape found no price, or when the price
- * is in a currency no exchange rate could resolve. Both mean the same thing
- * here: there is no figure we can honestly rank.
+ * The user's preference wins when they have one. Otherwise the stores decide:
+ * the primary listing's currency, falling back to whichever the listings
+ * actually use. Picking the primary's keeps the comparison stable as prices
+ * move, rather than letting the cheapest store redefine the currency.
  */
-function isComparable(listing: ProductWithSparkline): boolean {
-  const value = listing.converted_price;
-  return value !== null && value !== undefined && Number.isFinite(Number(value));
+function comparisonCurrency(
+  listings: ProductWithSparkline[],
+  primary: ProductWithSparkline,
+  preferredCurrency: string | null | undefined
+): string | null {
+  if (preferredCurrency) return preferredCurrency;
+  return primary.currency || listings.find(l => l.currency)?.currency || null;
+}
+
+/**
+ * The figure this listing contributes to the comparison, or null if it cannot
+ * take part.
+ *
+ * Null means the same thing in both branches: there is no number here we can
+ * honestly rank against the others.
+ */
+function comparablePrice(
+  listing: ProductWithSparkline,
+  preferredCurrency: string | null | undefined,
+  currency: string | null
+): number | null {
+  if (preferredCurrency) {
+    return finiteOrNull(listing.converted_price);
+  }
+  // No preference: only listings already in the comparison currency, since
+  // without a target currency there is no rate to convert with.
+  if (!currency || listing.currency !== currency) return null;
+  return finiteOrNull(listing.current_price);
+}
+
+function finiteOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
 }
 
 /** Currency arithmetic, kept to two places so a spread reads as money. */

--- a/backend/tests/unit/group-into-items.test.ts
+++ b/backend/tests/unit/group-into-items.test.ts
@@ -76,7 +76,7 @@ describe('best price', () => {
       listing({ id: 3, is_primary: false, converted_price: 310 }),
     ], 'CHF');
     expect(items[0].best_price).toBe(249.5);
-    expect(items[0].best_price_listing_id).toBe(2);
+    expect(items[0].best_price_listing_ids).toEqual([2]);
     expect(items[0].best_price_currency).toBe('CHF');
   });
 
@@ -108,7 +108,7 @@ describe('best price', () => {
       listing({ id: 2, is_primary: false, converted_price: null }),
     ], 'CHF');
     expect(items[0].best_price).toBeNull();
-    expect(items[0].best_price_listing_id).toBeNull();
+    expect(items[0].best_price_listing_ids).toEqual([]);
     expect(items[0].best_price_currency).toBeNull();
     expect(items[0].excluded_count).toBe(2);
   });
@@ -134,7 +134,7 @@ describe('best price', () => {
       listing({ id: 2, is_primary: false, converted_price: '249.50' }),
     ], 'CHF');
     expect(items[0].best_price).toBe(249.5);
-    expect(items[0].best_price_listing_id).toBe(2);
+    expect(items[0].best_price_listing_ids).toEqual([2]);
   });
 });
 
@@ -220,9 +220,105 @@ describe('edge cases', () => {
     expect(groupIntoItems([], 'CHF')).toEqual([]);
   });
 
-  it('does not crash when the user has no preferred currency', () => {
-    const items = groupIntoItems([listing()], null);
+  it('compares in the store\'s own currency when the user has no preference', () => {
+    // This previously asserted best_price_currency was null, which encoded the
+    // bug in #160: "Automatic" meant nothing could be compared at all. The
+    // store's own currency is the right answer.
+    const items = groupIntoItems([listing({ converted_price: null })], null);
     expect(items[0].best_price).toBe(299);
-    expect(items[0].best_price_currency).toBeNull();
+    expect(items[0].best_price_currency).toBe('CHF');
+  });
+});
+
+
+describe('a user on the default "Automatic" currency (issue #160)', () => {
+  // users.currency IS NULL is what every new account starts on. The SQL
+  // compares each price against a null currency and the rate join never fires,
+  // so converted_price is null for every listing. Treating that as "nothing is
+  // comparable" told a new user with two shops in one currency that neither
+  // could be compared -- the feature failing on first use.
+  const noConversion = (over: Record<string, any> = {}) =>
+    listing({ converted_price: null, ...over });
+
+  it('compares stores that share a currency, using their own prices', () => {
+    const items = groupIntoItems([
+      noConversion({ id: 1, currency: 'AUD', current_price: 379 }),
+      noConversion({ id: 2, is_primary: false, currency: 'AUD', current_price: 349 }),
+    ], null);
+    expect(items[0].comparable_count).toBe(2);
+    expect(items[0].excluded_count).toBe(0);
+    expect(items[0].best_price).toBe(349);
+    expect(items[0].best_price_currency).toBe('AUD');
+    expect(items[0].price_spread).toBe(30);
+  });
+
+  it('reports the stores own currency, not a guessed one', () => {
+    const items = groupIntoItems([noConversion({ currency: 'AUD', current_price: 379 })], null);
+    expect(items[0].best_price_currency).toBe('AUD');
+  });
+
+  it('still excludes a store in a different currency, since there is no rate', () => {
+    const items = groupIntoItems([
+      noConversion({ id: 1, currency: 'AUD', current_price: 379 }),
+      noConversion({ id: 2, is_primary: false, currency: 'EUR', current_price: 200 }),
+    ], null);
+    expect(items[0].comparable_count).toBe(1);
+    expect(items[0].excluded_count).toBe(1);
+    expect(items[0].best_price).toBe(379);
+  });
+
+  it('takes the comparison currency from the primary listing, so it does not move with prices', () => {
+    const items = groupIntoItems([
+      noConversion({ id: 1, is_primary: true, currency: 'AUD', current_price: 379 }),
+      noConversion({ id: 2, is_primary: false, currency: 'EUR', current_price: 1 }),
+    ], null);
+    expect(items[0].best_price_currency).toBe('AUD');
+    expect(items[0].best_price).toBe(379);
+  });
+
+  it('does not fall back to raw prices when the user HAS a preferred currency', () => {
+    // With a preference, an unconvertible listing must stay excluded rather
+    // than sneaking in at its raw number.
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 300 }),
+      listing({ id: 2, is_primary: false, converted_price: null, currency: 'XYZ', current_price: 5 }),
+    ], 'CHF');
+    expect(items[0].comparable_count).toBe(1);
+    expect(items[0].best_price).toBe(300);
+  });
+});
+
+describe('tied prices (issue #161)', () => {
+  it('marks every store at the best price, not just the first', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 379 }),
+      listing({ id: 2, is_primary: false, converted_price: 379 }),
+      listing({ id: 3, is_primary: false, converted_price: 400 }),
+    ], 'AUD');
+    expect(items[0].best_price_listing_ids.sort()).toEqual([1, 2]);
+  });
+
+  it('flags an all-tied item, so the card does not claim a difference', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 379 }),
+      listing({ id: 2, is_primary: false, converted_price: 379 }),
+    ], 'AUD');
+    expect(items[0].all_tied).toBe(true);
+    expect(items[0].price_spread).toBe(0);
+  });
+
+  it('is not all-tied when one store is cheaper', () => {
+    const items = groupIntoItems([
+      listing({ id: 1, converted_price: 379 }),
+      listing({ id: 2, is_primary: false, converted_price: 349 }),
+    ], 'AUD');
+    expect(items[0].all_tied).toBe(false);
+    expect(items[0].best_price_listing_ids).toEqual([2]);
+  });
+
+  it('is not all-tied with a single store, where there is nothing to tie with', () => {
+    const items = groupIntoItems([listing({ converted_price: 379 })], 'AUD');
+    expect(items[0].all_tied).toBe(false);
+    expect(items[0].best_price_listing_ids).toEqual([1]);
   });
 });

--- a/frontend/src/features/products/components/ItemCard/ItemCard.tsx
+++ b/frontend/src/features/products/components/ItemCard/ItemCard.tsx
@@ -47,12 +47,15 @@ const ItemCard: React.FC<ItemCardProps> = ({ item, userLocale }) => {
                 {formatPrice(item.best_price, item.best_price_currency, userLocale)}
               </div>
               {/*
-                Only claim "best" when there was actually a choice. With one
-                comparable store it is just the price.
+                Only claim "best" when there was actually a choice, and only
+                when there is a difference. With every store at the same price,
+                "best of 3" asserts a gap that does not exist (issue #161).
               */}
               {item.comparable_count > 1 && (
                 <div className="item-card-price-label">
-                  best of {item.comparable_count}
+                  {item.all_tied
+                    ? `same at all ${item.comparable_count}`
+                    : `best of ${item.comparable_count}`}
                 </div>
               )}
             </>
@@ -88,7 +91,12 @@ const ItemCard: React.FC<ItemCardProps> = ({ item, userLocale }) => {
             key={listing.id}
             to="/products/$productId"
             params={{ productId: String(listing.id) }}
-            className={`item-listing ${listing.id === item.best_price_listing_id ? 'is-best' : ''}`}
+            /*
+              Every listing at the best price is marked, not just whichever
+              sorted first -- and none is when they are all tied, since
+              highlighting all of them says nothing.
+            */
+            className={`item-listing ${!item.all_tied && item.best_price_listing_ids.includes(listing.id) ? 'is-best' : ''}`}
           >
             <span className="item-listing-store">
               {listing.retailer_name || hostOf(listing.url)}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -400,7 +400,10 @@ export interface ItemWithListings {
   listings: Product[];
   store_count: number;
   best_price: number | null;
-  best_price_listing_id: number | null;
+  /** Every listing at the best price — plural, because ties are common. */
+  best_price_listing_ids: number[];
+  /** True when every comparable store is at the same price. */
+  all_tied: boolean;
   best_price_currency: string | null;
   price_spread: number | null;
   comparable_count: number;


### PR DESCRIPTION
Two regressions in the grouped view, both reported by @stevene1919 against `2.1.0-beta.8`, and both mine.

## #160 — the view compared nothing on a fresh install

`users.currency IS NULL` is what **every new account starts on** — the "Automatic" regional default. The dashboard query computes `converted_price` by comparing each listing's currency against the user's, and joining exchange rates on the two differing. With a null user currency **both comparisons are null**, the rate join never fires, and `converted_price` is null for every row. `isComparable` then excluded every listing.

Measured against a restore of production with currency set back to Automatic:

```
BEFORE   listings with a usable price:  0 of 22   -> every card said "could not be compared"
AFTER    listings compared:            22 of 22
         items with nothing comparable: 0 of 21
```

It was not a degraded comparison. It was none at all, for anyone who had not changed the default.

**Fix:** with no preferred currency, compare in the currency the stores share — two AUD shops compare in AUD, which is what "Automatic" means. A listing in a *different* currency is still excluded, because without a target currency there is genuinely no rate to convert with. The comparison currency comes from the **primary** listing rather than the cheapest, so it does not move as prices do.

## #161 — tied prices crowned one store arbitrarily

`best_price_listing_id` took the first match, so two shops at 379 produced one green highlight and a `best of 2` badge asserting a difference that does not exist.

Now `best_price_listing_ids` (plural) plus an `all_tied` flag:

```
both stores at CHF 379:  all_tied=true  spread=0
best listing ids: [51, 1]        <- both, not one
card reads: "same at all 2"      <- instead of "best of 2"
```

Every store at the best price is marked; when they are **all** tied none is, since highlighting all of them says nothing.

## One test was asserting the bug

`best_price_currency` was expected to be `null` when the user had no preference. That encoded #160 rather than describing intent — it now asserts the store's own currency, with a comment saying why.

555 tests, up from 546. Both builds, Playwright 13/13, emoji lint, `git diff --check`.

Closes #160
Closes #161
