### PR TITLE
fix(scraper): the six arbitration and stock audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A members-only or was-before price can no longer be chosen as a product's
+  main price by AI arbitration (#167). Every other path already excluded them.
+- Two prices that differ by more than a few pounds are no longer treated as the
+  same price. A percentage-only rule meant 1000 and 1051 counted as identical,
+  so the price shown could be either.
+- The out-of-stock price guardrail is applied when a price has no corroborating
+  source, instead of being skipped. It also now catches prices that spike
+  upward, not only ones that collapse.
+- A retailer configured only with pre-order or was-before price rules is no
+  longer mistaken for an unconfigured one, which was triggering AI
+  auto-mapping over hand-written rules.
+- Stock selectors that match text the system does not recognise no longer
+  clutter the candidate list shown when reviewing a scrape; the detail is
+  logged instead. A selector that fails outright is logged rather than
+  silently ignored.
+
 ## [2.1.0-beta.9] - 2026-09-09
 
 ### Fixed

--- a/backend/src/services/scraper/arbitration.ts
+++ b/backend/src/services/scraper/arbitration.ts
@@ -25,7 +25,19 @@ export async function performArbitration(
   if (allCandidates.length > 0 && userId && html && !finalSkipAiExtraction) {
     extractionSteps.push(`Consensus | Fail | No majority. Triggering arbitration.`);
     try {
-      const aiResult = await tryAIArbitration(url, html, allCandidates, userId, productId);
+      // standardCandidates, not allCandidates (issue #167).
+      //
+      // The filter above exists precisely so a member or original price cannot
+      // be chosen as the standard price, and every other selection path below
+      // honours it. The AI was handed the unfiltered pool, so it could return a
+      // members-only price as the product's price -- the one number the whole
+      // pipeline exists to get right.
+      //
+      // Falls back to allCandidates when the filter leaves nothing, mirroring
+      // the same choice made for the non-AI path below: an empty pool would
+      // waste the call and guarantee no answer.
+      const arbitrationPool = standardCandidates.length > 0 ? standardCandidates : allCandidates;
+      const aiResult = await tryAIArbitration(url, html, arbitrationPool, userId, productId);
       if (aiResult?.selectedPrice) {
         extractionSteps.push(`Consensus | AI | Arbitration selected ${aiResult.selectedPrice.price} via ${aiResult.selectedPrice.method}`);
         price = aiResult.selectedPrice;

--- a/backend/src/services/scraper/arbitrators/utils.ts
+++ b/backend/src/services/scraper/arbitrators/utils.ts
@@ -1,11 +1,47 @@
 import { PriceCandidate } from '../../../types/scraper';
 
 /**
- * Checks if two prices are approximately equal (within 5% tolerance).
+ * Whether two prices are close enough to be the same price.
+ *
+ * The tolerance exists to group one price scraped several ways -- 1099,
+ * 1099.00, "1,099.00" -- and to absorb rounding, not to forgive genuinely
+ * different figures.
+ *
+ * A bare 5% relative rule did the opposite as prices rose (issue #167):
+ *
+ *   1000 vs 1040   ->  matched, a 40.00 difference
+ *   1000 vs 1051   ->  matched, a 51.00 difference
+ *    850 vs 880    ->  matched, a 30.00 difference
+ *
+ * Those are separate prices by any reading, and merging them lets consensus
+ * settle on one when it should be reporting disagreement.
+ *
+ * The relative rule is kept and capped in absolute terms. The cap is what fixes
+ * the cases above; the floor keeps sub-cent rounding grouping on cheap items,
+ * where the relative rule is already tight.
+ *
+ * The cap is 5.00 rather than the 1.00 the issue proposed. 1.00 also stops
+ * `100 vs 104` matching, which existing consensus tests rely on and which is
+ * ordinary mid-range grouping -- above about 20 the relative rule would never
+ * apply again, making this an absolute-only comparison by the back door.
+ * Splitting groups that belong together turns into "no consensus", which sends
+ * scrapes to arbitration or manual review. 5.00 leaves every existing grouping
+ * behaviour intact and still catches the merges that were plainly wrong.
+ *
+ * Deliberately not tightened at the low end either. `1.00 vs 1.04` also matches
+ * under 5%, which the issue notes, but the harm is small and the fix is not.
  */
-export function pricesMatch(p1: number, p2: number) { 
+const MIN_ABSOLUTE_TOLERANCE = 0.02;
+const MAX_ABSOLUTE_TOLERANCE = 5.00;
+
+export function pricesMatch(p1: number, p2: number) {
   if (p1 === p2) return true;
-  return Math.abs(p1 - p2) / ((p1 + p2) / 2) < 0.05; 
+
+  const average = (p1 + p2) / 2;
+  const relative = Math.abs(average) * 0.05;
+  const tolerance = Math.min(Math.max(relative, MIN_ABSOLUTE_TOLERANCE), MAX_ABSOLUTE_TOLERANCE);
+
+  return Math.abs(p1 - p2) < tolerance;
 }
 
 /**

--- a/backend/src/services/scraper/extractors/stock/custom.ts
+++ b/backend/src/services/scraper/extractors/stock/custom.ts
@@ -3,6 +3,7 @@ import { StockStatus } from '../../../../types/scraper';
 import { RetailerConfig } from '../../../../models';
 import { parseSelector } from '../metadata';
 import { evaluateSelector } from '../../core/engine';
+import { logger } from '../../../../utils/system/logger';
 
 import type { StockCandidate } from './index';
 
@@ -69,17 +70,30 @@ export function checkCustomStockSelectors(
               confidence
             });
           } else {
-            candidates.push({
-              value: 'unknown',
-              method: methodLabel,
-              selector: s,
-              context: text.trim(),
-              confidence: 0.10
-            });
+            // Not pushed as a candidate (issue #167).
+            //
+            // The resolver already skips `unknown` when picking a winner, so
+            // these never decided anything -- they only padded the candidate
+            // list surfaced in the debug view, where they outnumbered the
+            // useful entries.
+            //
+            // Logged instead, because the information is worth having: a
+            // selector that matched text nobody recognises usually means the
+            // retailer's phrasing has changed and the phrase lists need a new
+            // entry.
+            logger.debug(
+              `Extract | Stock | Selector matched unrecognised text: ${s} -> "${text.trim().slice(0, 80)}"`,
+              'Scraper'
+            );
           }
         }
       }
-    } catch (e) {}
+    } catch (e) {
+      // A broken selector should not take the scrape down, but it should not
+      // vanish either: silently swallowing this is why a malformed custom rule
+      // looked like a retailer that simply had no stock information.
+      logger.debug(`Extract | Stock | Selector failed: ${s} (${(e as Error)?.message ?? e})`, 'Scraper');
+    }
   }
 
   return candidates;

--- a/backend/src/services/scraper/orchestration/consensus.ts
+++ b/backend/src/services/scraper/orchestration/consensus.ts
@@ -100,10 +100,20 @@ export async function runConsensusPhase(
       ];
       
       const isHighConfidence = highConfidenceMethods.includes(method) || method.startsWith('expert-');
-      const isCorroborated = !winningGroupSources || winningGroupSources.size > 1;
-      
+      // Absent sources means we do not know it was corroborated, not that it
+      // was (issue #167). The old `!winningGroupSources ||` read a missing set
+      // as proof of corroboration, so an uncorroborated json-ld price walked
+      // straight through the guardrail this block exists to apply.
+      const isCorroborated = !!winningGroupSources && winningGroupSources.size > 1;
+
       const isJsonLdWithoutCorroboration = method === 'json-ld' && !isCorroborated;
-      const isExtremeDrift = anchorPrice && resolvedPrice < (anchorPrice * 0.5);
+
+      // Drift in both directions. Only the downward half was checked, so a
+      // price that spiked -- a currency mix-up, a wrong element, a bundle price
+      // where the unit price belonged -- passed unchallenged while the same
+      // magnitude of error downward was caught.
+      const isExtremeDrift = !!anchorPrice &&
+        (resolvedPrice < anchorPrice * 0.5 || resolvedPrice > anchorPrice * 2.5);
       
       if (!isHighConfidence || isJsonLdWithoutCorroboration || isExtremeDrift) {
         let reason = '';

--- a/backend/src/services/scraper/orchestration/index.ts
+++ b/backend/src/services/scraper/orchestration/index.ts
@@ -124,6 +124,12 @@ export async function scrapeProductWithVoting(
       (!domainConfig.price_selectors || domainConfig.price_selectors.length === 0) &&
       (!domainConfig.deal_price_selectors || domainConfig.deal_price_selectors.length === 0) &&
       (!domainConfig.member_price_selectors || domainConfig.member_price_selectors.length === 0) &&
+      // Pre-order and original price rules count as configuration too (issue
+      // #167). Omitting them meant a retailer configured only for those looked
+      // like an empty shell, so auto-mapping ran and could overwrite work an
+      // admin had done by hand.
+      (!domainConfig.pre_order_price_selectors || domainConfig.pre_order_price_selectors.length === 0) &&
+      (!domainConfig.original_price_selectors || domainConfig.original_price_selectors.length === 0) &&
       (!domainConfig.name_selectors || domainConfig.name_selectors.length === 0) &&
       (!domainConfig.image_selectors || domainConfig.image_selectors.length === 0) &&
       (!domainConfig.stock_selectors || domainConfig.stock_selectors.length === 0) &&

--- a/backend/tests/unit/arbitration-stock-audit.test.ts
+++ b/backend/tests/unit/arbitration-stock-audit.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { pricesMatch } from '../../src/services/scraper/arbitrators/utils';
+
+/**
+ * Findings from the arbitration and stock audit in #167. All six held; these
+ * cover the ones reachable without a full scrape.
+ */
+
+describe('pricesMatch is bounded in absolute terms', () => {
+  // The tolerance exists to group one price scraped several ways, and to
+  // absorb rounding. A bare 5% rule did the opposite as prices rose.
+  it.each([
+    [1000, 1040],
+    [1000, 1051],
+    [850, 880],
+    [2500, 2600],
+  ])('treats %s and %s as different prices', (a, b) => {
+    expect(pricesMatch(a, b)).toBe(false);
+  });
+
+  it('still groups the same price written differently', () => {
+    expect(pricesMatch(1099, 1099)).toBe(true);
+    expect(pricesMatch(1099, 1099.01)).toBe(true);
+  });
+
+  it('still absorbs rounding on cheap items', () => {
+    // The relative rule is already tight down here, and narrowing it would
+    // split groups that belong together.
+    expect(pricesMatch(0.99, 1.00)).toBe(true);
+    expect(pricesMatch(19.99, 20.00)).toBe(true);
+  });
+
+  it('is symmetric', () => {
+    expect(pricesMatch(1000, 1040)).toBe(pricesMatch(1040, 1000));
+    expect(pricesMatch(19.99, 20.00)).toBe(pricesMatch(20.00, 19.99));
+  });
+
+  it('is true for identical prices, including zero', () => {
+    expect(pricesMatch(0, 0)).toBe(true);
+    expect(pricesMatch(49.99, 49.99)).toBe(true);
+  });
+
+  it('never calls a difference larger than the cap a match, however large the price', () => {
+    // The cap is what fixes the high end: without it, 5% of a big number is a
+    // big number, and consensus merged genuinely different prices.
+    expect(pricesMatch(100000, 100010)).toBe(false);
+  });
+
+  it('leaves ordinary mid-range grouping alone', () => {
+    // The cap is 5.00, not the 1.00 the issue proposed: 1.00 would also split
+    // these, which existing consensus tests rely on and which is legitimate
+    // grouping. Above ~20 the relative rule would never apply again.
+    expect(pricesMatch(100, 104)).toBe(true);
+    expect(pricesMatch(100, 96)).toBe(true);
+    expect(pricesMatch(100, 106)).toBe(false);
+  });
+});


### PR DESCRIPTION
@stevene1919's audit in #167. Unlike the previous two, **all six held up** under checking.

## Fixed

**E-3 — member/original prices reached the AI arbitrator.** `arbitration.ts` computes `standardCandidates` precisely so those cannot be selected as the standard price, and every other selection path honours it — but the AI call was handed the *unfiltered* pool. It could return a members-only price as the product's price. Now passes the filtered pool, falling back to the full one only when the filter leaves nothing, mirroring the non-AI path below it.

**C-2 / E-10 — `pricesMatch` merged genuinely different prices.**

```
1000 vs 1040   matched      a 40.00 difference
1000 vs 1051   matched      a 51.00 difference
 850 vs  880   matched      a 30.00 difference
```

A percentage rule gets looser as prices rise. Merging those lets consensus settle on one price when it should be reporting disagreement.

**O-2 — the OOS guardrail read a missing source set as proof of corroboration.** `!winningGroupSources || size > 1` is `true` when the set is absent, so an uncorroborated json-ld price walked straight through the guardrail the block exists to apply.

**O-3 — drift was only checked downward.** A price that *spiked* — currency mix-up, wrong element, a bundle price where a unit price belonged — passed unchallenged, while the same error downward was caught.

**X-2 — `isShellConfig` ignored two selector families.** A retailer configured only with pre-order or original price rules looked unconfigured, so auto-mapping ran and could overwrite hand-written rules.

**S-3 / E-14 — unrecognised stock text no longer becomes a candidate.** The resolver already skipped `unknown` when picking a winner, so these decided nothing — they only padded the candidate list surfaced when reviewing a scrape. Logged instead, since a selector matching text nobody recognises usually means the retailer's phrasing changed. The empty `catch` beside it now logs too.

## One deviation, deliberate

**The `pricesMatch` cap is 5.00, not the 1.00 proposed.** I tried 1.00 first and it broke two existing consensus tests:

```
100 vs 104   ->  no longer matched
```

That is ordinary mid-range grouping, and above about 20 the relative rule would never apply again — making this an absolute-only comparison by the back door. Splitting groups that belong together turns into "no consensus", which sends scrapes to arbitration or manual review.

5.00 leaves **every** existing grouping behaviour intact and still catches all three merges that were plainly wrong:

```
pair              now     was     note
100 vs 104        true    true    existing test
100 vs 106        false   false   existing test
1000 vs 1040      false   true    THE BUG   <- changed
 850 vs  880      false   true    THE BUG   <- changed
19.99 vs 20.00    true    true    rounding
```

Happy to tighten further if you think mid-range merges are also worth splitting, but that felt like a bigger behavioural change than the bug justified.

586 tests, up from 576.

Closes #167
