### PR TITLE
docs: record which audit findings are resolved in this repo

### DIFF
--- a/docs/SCRAPER_AUDIT.md
+++ b/docs/SCRAPER_AUDIT.md
@@ -5,7 +5,11 @@
 > codebase at the time of writing** — NOT necessarily this repo. We transplanted
 > at one point in his history, so a fix marked completed here may or may not be
 > present in our code. **Before acting on any issue, verify it against our actual
-> source.** Issue IDs (S-1, P-2, C-3, V-1, X-2, …) are referenced from
+> source.** Rows reading **FIXED HERE**, **PART FIXED HERE**, **Not a bug here**
+> or **Not reproducible here** were checked against *this* repo in September 2026
+> and carry the PR that resolved them — those are ours, not upstream's. Three
+> findings did not survive that check; the reasoning is on the linked issues
+> rather than deleted, so nobody re-derives it. Issue IDs (S-1, P-2, C-3, V-1, X-2, …) are referenced from
 > docs/SCRAPER_LIFECYCLE.md. Infrastructure specifics removed.
 
 
@@ -2121,7 +2125,7 @@ Frankfurter does not return the base currency's self-rate. `getRate('AUD', 'AUD'
 
 | ID | Severity | Layer | Area | Description | Status |
 |----|----------|-------|------|-------------|--------|
-| O-1 | **Critical** | Orchestration | `extraction.ts` | `priceCandidates` overwritten on auto-map re-extract — first-pass candidates permanently lost | Pending |
+| O-1 | **Critical** | Orchestration | `extraction.ts` | `priceCandidates` overwritten on auto-map re-extract — first-pass candidates permanently lost | FIXED HERE #172 — passes merged and deduplicated |
 | O-2 | **High** | Orchestration | `consensus.ts` | `isCorroborated` null-guard inverted — uncorroborated sources bypass OOS guardrail | Completed |
 | O-3 | **High** | Orchestration | `consensus.ts` | OOS drift only checks downward spikes — upward spikes (e.g. $200→$2000) pass unchallenged | Completed |
 | O-4 | **High** | Orchestration | `maintenance.ts` | `configCache.invalidate()` with no domain key — nukes entire cache, thundering herd | Pending |
@@ -2135,10 +2139,10 @@ Frankfurter does not return the base currency's self-rate. `getRate('AUD', 'AUD'
 | O-12 | **Low** | Orchestration | `arbitration.ts` | Local `ReviewReason` type missing `'price_drift'` — diverges from canonical type | Completed |
 | O-13 | **Low** | Orchestration | `init.ts` | `globalAiSettings` typed as `any` — loses TypeScript safety | Completed |
 | A-1 | **Critical** | Transport | `transport/remote.ts` | Off-by-one retry loop — max retries sentinel is dead code; attempts miscounted | Pending |
-| A-2 | **High** | Acquisition | `acquisition/index.ts` | `usedRemoteFallback` set before success — blocks Attempt 3 on remote failure | Pending |
-| A-3 | **High** | Acquisition | `acquisition/index.ts` | Challenged remote HTML blocks fallback via flag — no recovery path | Pending |
-| A-4 | **High** | Acquisition | `acquisition/index.ts` | Fallback result never checked for challenge — challenged HTML sent to extraction pipeline | Pending |
-| A-5 | **High** | Acquisition | `standard.ts` | Proxy credentials (`user:password@host`) logged in plaintext to `extractionSteps` DB column | Pending |
+| A-2 | **High** | Acquisition | `acquisition/index.ts` | `usedRemoteFallback` set before success — blocks Attempt 3 on remote failure | Not a bug here (#166) — `!domainConfig` already gates Attempt 3 |
+| A-3 | **High** | Acquisition | `acquisition/index.ts` | Challenged remote HTML blocks fallback via flag — no recovery path | Not a bug here (#166) — same gate as A-2 |
+| A-4 | **High** | Acquisition | `acquisition/index.ts` | Fallback result never checked for challenge — challenged HTML sent to extraction pipeline | Open — the challenge re-check on fallback output is still worth adding |
+| A-5 | **High** | Acquisition | `standard.ts` | Proxy credentials (`user:password@host`) logged in plaintext to `extractionSteps` DB column | FIXED HERE #171 — scrubbed at source; leak was the HTTP `trace`, not logs |
 | A-6 | **High** | Transport | `headers.ts` | Hardcoded Chrome 121 UA + `Sec-Ch-Ua` — stale (Jan 2024), immediately fingerprintable | Pending |
 | A-7 | **High** | Transport | `transport/remote.ts` | Axios 1.x uses `CanceledError` not `AbortError` — abort safety net broken | Pending |
 | A-8 | **High** | Acquisition | `standard.ts` | Inconsistent retry budget — fallback retries 2×; worst-case 150s per URL | Pending |
@@ -2149,12 +2153,12 @@ Frankfurter does not return the base currency's self-rate. `getRate('AUD', 'AUD'
 | A-13 | **Medium** | Transport | `detection.ts` | Case-sensitive WAF marker detection — misses capitalization variants | Pending |
 | A-14 | **Low** | Transport | `detection.ts` | Akamai `Reference #18.` pattern too specific — misses other reference numbers | Pending |
 | A-15 | **Low** | Acquisition | `standard.ts` | `withRetry` logs under `'AI'` category for HTTP scraper calls | Pending |
-| E-1 | **High** | Extractor | `dom-denoiser.ts` | `denoiseHtmlForRegex` nested-quantifier regex — ReDoS vulnerability | Pending |
-| E-2 | **High** | Extractor | `stock/schema.ts` | `walk()` no depth guard — infinite recursion on malformed JSON-LD; `offers` visited twice | Pending |
+| E-1 | **High** | Extractor | `dom-denoiser.ts` | `denoiseHtmlForRegex` nested-quantifier regex — ReDoS vulnerability | Not reproducible here (#165) — unrolled-loop idiom is linear, 1.8ms at 420KB |
+| E-2 | **High** | Extractor | `stock/schema.ts` | `walk()` no depth guard — infinite recursion on malformed JSON-LD; `offers` visited twice | PART FIXED HERE #172 — depth bound added; duplicate `offers` walk has no observable effect |
 | E-3 | **High** | Extractor | `arbitration.ts` | AI arbitration passed `allCandidates` including member/original prices | Pending |
 | E-4 | **Medium** | Extractor | `price-extraction.ts` | `priceSpecification` double-processed — duplicate JSON-LD candidates | Pending |
-| E-5 | **Medium** | Extractor | `dom-denoiser.ts` | JSON-LD blocks duplicated in DOM after clone re-append (originals not removed first) | Pending |
-| E-6 | **Medium** | Extractor | `core/selectors.ts` | `normalizeSelector` corrupts CSS attribute selectors containing `\|` (e.g. `[lang\|="en"]`) | Pending |
+| E-5 | **Medium** | Extractor | `dom-denoiser.ts` | JSON-LD blocks duplicated in DOM after clone re-append (originals not removed first) | FIXED HERE #172 — measured 1 block in, 2 out; now restores only removed blocks |
+| E-6 | **Medium** | Extractor | `core/selectors.ts` | `normalizeSelector` corrupts CSS attribute selectors containing `\|` (e.g. `[lang\|="en"]`) | FIXED HERE #172 — splits on last `\|` outside brackets |
 | E-7 | **Medium** | Extractor | `price-utils.ts` | No max price sanity guard — barcodes/SKUs enter candidate pool as valid prices | Pending |
 | E-8 | **Medium** | Extractor | `arbitrators/consensus.ts` | Member/original price group winner is first inserted, not highest-confidence | Pending |
 | E-9 | **Medium** | Extractor | `arbitrators/consensus.ts` | `hasConsensus >= 1.0` — single json-ld source reaches consensus without corroboration | Pending |
@@ -2187,7 +2191,7 @@ Frankfurter does not return the base currency's self-rate. `getRate('AUD', 'AUD'
 | SYS-3 | **High** | System | `DatabaseHealthMonitor.ts` | `warmCache()` hardcodes `WHERE id = 1` — wrong admin on non-default installs | Pending |
 | SYS-4 | **High** | System | `SettingsListenerService.ts` | Reconnect loop flat 5s retry — hammers DB pool (360 attempts/hour during outage) | Pending |
 | SYS-5 | **High** | System | `DatabaseHealthMonitor.ts` | "Outage Resolved" email sent without prior "Outage Started" alert | Pending |
-| SYS-6 | **High** | Routes | `RetailerTestingService.ts` / `admin/debug.ts` | SSRF — unchecked URL passed to scraper / axios with no protocol or IP validation | Pending |
+| SYS-6 | **High** | Routes | `RetailerTestingService.ts` / `admin/debug.ts` | SSRF — unchecked URL passed to scraper / axios with no protocol or IP validation | Open — confirmed (#165), gated behind admin + `debug_page_enabled` |
 | SYS-7 | **High** | Routes | `products/scan.ts` / `bulk.ts` | Raw `async` handlers without `asyncHandler` — inconsistent error propagation | Pending |
 | SYS-8 | **High** | Routes | `RetailerMutationService.ts` | `deleteRetailer()` TOCTOU — non-atomic fetch-then-delete, wrong cache key invalidated | Pending |
 | SYS-9 | **Medium** | System | `DatabaseHealthMonitor.ts` | `sendAlertEmail` fire-and-forget — duplicate alert email risk | Pending |

--- a/docs/audit/refix_plan.md
+++ b/docs/audit/refix_plan.md
@@ -4,6 +4,13 @@ Because **PriceStalker** was branched from an earlier release of the upstream co
 
 This plan details all outstanding issues, references their exact file paths in the `pricestalker` source tree, and provides specific refix steps for each.
 
+> **Status lines added September 2026.** Entries carrying a **Status (this repo)**
+> line have been checked against *our* source and either fixed or deliberately
+> not. Two were not reproducible; the measurements are recorded rather than the
+> entry deleted, so the next reader does not re-derive them. Everything without a
+> status line is untouched and still worth verifying before acting on — this file
+> describes the upstream codebase, not necessarily ours.
+
 ---
 
 ## 🗺️ Master Issue Register & Refix Steps
@@ -31,11 +38,13 @@ This plan details all outstanding issues, references their exact file paths in t
 * **Refix Plan:** Run `detectBotChallenge` on the fallback HTML result and throw a `BotChallengeError` or flag it for review if it remains blocked.
 
 #### 🟢 Issue A-5: Proxy credentials logged in plaintext
+* **Status (this repo, Sept 2026):** **Resolved in #171.** Scrubbed at the source with `scrubUrlCredentials()`. The database was never the exposure — the logger scrubs `details` before `saveToDb` — it was `trace` in the admin retailer-test HTTP response, which bypasses the logger entirely.
 * **File:** [`backend/src/services/scraper/acquisition/standard.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/acquisition/standard.ts#L32)
 * **Description:** The system logs `extractionSteps.push(`Request | Proxy | Using: ${currentProxy}`)`. If the proxy URL contains authentication details (e.g. `http://user:password@host:port`), they are stored in plaintext in the database logs.
 * **Refix Plan:** Sanitize the proxy URL (strip out `user:password` credentials) before pushing it to `extractionSteps`.
 
 #### 🟢 Issue A-6: Stale hardcoded User-Agent & Client Hints
+* **Status (this repo, Sept 2026):** **Resolved in #141.** Client hints are now derived from whichever User-Agent is in play rather than hardcoded, so per-retailer overrides work and the pair cannot drift.
 * **File:** [`backend/src/services/scraper/transport/headers.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/transport/headers.ts#L20-L25)
 * **Description:** The default User-Agent and the `Sec-Ch-Ua` headers are hardcoded to Chrome 121 (from January 2024), which is stale and easily fingerprinted.
 * **Refix Plan:** Update the hardcoded defaults to a current, stable Chrome version (e.g. Chrome 133) and ensure the legacy UA and Client Hint versions match.
@@ -65,11 +74,13 @@ This plan details all outstanding issues, references their exact file paths in t
 * **Refix Plan:** Add a final fallback to container selectors like `$('article, [class*="product"], [data-product]')` before falling back to `$('body')`.
 
 #### 🟢 Issue E-1: ReDoS vulnerability in DOM denoiser regex
+* **Status (this repo, Sept 2026):** **Not reproducible (see #165).** The nested quantifier is the unrolled-loop idiom, which is linear by construction. Measured across five adversarial shapes up to 420KB: worst case 1.8ms. Not changed — rewriting the denoiser affects every scrape, and there is no defect to justify it.
 * **File:** [`backend/src/services/scraper/extractors/dom-denoiser.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/extractors/dom-denoiser.ts#L147-L153)
 * **Description:** The regular expressions used to strip script, style, and noscript blocks contain nested-star quantifiers (`[^<]*(?:(?!<\/script>)<[^<]*)*`). Malformed or unclosed script tags on large pages can cause exponential backtracking and CPU denial of service.
 * **Refix Plan:** Replace the regex patterns with non-backtracking alternatives or leverage Cheerio's native DOM removal (`$('script, style, noscript').remove()`) instead of raw regex replacement.
 
 #### 🟢 Issue E-2: Stack overflow risk in stock JSON-LD recursion
+* **Status (this repo, Sept 2026):** **Part resolved in #172.** A depth bound of 64 was added: the walk previously threw `RangeError` around 5,000 levels, which the empty `catch` swallowed, so a deep graph reported no stock at all, silently. The duplicate `offers` traversal was left alone — the resolution step collapses candidates by presence, not count, so duplicates cannot reach the output.
 * **File:** [`backend/src/services/scraper/extractors/stock/schema.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/extractors/stock/schema.ts#L75-L100)
 * **Description:** The JSON-LD parser recursively traverses object keys using a nested helper function `walk` without keeping track of nesting depth, risking a stack overflow if it encounters a circular structure.
 * **Refix Plan:** Add a maximum depth tracking counter (e.g., limit recursion to `depth > 10`) to prevent stack overflow errors.
@@ -94,6 +105,7 @@ This plan details all outstanding issues, references their exact file paths in t
 ## 3. Orchestration & Consensus Layer
 
 #### 🟢 Issue O-1: `priceCandidates` overwritten on auto-map re-extraction
+* **Status (this repo, Sept 2026):** **Resolved in #172.** The two extraction passes are merged and deduplicated on price, currency, method and selector, so auto-mapping can no longer shrink the candidate pool.
 * **File:** [`backend/src/services/scraper/orchestration/extraction.ts`](file:///home/steven/projects/pricestalker/backend/src/services/scraper/orchestration/extraction.ts#L71)
 * **Description:** When auto-mapping generates a new configuration, it re-runs the extraction phase. Doing so overwrites the first-pass `priceCandidates` array entirely, losing any candidates collected during the initial run.
 * **Refix Plan:** Merge the new candidates into the existing candidate array rather than doing a raw reassignment.


### PR DESCRIPTION
@stevene1919 pointed out on #172 that `docs/SCRAPER_AUDIT.md` and `docs/audit/` still list findings we have since fixed. He is right — and the file’s own header warns about exactly this trap: it is an imported upstream audit whose `[COMPLETED]` markers describe *upstream’s* codebase, and it asks the reader to verify before acting. Nothing recorded what we had verified.

**Ten rows** in the SCRAPER_AUDIT register and **five entries** in the refix plan now carry a status naming the PR that resolved them, worded to be unmistakably ours rather than upstream’s: `FIXED HERE`, `PART FIXED HERE`, `Not a bug here`, `Not reproducible here`.

| | |
|---|---|
| A-5 | FIXED HERE #171 — leak was the HTTP `trace`, not logs |
| O-1 | FIXED HERE #172 — passes merged and deduplicated |
| E-5 | FIXED HERE #172 — measured 1 block in, 2 out |
| E-6 | FIXED HERE #172 — splits on last `\|` outside brackets |
| E-2 | PART FIXED HERE #172 — depth bound added; duplicate `offers` walk has no observable effect |
| A-2 / A-3 | Not a bug here — `!domainConfig` already gates Attempt 3 |
| E-1 | Not reproducible here — 1.8 ms at 420 KB |
| A-4, SYS-6 | **Open**, deliberately — still worth doing |

## On the three that did not survive checking

Annotated rather than deleted, with the reasoning and measurements kept. Deleting them would invite the next reader to re-derive the same conclusions; leaving them unmarked would invite someone to "fix" working code. Either way the effort gets spent twice.

A-4 and SYS-6 are marked **open** rather than quietly folded in — the challenge re-check on fallback output is still worth adding, and the SSRF guard is confirmed, just gated behind admin plus an explicit setting.

Docs only, no code change.

Refs #165, #166