### PR TITLE
fix(scraper): four of the five pipeline audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AI auto-mapping can no longer make extraction worse (#166). When it generated
+  a retailer configuration it re-ran extraction and discarded everything the
+  first pass had found, so if the generated selectors matched less, the price
+  was decided from a smaller pool than before the AI was consulted. The two
+  passes are now combined.
+- Structured product data is read once rather than twice. Cleaning the page
+  duplicated every JSON-LD block instead of only restoring ones it had removed.
+- A page with an unusually deep JSON-LD graph no longer loses its stock
+  information entirely. The reader hit an internal limit and gave up silently;
+  it now stops descending at a depth no real product page reaches and keeps
+  what it found above.
+- Retailer selectors using CSS attribute operators such as `[lang|="en"]` work.
+  They were being corrupted into invalid CSS and quietly matched nothing.
+
+### Fixed
+
 - A proxy configured with a username and password no longer has them recorded
   in the extraction trace (#165). The trace is returned in the admin retailer
   test response, so the credentials left the server in an HTTP response body.

--- a/backend/src/services/scraper/core/selectors.ts
+++ b/backend/src/services/scraper/core/selectors.ts
@@ -10,13 +10,38 @@ export function normalizeSelector(selector: string): string {
   if (trimmed.startsWith('~') && trimmed.endsWith('~')) return trimmed; // regex
   if (trimmed.startsWith('!')) return trimmed; // html
 
-  if (trimmed.includes('|')) {
-    const parts = trimmed.split('|');
-    const attr = parts.pop();
-    const base = parts.join('|');
+  // Split only on a `|` outside square brackets (issue #166).
+  //
+  // CSS has its own `|` operators inside attribute selectors -- the dashmatch
+  // `[lang|="en"]`, and namespaces like `[svg|href]`. Splitting on those turned
+  // `span[lang|="en"]` into `span[lang::attr(="en"])`, which is not valid CSS
+  // and matches nothing, so the selector silently found no elements.
+  const pipe = lastPipeOutsideBrackets(trimmed);
+  if (pipe !== -1) {
+    const base = trimmed.slice(0, pipe);
+    const attr = trimmed.slice(pipe + 1);
     return `${base}::attr(${attr})`;
   }
   return trimmed;
+}
+
+/**
+ * Index of the last `|` that is not inside `[...]`, or -1.
+ *
+ * Scanning rather than a regex because the legacy form allows a `|` in the
+ * base -- `a|b|attr` means base `a|b` -- so the *last* separator is the one
+ * that matters, and only when it sits outside an attribute selector.
+ */
+function lastPipeOutsideBrackets(selector: string): number {
+  let depth = 0;
+  let found = -1;
+  for (let i = 0; i < selector.length; i++) {
+    const c = selector[i];
+    if (c === '[') depth++;
+    else if (c === ']') depth = Math.max(0, depth - 1);
+    else if (c === '|' && depth === 0) found = i;
+  }
+  return found;
 }
 
 export interface ParsedSelector {

--- a/backend/src/services/scraper/extractors/dom-denoiser.ts
+++ b/backend/src/services/scraper/extractors/dom-denoiser.ts
@@ -132,10 +132,16 @@ export function denoiseDomForExtraction(
   // 1. Compile the set of elements to preserve
   const preservedElements = getPreservedElements($, domainConfig, globalSelectors);
 
-  // 2. Clone and extract JSON-LD script blocks
-  const jsonLdBlocks: any[] = [];
+  // 2. Keep a copy of every JSON-LD block, to restore any that step 4 removes.
+  //
+  // Only their contents are needed. Step 5 used to re-append all of these
+  // unconditionally, but step 3 never removes JSON-LD -- it excludes that type
+  // explicitly -- so the originals were still in the document and every block
+  // ended up present twice (issue #166). Downstream extractors querying
+  // script[type="application/ld+json"] then read each block twice.
+  const jsonLdBefore: string[] = [];
   $('script[type="application/ld+json"]').each((_, el) => {
-    jsonLdBlocks.push($(el).clone());
+    jsonLdBefore.push($(el).html() || '');
   });
 
   // 3. Remove non-JSON-LD scripts, styles, and noscript blocks.
@@ -160,11 +166,30 @@ export function denoiseDomForExtraction(
     }
   });
 
-  // 5. Re-inject preserved JSON-LD blocks at the bottom of <body>
+  // 5. Restore only the JSON-LD blocks that step 4 actually removed.
+  //
+  // A block nested inside a noise container -- a footer, an aside -- goes with
+  // it, and that data is worth rescuing. One that is still in the document does
+  // not need re-adding, and adding it anyway is what caused the duplication.
+  //
+  // Matched on content and counted rather than de-duplicated by identity, so a
+  // page that genuinely ships the same block twice keeps both, and cheerio node
+  // identity does not have to survive removal.
   const body = $('body');
-  if (body.length > 0) {
-    for (const block of jsonLdBlocks) {
-      body.append(block);
+  if (body.length > 0 && jsonLdBefore.length > 0) {
+    const remaining = new Map<string, number>();
+    $('script[type="application/ld+json"]').each((_, el) => {
+      const key = $(el).html() || '';
+      remaining.set(key, (remaining.get(key) ?? 0) + 1);
+    });
+
+    for (const content of jsonLdBefore) {
+      const stillPresent = remaining.get(content) ?? 0;
+      if (stillPresent > 0) {
+        remaining.set(content, stillPresent - 1);
+        continue;
+      }
+      body.append(`<script type="application/ld+json">${content}</script>`);
     }
   }
 }

--- a/backend/src/services/scraper/extractors/stock/schema.ts
+++ b/backend/src/services/scraper/extractors/stock/schema.ts
@@ -72,8 +72,19 @@ export function checkSchemaStock($: CheerioAPI): StockCandidate[] {
       if (!content) return;
       const data = JSON.parse(content);
       
-      const walk = (obj: any) => {
-        if (!obj) return;
+      /**
+       * Depth-limited so a deeply nested graph loses only what is below the
+       * limit, rather than everything (issue #166).
+       *
+       * The recursion had no bound. At around 5,000 levels it threw a
+       * RangeError, which the empty catch below swallowed -- so a page with a
+       * pathological JSON-LD graph reported no stock information at all, with
+       * no error and no log line. Stopping at a depth no real product graph
+       * reaches keeps whatever was found above it.
+       */
+      const MAX_DEPTH = 64;
+      const walk = (obj: any, depth = 0) => {
+        if (!obj || depth > MAX_DEPTH) return;
         
         if (obj['@type'] === 'Offer' && obj.availability) {
           extractFromJsonLdAvailability(obj.availability, 'json-ld.availability');
@@ -89,12 +100,12 @@ export function checkSchemaStock($: CheerioAPI): StockCandidate[] {
         }
 
         if (obj['@graph']) {
-          if (Array.isArray(obj['@graph'])) obj['@graph'].forEach(walk);
-          else walk(obj['@graph']);
+          if (Array.isArray(obj['@graph'])) obj['@graph'].forEach((n: any) => walk(n, depth + 1));
+          else walk(obj['@graph'], depth + 1);
         } else if (Array.isArray(obj)) {
-          obj.forEach(walk);
+          obj.forEach((n: any) => walk(n, depth + 1));
         } else if (typeof obj === 'object') {
-          Object.values(obj).forEach(walk);
+          Object.values(obj).forEach((n: any) => walk(n, depth + 1));
         }
       };
       walk(data);

--- a/backend/src/services/scraper/orchestration/extraction.ts
+++ b/backend/src/services/scraper/orchestration/extraction.ts
@@ -1,6 +1,6 @@
 import { type CheerioAPI } from 'cheerio';
 import { RetailerConfig } from '../../../models';
-import { ScrapedProductWithVoting } from '../../../types/scraper';
+import { ScrapedProductWithVoting, PriceCandidate } from '../../../types/scraper';
 import { resolveScrapeContext } from '../context';
 import { extractAllPriceCandidates } from '../prices';
 import { extractMetadata } from '../metadata';
@@ -68,7 +68,39 @@ export async function runExtractionPhase(
     localeHint, 
     extractionSteps
   );
-  result.priceCandidates = allCandidates;
+  // Merged, not replaced (issue #166).
+  //
+  // Phase 4 runs this a second time after AI auto-mapping generates a retailer
+  // config. A plain assignment threw away everything the first pass had found
+  // -- JSON-LD, generic selectors -- so if the generated config matched fewer
+  // elements, or none, consensus then ran on a smaller pool than before the AI
+  // was consulted. Auto-mapping could make extraction worse.
+  //
+  // Deduplicated on what makes a candidate distinct rather than on identity:
+  // the same figure found twice by the same selector and method is one piece of
+  // evidence, and counting it twice would skew the consensus weighting.
+  result.priceCandidates = mergeCandidates(result.priceCandidates, allCandidates);
 
   return { currencyHint, localeHint };
+}
+
+
+/**
+ * Combines two extraction passes, keeping the earlier candidates.
+ *
+ * Order matters for readability of the trace rather than for correctness --
+ * consensus weighs candidates, it does not take the first.
+ */
+function mergeCandidates(existing: PriceCandidate[] | undefined, found: PriceCandidate[]): PriceCandidate[] {
+  if (!existing || existing.length === 0) return found;
+
+  const seen = new Set<string>();
+  const merged: PriceCandidate[] = [];
+  for (const c of [...existing, ...found]) {
+    const key = `${c.price}|${c.currency}|${c.method}|${c.selector ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(c);
+  }
+  return merged;
 }

--- a/backend/tests/unit/scraper-pipeline-audit.test.ts
+++ b/backend/tests/unit/scraper-pipeline-audit.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { load } from 'cheerio';
+import { normalizeSelector } from '../../src/services/scraper/core/selectors';
+import { denoiseDomForExtraction } from '../../src/services/scraper/extractors/dom-denoiser';
+import { checkSchemaStock } from '../../src/services/scraper/extractors/stock/schema';
+
+/**
+ * Findings from the scraper pipeline audit in #166, each verified against the
+ * code before being fixed. Two of the five reported did not hold; see the issue
+ * for the measurements. These cover the four that did.
+ */
+
+describe('normalizeSelector keeps CSS attribute operators intact', () => {
+  it('does not split a dashmatch selector', () => {
+    // `span[lang|="en"]` became `span[lang::attr(="en"])` -- not valid CSS, so
+    // it matched nothing and the rule silently found no elements.
+    expect(normalizeSelector('span[lang|="en"]')).toBe('span[lang|="en"]');
+  });
+
+  it('does not split a namespaced attribute selector', () => {
+    expect(normalizeSelector('[svg|href]')).toBe('[svg|href]');
+  });
+
+  it('still converts the legacy selector|attribute form', () => {
+    expect(normalizeSelector('.price|content')).toBe('.price::attr(content)');
+  });
+
+  it('splits on the last pipe outside brackets, so both forms can coexist', () => {
+    expect(normalizeSelector('.a[x|="1"]|content')).toBe('.a[x|="1"]::attr(content)');
+  });
+
+  it('keeps a pipe in the base, which the legacy form allows', () => {
+    expect(normalizeSelector('a|b|attr')).toBe('a|b::attr(attr)');
+  });
+
+  it('leaves regex and html markers alone', () => {
+    expect(normalizeSelector('~price: ([\\d.]+)~')).toBe('~price: ([\\d.]+)~');
+    expect(normalizeSelector('!.raw')).toBe('!.raw');
+  });
+});
+
+describe('the denoiser does not duplicate JSON-LD', () => {
+  const ld = (body: string) => load(`<html><head></head><body>${body}<p>content</p></body></html>`);
+
+  it('leaves a block that was never removed exactly once', () => {
+    // Step 3 excludes JSON-LD from script removal, so the original survived and
+    // step 5 appended a clone on top of it -- every extractor read it twice.
+    const $ = load('<html><head><script type="application/ld+json">{"a":1}</script></head><body><p>x</p></body></html>');
+    denoiseDomForExtraction($);
+    expect($('script[type="application/ld+json"]')).toHaveLength(1);
+  });
+
+  it('rescues a block that noise removal took with it', () => {
+    // This is what step 5 exists for: a footer goes, and its JSON-LD with it.
+    const $ = ld('<footer><script type="application/ld+json">{"b":2}</script></footer>');
+    denoiseDomForExtraction($);
+    expect($('script[type="application/ld+json"]')).toHaveLength(1);
+    expect($('script[type="application/ld+json"]').html()).toContain('"b":2');
+  });
+
+  it('keeps both when a page genuinely ships the same block twice', () => {
+    // Matched by content and counted, so multiplicity survives rather than
+    // being collapsed by a Set.
+    const $ = load('<html><head><script type="application/ld+json">{"c":3}</script><script type="application/ld+json">{"c":3}</script></head><body><p>x</p></body></html>');
+    denoiseDomForExtraction($);
+    expect($('script[type="application/ld+json"]')).toHaveLength(2);
+  });
+});
+
+describe('JSON-LD stock walking is depth-bounded', () => {
+  const withGraph = (obj: unknown) =>
+    load(`<script type="application/ld+json">${JSON.stringify(obj)}</script>`);
+
+  const nest = (depth: number, leaf: unknown) => {
+    let o: unknown = leaf;
+    for (let i = 0; i < depth; i++) o = { nested: o };
+    return o;
+  };
+
+  it('reads an ordinary product graph', () => {
+    const $ = withGraph({ '@type': 'Product', offers: { '@type': 'Offer', availability: 'https://schema.org/InStock' } });
+    expect(checkSchemaStock($)[0]?.value).toBe('in_stock');
+  });
+
+  it('keeps a reachable offer despite a pathological branch elsewhere', () => {
+    // The case that mattered. Unbounded recursion threw a RangeError, which the
+    // empty catch swallowed, so the page reported no stock at all -- silently.
+    const $ = withGraph({
+      '@type': 'Product',
+      offers: { '@type': 'Offer', availability: 'https://schema.org/InStock' },
+      unrelated: nest(20000, { junk: true }),
+    });
+    expect(checkSchemaStock($)[0]?.value).toBe('in_stock');
+  });
+
+  it('does not throw on a graph nested past any real depth', () => {
+    const $ = withGraph(nest(50000, { '@type': 'Offer', availability: 'https://schema.org/InStock' }));
+    expect(() => checkSchemaStock($)).not.toThrow();
+  });
+
+  it('still reaches an offer nested deeper than a real page but within the bound', () => {
+    const $ = withGraph(nest(30, { '@type': 'Offer', availability: 'https://schema.org/OutOfStock' }));
+    expect(checkSchemaStock($)[0]?.value).toBe('out_of_stock');
+  });
+});

--- a/backend/tests/unit/scraper-pipeline-audit.test.ts
+++ b/backend/tests/unit/scraper-pipeline-audit.test.ts
@@ -82,20 +82,32 @@ describe('JSON-LD stock walking is depth-bounded', () => {
     expect(checkSchemaStock($)[0]?.value).toBe('in_stock');
   });
 
-  it('keeps a reachable offer despite a pathological branch elsewhere', () => {
+  it('keeps a reachable offer despite a deeply nested branch elsewhere', () => {
     // The case that mattered. Unbounded recursion threw a RangeError, which the
     // empty catch swallowed, so the page reported no stock at all -- silently.
+    //
+    // 1,000 rather than the 20,000 this was first written with: the bound is
+    // 64, so 1,000 exercises it fifteen times over, while 20,000 made
+    // JSON.stringify overflow the stack on CI's smaller one -- the fixture
+    // failing, not the code.
     const $ = withGraph({
       '@type': 'Product',
       offers: { '@type': 'Offer', availability: 'https://schema.org/InStock' },
-      unrelated: nest(20000, { junk: true }),
+      unrelated: nest(1000, { junk: true }),
     });
     expect(checkSchemaStock($)[0]?.value).toBe('in_stock');
   });
 
   it('does not throw on a graph nested past any real depth', () => {
-    const $ = withGraph(nest(50000, { '@type': 'Offer', availability: 'https://schema.org/InStock' }));
+    const $ = withGraph(nest(1000, { '@type': 'Offer', availability: 'https://schema.org/InStock' }));
     expect(() => checkSchemaStock($)).not.toThrow();
+  });
+
+  it('stops descending past the bound rather than walking forever', () => {
+    // An offer buried below the limit is not found. That is the trade: a bound
+    // deep enough for any real graph, in exchange for never running away.
+    const $ = withGraph(nest(1000, { '@type': 'Offer', availability: 'https://schema.org/InStock' }));
+    expect(checkSchemaStock($)).toHaveLength(0);
   });
 
   it('still reaches an offer nested deeper than a real page but within the bound', () => {


### PR DESCRIPTION
@stevene1919's audit in #166 listed five findings. Each was checked against the code before anything changed. **Four held and are fixed here; two did not, and are answered below rather than implemented** — acting on them would have meant changing correct code.

## Fixed

**2 — AI auto-mapping could make extraction worse.** Phase 4 re-runs extraction after generating a retailer config, and `extraction.ts` assigned `result.priceCandidates` outright. Everything the first pass found — JSON-LD, generic selectors — was discarded, so a generated config matching *fewer* elements left consensus with a smaller pool than it had **before the AI was consulted**. Now merged, deduplicated on price + currency + method + selector, because the same figure found twice by the same route is one piece of evidence.

**4 — the denoiser duplicated every JSON-LD block.** It cloned them upfront and re-appended at the end, but the removal step excludes JSON-LD explicitly, so originals were still present. Measured **1 block in, 2 out** — every extractor read each block twice. Now restores only what noise removal actually took, matched on content and counted so a page shipping the same block twice keeps both.

**3 (first half) — a deep JSON-LD graph lost all stock information.** The walk was unbounded and threw `RangeError` around 5,000 levels, which the empty `catch (e) {}` swallowed: no stock, no error, no log line. Bounded at 64 now. The case that matters:

```
reachable offer + 20k-deep sibling branch
  before:  RangeError -> 0 candidates, silently
  after:   in_stock, 17 ms
```

**5 — `normalizeSelector` corrupted CSS attribute operators.**

```
span[lang|="en"]     ->  span[lang::attr(="en"])     invalid CSS, matched nothing
```

Now splits on the last `|` **outside** brackets, so the legacy form still works and `.a[x|="1"]|content` resolves correctly.

## Not changed, and why

**1 — the acquisition fallback flag does not affect behaviour.** `usedRemoteFallback` is read in exactly one place and returned to no consumer. At that one place the condition is:

```js
if (challengeReason && !usedRemoteFallback && !domainConfig)
```

`use_browser_scraper` only comes *from* a domain config, so whenever the flag is set early, `domainConfig` exists and `!domainConfig` already excludes the branch. The flag is dead logic, not a bug. Rewriting the acquisition sequence to tidy it would risk the pipeline for no behavioural gain — worth doing as deliberate cleanup, not as a fix.

**3 (second half) — duplicate offer traversal has no observable effect.** The offers array *is* walked twice. But the resolution step collapses all JSON-LD candidates into one representative using `.some()` presence checks, not counts:

```js
const hasInStock = jsonLdCandidates.some(c => c.value === 'in_stock');
...
candidates.push(representative);
```

Duplicates cannot reach the output or skew it. Confirmed empirically — a product with one offer returns exactly one candidate. Redundant work, not a defect.

## Verification

575 tests, up from 562 — the dashmatch and namespaced selectors, both denoiser paths plus the genuine-duplicate case, and the deep-graph cases including the one where a reachable offer survives a pathological branch.

Refs #166
