### PR TITLE
fix(items,scraper): highlight every tied store, and stop storing broken images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A product no longer shows a broken image when every image a retailer offers
+  is a folder rather than a file (#164). Suspicious URLs are now checked before
+  being stored, and one that is not an image is discarded — the product shows a
+  placeholder instead of a broken picture.
+- Every store tied for the lowest price is highlighted, rather than none of
+  them (#161). The highlight means "this store has the lowest price", and when
+  stores tie they all do.
+
+### Fixed
+
 - A product no longer shows a broken image when a retailer's structured data
   points at an image folder rather than an image file (#164). A candidate that
   names a real file is now preferred; a folder or extension-less URL is used

--- a/backend/src/services/scraper/metadata/image-verify.ts
+++ b/backend/src/services/scraper/metadata/image-verify.ts
@@ -1,0 +1,80 @@
+import axios from 'axios';
+import { logger } from '../../../utils/system/logger';
+
+/**
+ * Confirms that a suspicious image URL is actually an image (issue #164).
+ *
+ * The scoring heuristic reorders candidates so a real file beats a folder, but
+ * some pages offer nothing better. On the reported Telstra product *every*
+ * candidate is a directory -- the JSON-LD entries and the og:image alike -- so
+ * reordering changes which broken URL wins, not whether one does. Measured:
+ *
+ *   .../ghdwerb-pbp2/hazel/   ->  404 text/html
+ *
+ * and the only real image files in the static HTML are pictograms and a
+ * preloader; the product image is rendered by JavaScript.
+ *
+ * So a URL we cannot rank away has to be checked. Deliberately narrow:
+ *
+ * - Only for candidates the heuristic already flagged as suspicious. A URL
+ *   naming a real image file is not verified, which is nearly all of them.
+ * - Only the finally-chosen candidate, not every candidate.
+ * - HEAD, with a short timeout.
+ *
+ * Fails open. A timeout, a refusal, a retailer that rejects HEAD -- none of
+ * those prove the URL is bad, and discarding a working image because a check
+ * could not complete would be a worse failure than the one being fixed.
+ */
+const VERIFY_TIMEOUT_MS = 6000;
+
+/**
+ * Whether a HEAD response describes an image.
+ *
+ * Separated from the request so the decision can be tested without a network
+ * or a mocked client -- the rules here are the part worth pinning down, and
+ * the request around them is three lines of axios.
+ */
+export function isImageResponse(status: number, contentType: string | undefined): boolean {
+  if (status >= 400) return false;
+
+  const type = String(contentType || '').toLowerCase();
+
+  // An empty content-type is not evidence of anything; some CDNs omit it on
+  // HEAD. Only a positively non-image type rejects.
+  if (type && !type.startsWith('image/')) return false;
+
+  return true;
+}
+
+export async function looksLikeRealImage(url: string): Promise<boolean> {
+  try {
+    const response = await axios.head(url, {
+      timeout: VERIFY_TIMEOUT_MS,
+      maxRedirects: 3,
+      validateStatus: () => true,
+    });
+
+    const accepted = isImageResponse(response.status, response.headers['content-type'] as string | undefined);
+    if (!accepted) {
+      logger.debug(`Extract | Image | Rejected ${response.status} ${response.headers['content-type']} for ${url}`, 'Scraper');
+    }
+    return accepted;
+  } catch (error) {
+    // Network failure, HEAD not allowed, TLS problem. Not proof the image is
+    // bad, so keep it.
+    logger.debug(`Extract | Image | Could not verify ${url} (${(error as Error)?.message}); keeping it`, 'Scraper');
+    return true;
+  }
+}
+
+/** Whether a candidate is worth spending a request on. */
+const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|webp|avif|gif|bmp|svg)(?:[?#]|$)/i;
+
+export function needsVerification(url: string): boolean {
+  try {
+    const path = new URL(url).pathname;
+    return path.endsWith('/') || !IMAGE_FILE_EXTENSION.test(path);
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/services/scraper/metadata/image.ts
+++ b/backend/src/services/scraper/metadata/image.ts
@@ -6,6 +6,7 @@ import { extractMetaWithCandidates, findInJsonLd, evaluateMetadataSelectors } fr
 import { parseSelector } from '../extractors/metadata';
 import { extractByRegex } from '../extractors/price-extraction';
 import { resolveImageUrl } from './image-url';
+import { looksLikeRealImage, needsVerification } from './image-verify';
 
 export interface ImageDimensions {
   width: number;
@@ -287,8 +288,53 @@ export async function extractProductImage(
   }
 
   if (!result.imageUrl) {
-    result.imageUrl = (result.imageCandidates?.[0]?.value as string) || null;
+    result.imageUrl = await pickVerifiedImage(result.imageCandidates ?? [], extractionSteps);
   }
+}
+
+/**
+ * The best candidate that is actually an image (issue #164).
+ *
+ * Ranking alone is not enough when every candidate is a folder, which is the
+ * reported Telstra case -- reordering then only changes which broken URL wins.
+ * Candidates naming a real image file are taken on trust, as almost all are;
+ * only a suspicious one costs a HEAD request, and only until one passes.
+ *
+ * Returns null rather than a URL known to 404. A product with no image shows a
+ * placeholder; a product with a broken one shows a broken image, which looks
+ * like the app is failing rather than the retailer being unhelpful.
+ */
+async function pickVerifiedImage(
+  candidates: { value?: unknown }[],
+  extractionSteps: string[]
+): Promise<string | null> {
+  // Bounded: a page offering dozens of bad candidates must not turn one scrape
+  // into dozens of requests.
+  const MAX_VERIFICATIONS = 3;
+  let verifications = 0;
+
+  for (const candidate of candidates) {
+    const url = String(candidate?.value || '').trim();
+    if (!url) continue;
+
+    if (!needsVerification(url)) return url;
+
+    if (verifications >= MAX_VERIFICATIONS) {
+      // Out of budget. Returning it unverified matches the old behaviour, which
+      // is the right side to err on: usually right, and never worse than before.
+      extractionSteps.push(`Extract | Image | Verification budget spent; using ${url} unchecked`);
+      return url;
+    }
+
+    verifications++;
+    if (await looksLikeRealImage(url)) return url;
+    extractionSteps.push(`Extract | Image | Discarded ${url} (not an image)`);
+  }
+
+  if (candidates.length > 0) {
+    extractionSteps.push(`Extract | Image | No candidate resolved to an image`);
+  }
+  return null;
 }
 
 

--- a/backend/tests/unit/image-verify.test.ts
+++ b/backend/tests/unit/image-verify.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { isImageResponse, needsVerification } from '../../src/services/scraper/metadata/image-verify';
+
+/**
+ * Ranking alone could not fix the reported Telstra product: every candidate on
+ * that page is a directory, including the og:image, so reordering only changed
+ * which broken URL won. Measured against the live page, the directory returns
+ * 404 text/html and the only real image files in the static HTML are
+ * pictograms and a preloader (issue #164).
+ *
+ * The decision is separated from the request so it can be pinned down without
+ * a network or a mocked client -- the rules are the part worth testing, and
+ * the request around them is three lines of axios.
+ */
+
+describe('needsVerification spends requests only where they might help', () => {
+  it.each([
+    'https://x.test/p.jpg',
+    'https://x.test/p.jpg?w=800&fm=webp',
+    'https://x.test/a/b/c.webp',
+  ])('trusts %s without a request', (url) => {
+    expect(needsVerification(url)).toBe(false);
+  });
+
+  it.each([
+    'https://telstra.com.au/content/dam/a/hazel/',
+    'https://x.test/image/12345',
+  ])('checks %s', (url) => {
+    expect(needsVerification(url)).toBe(true);
+  });
+
+  it('does not try to verify something that is not a URL', () => {
+    expect(needsVerification('not a url')).toBe(false);
+  });
+});
+
+describe('isImageResponse', () => {
+  it('accepts an image content-type', () => {
+    expect(isImageResponse(200, 'image/webp')).toBe(true);
+  });
+
+  it('rejects the reported case: 404 text/html', () => {
+    expect(isImageResponse(404, 'text/html;charset=utf-8')).toBe(false);
+  });
+
+  it('rejects a 200 that is not an image', () => {
+    // A CMS serving a directory listing rather than an error.
+    expect(isImageResponse(200, 'text/html')).toBe(false);
+  });
+
+  it('accepts a 200 with no content-type rather than guessing', () => {
+    // Some CDNs omit it on HEAD. Absence is not evidence.
+    expect(isImageResponse(200, undefined)).toBe(true);
+    expect(isImageResponse(200, '')).toBe(true);
+  });
+
+  it.each([301, 302, 304])('accepts %s, which axios follows or treats as fresh', (status) => {
+    expect(isImageResponse(status, 'image/png')).toBe(true);
+  });
+
+  it.each([403, 404, 410, 500])('rejects %s', (status) => {
+    expect(isImageResponse(status, 'image/png')).toBe(false);
+  });
+
+  it('is case-insensitive about the content-type', () => {
+    expect(isImageResponse(200, 'IMAGE/JPEG')).toBe(true);
+  });
+});

--- a/frontend/src/features/products/components/ItemCard/ItemCard.tsx
+++ b/frontend/src/features/products/components/ItemCard/ItemCard.tsx
@@ -56,6 +56,11 @@ const ItemCard: React.FC<ItemCardProps> = ({ item, userLocale }) => {
                   {item.all_tied
                     ? `same at all ${item.comparable_count}`
                     : `best of ${item.comparable_count}`}
+                  {/*
+                    The label stays even though every store is now highlighted:
+                    the marks say which stores are cheapest, the label says there
+                    is nothing to choose between them.
+                  */}
                 </div>
               )}
             </>
@@ -92,11 +97,16 @@ const ItemCard: React.FC<ItemCardProps> = ({ item, userLocale }) => {
             to="/products/$productId"
             params={{ productId: String(listing.id) }}
             /*
-              Every listing at the best price is marked, not just whichever
-              sorted first -- and none is when they are all tied, since
-              highlighting all of them says nothing.
+              Every listing at the best price is marked, including when they all
+              tie (issue #161).
+
+              This first suppressed the highlight on an all-tied item, reasoning
+              that marking everything says nothing. That was wrong: green means
+              "this store has the lowest price", and when two stores tie both
+              genuinely do. Suppressing it makes the user learn a special case,
+              and asks them to notice an absence rather than read a mark.
             */
-            className={`item-listing ${!item.all_tied && item.best_price_listing_ids.includes(listing.id) ? 'is-best' : ''}`}
+            className={`item-listing ${item.best_price_listing_ids.includes(listing.id) ? 'is-best' : ''}`}
           >
             <span className="item-listing-store">
               {listing.retailer_name || hostOf(listing.url)}


### PR DESCRIPTION
Both reopened by @stevene1919. He is right on one and asking a fair question on the other.

## #161 — every tied store is highlighted

I originally suppressed the highlight when all stores tied, reasoning that marking everything says nothing. **That was the wrong call and his argument is better:** green means *"this store has the lowest price"*, and when two stores tie both genuinely do. Suppressing it makes the user learn a special case, and asks them to notice an absence rather than read a mark.

The backend already returned every tied listing — only the frontend was hiding them. The "same at all 2" label stays: the marks say which stores are cheapest, the label says there is nothing to choose between them.

## #164 — he was right, twice over

He tested `2.1.0-beta.9` and reported it still broken. Two things:

**The fix was not in that build.** It merged five hours after the tag.

**But it would not have been enough anyway.** Testing properly against the live page — which is what he asked, and I had only tested synthetic URLs:

```
json-ld   score 0.51  /content/dam/.../ghdwerb-pbp2/porcelain/
json-ld   score 0.51  /content/dam/.../ghdwerb-pbp2/hazel/
og:image  score 0.80  https://telstra.com.au/content/dam/.../ghdwerb-pbp2/
```

**Every candidate is a directory, the `og:image` included.** Reordering only changes which broken URL wins. The page's only real image files are pictograms and a preloader — the product image is rendered by JavaScript. And the directory does 404 with `text/html`, exactly as the issue said.

So a URL that cannot be ranked away is now checked:

```
Telstra directory (the reported one)   verify=true   accepted=false
Telstra og:image (also a directory)    verify=true   accepted=false
a real image file elsewhere            verify=false  accepted=true
```

Deliberately narrow — only candidates the heuristic already flagged, only the chosen one, HEAD with a short timeout, at most three per scrape. A URL naming a real image file costs nothing, which is nearly all of them.

**Fails open.** A timeout, a refusal, a retailer that rejects HEAD — none prove the URL is bad, and discarding a working image because a check could not complete would be worse than the bug. When nothing verifies, the result is **no image rather than a broken one**: a placeholder reads as the retailer being unhelpful, a broken image reads as the app failing.

Telstra will still not show a product image, because there isn't one in the HTML we fetch — that needs the Browser Scraper enabled for the domain. What it will no longer do is store a URL known to 404.

## A note on the tests

The verification decision is a pure function separate from the request. That started as a way around vitest reporting mocked rejections as unhandled errors, but it is the better shape regardless — the rules are what is worth pinning down; the request around them is three lines of axios.

621 tests, up from 603.

Closes #161
Closes #164
