### PR TITLE
fix(security): scrub proxy credentials out of the extraction trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A proxy configured with a username and password no longer has them recorded
+  in the extraction trace (#165). The trace is returned in the admin retailer
+  test response, so the credentials left the server in an HTTP response body.
+  Logging was never affected -- it scrubs credentials already -- but the trace
+  does not go through the logger.
+
+### Fixed
+
 - The By product view compares stores again when your currency is set to
   Automatic, which is the default every account starts on (#160). Prices are
   compared in the currency the stores share, so two shops both selling in AUD

--- a/backend/src/services/scraper/acquisition/standard.ts
+++ b/backend/src/services/scraper/acquisition/standard.ts
@@ -10,6 +10,7 @@ import {
 } from '../transport';
 import { RetailerConfig } from '../../../models';
 import { withRetry } from '../../../utils/system/retry';
+import { scrubUrlCredentials } from '../../../utils/system/logging/scrubber';
 
 export interface StandardAcquisitionOptions {
   url: string;
@@ -31,7 +32,20 @@ export async function acquireStandardHtml(options: StandardAcquisitionOptions): 
   const httpsAgent = currentProxy ? new HttpsProxyAgent(currentProxy) : undefined;
   
   if (currentProxy) {
-    extractionSteps.push(`Request | Proxy | Using: ${currentProxy}`);
+    // Scrubbed at the source, not left to the logger (issue #165).
+    //
+    // The logger does scrub `details`, so the console and system_logs were
+    // safe. extractionSteps is not only logged: it is attached to the scrape
+    // result and returned as `trace` in the admin retailer-test response
+    // (routes/admin/retailers.ts), which never passes through the logger at
+    // all. A proxy configured as http://user:pass@host therefore left its
+    // password in an HTTP response body.
+    //
+    // Fixing it here rather than at each consumer means every present and
+    // future path is covered by construction: the secret never enters the
+    // array. CLAUDE.md's rule is not to write credentials in the first place,
+    // and the scrubber is a backstop rather than a licence.
+    extractionSteps.push(`Request | Proxy | Using: ${scrubUrlCredentials(currentProxy)}`);
   }
   extractionSteps.push(`Request | HTTP | UA: ${headers['User-Agent'] ? 'Yes' : 'No'} | Proxy: ${currentProxy ? 'Yes' : 'No'}`);
 

--- a/backend/tests/unit/proxy-credential-leak.test.ts
+++ b/backend/tests/unit/proxy-credential-leak.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { scrubUrlCredentials, scrubSensitiveData } from '../../src/utils/system/logging/scrubber';
+
+/**
+ * A configured proxy can carry credentials -- http://user:pass@host:8080 --
+ * and the acquisition layer records which proxy it used in `extractionSteps`
+ * (issue #165).
+ *
+ * The logger scrubs its `details`, so the console and system_logs were never
+ * the problem. `extractionSteps` is not only logged: it is attached to the
+ * scrape result and returned as `trace` in the admin retailer-test response,
+ * which never passes through the logger at all. The password left the process
+ * in an HTTP response body.
+ *
+ * Scrubbed at the source now, so every present and future consumer is covered
+ * by construction rather than each having to remember.
+ */
+
+const WITH_CREDS = 'http://scraperuser:hunter2@proxy.example.com:8080';
+
+describe('a proxy URL recorded in the extraction trace', () => {
+  it('keeps the host, so the trace still says which proxy was used', () => {
+    const scrubbed = scrubUrlCredentials(WITH_CREDS);
+    expect(scrubbed).toContain('proxy.example.com:8080');
+  });
+
+  it('does not carry the password', () => {
+    const scrubbed = scrubUrlCredentials(WITH_CREDS);
+    expect(scrubbed).not.toContain('hunter2');
+    expect(scrubbed).toBe('http://[REDACTED]:[REDACTED]@proxy.example.com:8080');
+  });
+
+  it('does not carry the username either', () => {
+    // The username is half a credential and identifies the account.
+    expect(scrubUrlCredentials(WITH_CREDS)).not.toContain('scraperuser');
+  });
+
+  it('leaves a proxy without credentials readable', () => {
+    // Scrubbing must not damage the common case.
+    const plain = 'http://proxy.example.com:8080';
+    expect(scrubUrlCredentials(plain)).toBe(plain);
+  });
+
+  it('handles https the same way', () => {
+    expect(scrubUrlCredentials('https://u:p@secure-proxy.example.com'))
+      .toBe('https://[REDACTED]:[REDACTED]@secure-proxy.example.com');
+  });
+});
+
+describe('the trace as it actually travels', () => {
+  it('is safe in the log path, which was never the leak', () => {
+    // printer.ts scrubs `details` before both the console and saveToDb.
+    const details = { trace: [`Request | Proxy | Using: ${WITH_CREDS}`] };
+    expect(JSON.stringify(scrubSensitiveData(details))).not.toContain('hunter2');
+  });
+
+  it('is safe in the HTTP path, which was', () => {
+    // routes/admin/retailers.ts returns `trace: extractionSteps` as JSON with
+    // no logger involved, so the entry has to be clean before it is stored.
+    const step = `Request | Proxy | Using: ${scrubUrlCredentials(WITH_CREDS)}`;
+    expect(JSON.stringify({ success: true, trace: [step] })).not.toContain('hunter2');
+  });
+});


### PR DESCRIPTION
Part 1 of @stevene1919's audit in #165. Confirmed, with one correction to the diagnosis and one path the issue did not name.

## The logging path was already safe

The issue says the credentials leak because `extractionSteps` "is persisted into database history". I checked before changing anything: `printer.ts:79` scrubs `details` — which is exactly where the trace goes — **before** both the console and `saveToDb`. Verified directly:

```
input     Request | Proxy | Using: http://user:hunter2@proxy.example.com:8080
scrubbed  Request | Proxy | Using: http://[REDACTED]:[REDACTED]@proxy.example.com:8080
```

So `system_logs` and the console were never exposed.

## The real path is one the issue did not mention

`extractionSteps` is not only logged. It is attached to the scrape result and returned as `trace` in the **admin retailer-test response** — `routes/admin/retailers.ts`, three call sites, including:

```js
res.json({ success: true, retailer: config, trace: extractionSteps });
```

That never passes through the logger at all. A proxy password therefore left the server **in an HTTP response body**, where it would sit in browser devtools, any intermediate proxy log, or a saved HAR capture.

So the conclusion stands and the fix is warranted — just for a different reason than stated, which seemed worth writing down rather than quietly patching.

## Fixed at the source

The secret never enters the array, so every present and future reader is covered by construction — including the next route that decides to surface a trace. CLAUDE.md's rule is not to write credentials in the first place; the scrubber is a backstop, not a licence to rely on one.

The host and port survive, so the trace still says *which* proxy was used, which is the reason that line exists.

## Tests

562, up from 555 — covering the username as well as the password (half a credential, and it identifies the account), a credential-free proxy that must stay readable, https, and **both** travel paths: the logged one that was already safe and the HTTP one that was not.

Refs #165 — parts 2 and 3 answered separately on the issue.
