### PR TITLE
fix(scraper): prefer real image files, and explain deal-price precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A product no longer shows a broken image when a retailer's structured data
+  points at an image folder rather than an image file (#164). A candidate that
+  names a real file is now preferred; a folder or extension-less URL is used
+  only when nothing better is available.
+
+### Changed
+
+- The Extraction Rules settings page distinguishes two things that were
+  presented as one (#159): which rule is consulted (retailer, then defaults,
+  then built-ins) and which kind of price wins once several are found (a
+  deal or sale price beats a standard one, whichever rule found it). Reading
+  the first as covering both made a retailer's own standard-price rule look
+  like it was being ignored.
+- Troubleshoot Price now says when a deal or pre-order price won by rule
+  rather than by score, and what it beat.
+
+### Fixed
+
 - Saving an auto-mapped retailer configuration no longer discards the cached
   configuration for every other retailer (#169), which made the next scheduled
   batch re-read all of them from the database at once.

--- a/backend/src/services/scraper/metadata/image.ts
+++ b/backend/src/services/scraper/metadata/image.ts
@@ -252,8 +252,8 @@ export async function extractProductImage(
   // Deduplication & Priority Sorting
   if (result.imageCandidates.length > 0) {
     result.imageCandidates.sort((a, b) => {
-      const confA = (preferJsonLd && a.method === 'json-ld') ? 1.01 : a.confidence;
-      const confB = (preferJsonLd && b.method === 'json-ld') ? 1.01 : b.confidence;
+      const confA = scoreImageCandidate(a, preferJsonLd);
+      const confB = scoreImageCandidate(b, preferJsonLd);
       return confB - confA;
     });
 
@@ -291,3 +291,53 @@ export async function extractProductImage(
   }
 }
 
+
+
+/**
+ * How strongly to trust an image candidate, ahead of picking one.
+ *
+ * Method confidence alone was not enough (issue #164). Enterprise CMSs -- AEM
+ * in the reported case -- put an asset *folder* in JSON-LD:
+ *
+ *   "image": "/content/dam/.../ghdwerb-pbp2/hazel/"
+ *
+ * That resolves to a valid-looking URL and JSON-LD scores highest, so it beat
+ * an `og:image` pointing at an actual file and the product showed a broken
+ * image. The directory returns 404 with text/html.
+ *
+ * A path ending in `/`, or with no extension at all, is demoted rather than
+ * discarded. #102 deliberately kept trailing-slash URLs because some retailers
+ * serve images from dynamic endpoints with no file extension, and those are
+ * still better than nothing -- so this reorders rather than filters, and such a
+ * candidate still wins if it is the only one.
+ *
+ * Deliberately not an HTTP check. Verifying each candidate's status and
+ * content-type would be the certain answer, but it means extra requests per
+ * scrape against a retailer that is already rate-limiting us, on a path that
+ * runs for every product on every refresh.
+ */
+const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|webp|avif|gif|bmp|svg)(?:[?#]|$)/i;
+
+export function scoreImageCandidate(
+  candidate: { value?: unknown; method?: string; confidence: number },
+  preferJsonLd: boolean
+): number {
+  const base = (preferJsonLd && candidate.method === 'json-ld') ? 1.01 : candidate.confidence;
+
+  let path: string;
+  try {
+    path = new URL(String(candidate.value), 'https://example.invalid').pathname;
+  } catch {
+    return base;
+  }
+
+  // A folder, not a file. The clearest signal, and the reported case.
+  if (path.endsWith('/')) return base - 0.5;
+
+  // No extension: might be a dynamic endpoint, might be a path fragment. Worth
+  // less than a candidate that plainly names an image file, worth more than a
+  // directory.
+  if (!IMAGE_FILE_EXTENSION.test(path)) return base - 0.25;
+
+  return base;
+}

--- a/backend/src/services/scraper/orchestration/consensus.ts
+++ b/backend/src/services/scraper/orchestration/consensus.ts
@@ -35,6 +35,31 @@ export async function runConsensusPhase(
   if (hasConsensus && consensus) {
     const selectorInfo = consensus.selector ? ` (${consensus.selector})` : '';
     extractionSteps.push(`Consensus | Win | ${consensus.price} via ${consensus.method}${selectorInfo}`);
+
+    // Say when a deal or pre-order price won by rule rather than by weight
+    // (issue #159).
+    //
+    // findPriceConsensus gives those methods strict priority: one deal-price
+    // candidate beats any number of standard ones, whatever their confidence
+    // and wherever their selector came from. That is deliberate -- a deal price
+    // is what you would actually pay -- but it is invisible. A user whose
+    // retailer rule found the right standard price saw a different figure win
+    // and had nothing in the trace to explain it, which reads as the retailer
+    // rules being ignored.
+    const strictPriority = consensus.method === 'deal-price' || consensus.method === 'pre-order-price';
+    if (strictPriority) {
+      const beaten = allCandidates.filter(c =>
+        c.method !== consensus.method &&
+        c.method !== 'member-price' &&
+        c.method !== 'original-price'
+      );
+      if (beaten.length > 0) {
+        const others = [...new Set(beaten.map(c => `${c.method} ${c.price}`))].slice(0, 4).join(', ');
+        extractionSteps.push(
+          `Consensus | Priority | ${consensus.method} takes precedence over standard prices by rule, not by score. Also found: ${others}`
+        );
+      }
+    }
     result.price = { price: consensus.price, currency: consensus.currency };
     result.selectedMethod = consensus.method;
   } else {

--- a/backend/tests/unit/image-candidate-scoring.test.ts
+++ b/backend/tests/unit/image-candidate-scoring.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { scoreImageCandidate } from '../../src/services/scraper/metadata/image';
+
+/**
+ * An enterprise CMS can put an asset *folder* in JSON-LD rather than a file
+ * (issue #164). It resolves to a valid-looking URL, JSON-LD scores highest, and
+ * the product ends up showing a broken image while a perfectly good og:image
+ * sits unused.
+ *
+ * Reordering rather than filtering: #102 deliberately kept extension-less URLs
+ * because some retailers serve images from dynamic endpoints, and one of those
+ * is still better than no image at all.
+ */
+
+const jsonLd = (value: string) => ({ value, method: 'json-ld', confidence: 0.99 });
+const ogImage = (value: string) => ({ value, method: 'og:image', confidence: 0.8 });
+
+const better = (a: Parameters<typeof scoreImageCandidate>[0], b: Parameters<typeof scoreImageCandidate>[0]) =>
+  scoreImageCandidate(a, true) > scoreImageCandidate(b, true);
+
+describe('scoreImageCandidate', () => {
+  it('prefers a real image file over a JSON-LD directory path', () => {
+    // The reported case, from telstra.com.au.
+    const directory = jsonLd('https://www.telstra.com.au/content/dam/tcom/devices/ghdwerb-pbp2/hazel/');
+    const file = ogImage('https://www.telstra.com.au/content/dam/tcom/devices/front.png');
+    expect(better(file, directory)).toBe(true);
+  });
+
+  it('still prefers JSON-LD when both point at real files', () => {
+    // The demotion must not reverse the normal ordering.
+    expect(better(jsonLd('https://x.test/a.jpg'), ogImage('https://x.test/b.jpg'))).toBe(true);
+  });
+
+  it('ranks an extension-less URL between a directory and a file', () => {
+    const directory = jsonLd('https://x.test/assets/');
+    const dynamic = jsonLd('https://x.test/image/12345');
+    const file = jsonLd('https://x.test/image.png');
+    expect(scoreImageCandidate(file, true)).toBeGreaterThan(scoreImageCandidate(dynamic, true));
+    expect(scoreImageCandidate(dynamic, true)).toBeGreaterThan(scoreImageCandidate(directory, true));
+  });
+
+  it('accepts a query string after the extension', () => {
+    // CDN URLs routinely carry resize parameters.
+    const plain = jsonLd('https://x.test/p.jpg');
+    const resized = jsonLd('https://x.test/p.jpg?w=800&fm=webp');
+    expect(scoreImageCandidate(resized, true)).toBe(scoreImageCandidate(plain, true));
+  });
+
+  it.each(['jpg', 'jpeg', 'png', 'webp', 'avif', 'gif', 'svg'])('treats .%s as an image file', (ext) => {
+    const file = jsonLd(`https://x.test/p.${ext}`);
+    const directory = jsonLd('https://x.test/p/');
+    expect(scoreImageCandidate(file, true)).toBeGreaterThan(scoreImageCandidate(directory, true));
+  });
+
+  it('does not throw on a value that is not a URL', () => {
+    expect(() => scoreImageCandidate({ value: 'not a url', method: 'json-ld', confidence: 0.99 }, true)).not.toThrow();
+    expect(() => scoreImageCandidate({ value: undefined, method: 'og:image', confidence: 0.8 }, false)).not.toThrow();
+  });
+
+  it('leaves a directory candidate usable when it is the only one', () => {
+    // Demoted, not discarded: a dynamic endpoint beats no image at all.
+    expect(scoreImageCandidate(jsonLd('https://x.test/assets/'), true)).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
+++ b/frontend/src/features/admin/components/sections/GlobalSelectorsSection.tsx
@@ -126,9 +126,30 @@ export default function GlobalSelectorsSection() {
       </p>
 
       <PriorityNote
-        label="Rule priority"
+        label="Where a rule comes from"
         steps={['Retailer rules', 'These default rules', 'Built-in fallbacks']}
       />
+
+      {/*
+        Two different orderings were being read as one (issue #159). The list
+        above is about which *rule* is consulted; this is about which *kind of
+        price* wins once several have been found. A user with a retailer rule
+        for the standard price saw a deal price win anyway and reasonably
+        concluded their retailer rules were being ignored.
+      */}
+      <PriorityNote
+        label="Which price wins"
+        steps={['Deal / sale price', 'Pre-order price', 'Standard price']}
+      />
+
+      <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem', marginTop: '-0.5rem', marginBottom: '1rem', maxWidth: '70ch' }}>
+        These are separate. A deal or sale price wins over a standard price
+        whichever rule found it, because it is what you would pay today. So a
+        retailer rule that matches a sale price will override a standard price
+        found by another retailer rule. If a retailer is showing a price you do
+        not expect, check its Deal/Sale rule first, then use Troubleshoot Price
+        on the product &mdash; the trace names which rule won and why.
+      </p>
 
       <SettingsCacheNotice />
 


### PR DESCRIPTION
Two reports that turned out to share a theme: the system was right and unable to say so.

## #164 — directory paths beat real images

An enterprise CMS (AEM, in the reported Telstra case) can put an asset **folder** in JSON-LD:

```json
"image": "/content/dam/.../ghdwerb-pbp2/hazel/"
```

It resolves to a valid-looking URL, JSON-LD scores highest, so it beat an `og:image` pointing at an actual file. The folder returns 404 with `text/html` and the product showed a broken image.

Candidates naming a real image file now outrank folders and extension-less paths. **Demoted, not discarded** — #102 deliberately kept trailing-slash URLs because some retailers serve images from dynamic endpoints, and one of those beats no image at all. A directory candidate still wins when it is the only one.

Deliberately **not** the HTTP status/content-type check #102 proposed: verifying each candidate would be certain, but it means extra requests per scrape against retailers already rate-limiting us, on a path that runs for every product on every refresh. The heuristic costs nothing and covers the reported failure.

## #159 — two orderings presented as one

@Ulixes86 reported that a retailer’s own standard-price rule was being ignored: their rule found `812,32` and the product kept showing `762,50`.

**It was not being ignored.** `findPriceConsensus` gives deal prices *strict* priority — one deal-price candidate beats any number of standard ones, whatever their confidence and wherever the selector came from — and their retailer’s Deal/Sale rule matches a `product:sale_price:amount` meta tag.

That is intended. Nothing said so. The settings page listed:

> Rule priority: Retailer rules → These default rules → Built-in fallbacks

which is about which **rule** is consulted, and says nothing about which **kind of price** wins. Reading it as covering both is the obvious reading, and it is wrong.

Now shown as two separate orderings, with a note that a deal price beats a standard one whichever rule found it. And Troubleshoot Price now says so directly:

```
Consensus | Win | 762.50 via deal-price (regex ...)
Consensus | Priority | deal-price takes precedence over standard prices by rule,
                       not by score. Also found: custom-regex 812.32
```

**No behaviour change to price selection.** Whether a deal price should always beat a standard one is a product question, not a defect, and settling it from one report would be the wrong call — raised separately for @mikeknight85.

603 tests, up from 590.

Closes #164
Refs #159