### PR TITLE
fix(scraper): four of the five resilience audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Saving an auto-mapped retailer configuration no longer discards the cached
+  configuration for every other retailer (#169), which made the next scheduled
+  batch re-read all of them from the database at once.
+- Flagging a retailer as blocked, or restoring it, now takes effect
+  immediately instead of after the cache expires. The scraper was carrying on
+  as though a retailer it had just flagged were healthy.
+- A broad custom price selector can no longer flood the candidate pool. Custom
+  rules were unbounded while the generic ones were capped.
+- The same price appearing several times in one structured-data document is
+  counted once. Repeats read as independent sources agreeing, which is the
+  corroboration the out-of-stock safeguards depend on being real.
+
+### Fixed
+
 - A members-only or was-before price can no longer be chosen as a product's
   main price by AI arbitration (#167). Every other path already excluded them.
 - Two prices that differ by more than a few pounds are no longer treated as the

--- a/backend/src/services/scraper/extractors/custom-prices.ts
+++ b/backend/src/services/scraper/extractors/custom-prices.ts
@@ -19,7 +19,14 @@ export function extractCustomCandidates($: CheerioAPI, selectors: string[], html
     0.9, 
     currencyHint, 
     localeHint, 
-    0, 
+    // Bounded (issue #169). 0 means unlimited, so a broad custom selector --
+    // `.price` on a page that lists related items -- could put hundreds of
+    // candidates into consensus and drown the real one.
+    //
+    // 40 rather than the 20 proposed: it matches what generic extraction
+    // already uses, so this is not tighter than a bound the codebase has been
+    // running successfully, while still stopping the flood.
+    40,
     false,
     html
   );

--- a/backend/src/services/scraper/extractors/price-extraction.ts
+++ b/backend/src/services/scraper/extractors/price-extraction.ts
@@ -112,5 +112,18 @@ export function extractJsonLdCandidates(
       if (Array.isArray(data)) data.forEach(findData); else findData(data);
     } catch (e) {}
   });
-  return candidates;
+
+  // Deduplicated before returning (issue #169). A @graph that cross-references
+  // by @id, or nests priceSpecification inside offers, yields the same figure
+  // several times from one document. Consensus weighs candidates, so the same
+  // price arriving three times counts as three sources agreeing when it is one
+  // source repeated -- which is exactly the corroboration the guardrails rely
+  // on being real.
+  const seen = new Set<string>();
+  return candidates.filter(c => {
+    const key = `${c.price}|${c.currency}|${c.method}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }

--- a/backend/src/services/scraper/orchestration/maintenance.ts
+++ b/backend/src/services/scraper/orchestration/maintenance.ts
@@ -89,7 +89,11 @@ export async function handleAutoMapping(
       });
 
       const domainConfig = await retailerRepository.upsert(upsertData);
-      configCache.invalidate();
+      // Scoped to the domain that changed (issue #169). An argument-less call
+      // drops every retailer's config, so one auto-map save made the next
+      // scrape of every other domain re-read from the database -- and they all
+      // arrive together, because the scheduler batches.
+      configCache.invalidate(domain);
       extractionSteps.push(`Retailer | Auto-Map | Saved (Currency Hint: ${currencyHint})`);
       return domainConfig;
     }

--- a/backend/src/services/scraper/retailer-maintenance.ts
+++ b/backend/src/services/scraper/retailer-maintenance.ts
@@ -1,5 +1,6 @@
 import { retailerRepository, RetailerConfig } from '../../models';
 import { logger } from '../../utils/system/logger';
+import { configCache } from '../../utils/cache';
 
 /**
  * Updates a retailer's status if they are detected as blocked.
@@ -15,6 +16,11 @@ export async function flagBlockedRetailer(
       status: 'BLOCKED',
       description: `Auto-flagged: ${challenge} detected during extraction`
     });
+    // Without this the cache keeps serving status OK until its TTL expires, so
+    // the scraper carries on treating a retailer it has just flagged as blocked
+    // as healthy -- and the flag exists precisely to change what happens next
+    // (issue #169).
+    configCache.invalidate(domainConfig.domain);
     extractionSteps.push(`Retailer | Status | Updated to BLOCKED`);
   } catch (e) {
     logger.error(`Scraper | Status | Failed to update for ${domainConfig.domain}`, 'Scraper', e);
@@ -35,6 +41,7 @@ export async function restoreRetailerStatus(
         status: 'OK',
         description: `Auto-restored: Successful extraction completed`
       });
+      configCache.invalidate(domainConfig.domain);
       extractionSteps.push(`Retailer | Status | Restored to OK`);
     } catch (e) {
       logger.error(`Retailer | Status | Failed to restore for ${domainConfig.domain}`, 'Scraper', e);

--- a/backend/tests/unit/scraper-resilience-audit.test.ts
+++ b/backend/tests/unit/scraper-resilience-audit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { load } from 'cheerio';
+import { extractJsonLdCandidates } from '../../src/services/scraper/extractors/price-extraction';
+
+/**
+ * Findings from the resilience audit in #169. Four held; the fifth -- the
+ * "unreachable" sentinel in the remote retry loop -- is required by
+ * TypeScript's control-flow analysis and removing it fails the build. See the
+ * issue.
+ */
+
+const withJsonLd = (obj: unknown) =>
+  load(`<script type="application/ld+json">${JSON.stringify(obj)}</script>`);
+
+describe('JSON-LD price candidates are deduplicated', () => {
+  it('returns one candidate when a graph repeats the same price', () => {
+    // A @graph that cross-references by @id, or nests priceSpecification inside
+    // offers, yields the same figure several times from one document.
+    // Consensus weighs candidates, so repeats read as independent corroboration
+    // when they are one source counted twice.
+    const $ = withJsonLd({
+      '@graph': [
+        { '@type': 'Product', offers: { '@type': 'Offer', price: '49.99', priceCurrency: 'CHF' } },
+        { '@type': 'Product', offers: { '@type': 'Offer', price: '49.99', priceCurrency: 'CHF' } },
+      ],
+    });
+    const prices = extractJsonLdCandidates($);
+    const at4999 = prices.filter(c => Number(c.price) === 49.99);
+    expect(at4999).toHaveLength(1);
+  });
+
+  it('keeps genuinely different prices from the same document', () => {
+    // Deduplication must not collapse a real price range into one figure.
+    const $ = withJsonLd({
+      '@graph': [
+        { '@type': 'Product', offers: { '@type': 'Offer', price: '49.99', priceCurrency: 'CHF' } },
+        { '@type': 'Product', offers: { '@type': 'Offer', price: '59.99', priceCurrency: 'CHF' } },
+      ],
+    });
+    const values = extractJsonLdCandidates($).map(c => Number(c.price)).sort();
+    expect(values).toContain(49.99);
+    expect(values).toContain(59.99);
+  });
+
+  it('keeps the same figure in two currencies, which is not a duplicate', () => {
+    const $ = withJsonLd({
+      '@graph': [
+        { '@type': 'Product', offers: { '@type': 'Offer', price: '49.99', priceCurrency: 'CHF' } },
+        { '@type': 'Product', offers: { '@type': 'Offer', price: '49.99', priceCurrency: 'EUR' } },
+      ],
+    });
+    const currencies = new Set(extractJsonLdCandidates($).map(c => c.currency));
+    expect(currencies.size).toBeGreaterThan(1);
+  });
+
+  it('returns nothing for a document with no offers, without throwing', () => {
+    const $ = withJsonLd({ '@type': 'Article', headline: 'Not a product' });
+    expect(() => extractJsonLdCandidates($)).not.toThrow();
+  });
+});


### PR DESCRIPTION
@stevene1919's audit in #169. Four held; the fifth is answered with compiler output rather than implemented, and one is left for a product decision.

## Fixed

**O-4a — auto-map saves evicted the whole retailer cache.** `maintenance.ts` called `configCache.invalidate()` with no argument, while every other site in the codebase passes a domain. One retailer's config being saved made the next scrape of *every other domain* re-read from the database — and they arrive together, because the scheduler batches.

**O-4b — retailer status changes never invalidated at all.** `flagBlockedRetailer` and `restoreRetailerStatus` write status to the database and return, so the cache kept serving the old value until TTL. The scraper carried on treating a retailer it had *just flagged as blocked* as healthy — the opposite of what flagging it is for.

**P-4 — custom price selectors were unbounded.** `evaluatePriceSelectors` treats `limit: 0` as unlimited, and custom extraction passed `0` while generic passes `40`. A broad rule — `.price` on a page listing related items — could put hundreds of candidates into consensus and drown the real one.

**P-3 — JSON-LD price candidates were not deduplicated.** A `@graph` cross-referencing by `@id`, or nesting `priceSpecification` inside `offers`, yields the same figure several times from one document. Consensus *weighs* candidates, so one source repeated three times read as three sources agreeing — and that corroboration is exactly what the out-of-stock guardrails rely on being real.

```
graph repeating 49.99 three times, plus one 59.99
  before:  CHF 49.99, CHF 49.99, CHF 49.99, CHF 59.99
  after:   CHF 49.99, CHF 59.99
```

## Not changed — A-1, the retry sentinel

The audit is right that the trailing `throw` is unreachable: every path inside the loop either `continue`s or throws. But it is **not dead code to remove**. Deleting it fails the build:

```
error TS2366: Function lacks ending return statement and return type
does not include 'undefined'
```

It is the standard way to satisfy TypeScript's control-flow analysis where a loop provably always exits but the compiler cannot prove it. Restructuring the retry loop to make it reachable would be churn in a retry path for no behavioural gain.

## Left for a decision — S-2, multi-offer stock

This one is a **product question, not a defect**, so I have not guessed. Currently any offer being `InStock` resolves the whole product to in stock.

- **Optimistic (today):** a marketplace seller has it, so you *can* buy it — but a back-in-stock alert may lead to a third-party listing at a very different price from the one being tracked.
- **First-offer precedence (proposed):** matches the buybox, but a stale primary offer means a missed back-in-stock alert.

Both failure modes are real and roughly symmetric. @mikeknight85's call, since it depends on whether "in stock" here means *buyable anywhere* or *buyable from the seller whose price we track*.

## One deviation

The custom-selector bound is **40**, not the 20 proposed — matching what generic extraction already uses, so this is not tighter than a limit the codebase has been running successfully. Still stops the flood.

590 tests, up from 586.

Refs #169
