### PR TITLE
fix(debug): show why an image candidate failed, not a broken icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The debug page shows a "did not load" marker for an image candidate that
+  resolves to nothing, instead of the browser's broken-image icon (#180). The
+  page deliberately lists candidates the extractor rejected, and a broken icon
+  read as the page malfunctioning rather than as the candidate being bad.
+
 ## [2.1.0-beta.10] - 2026-09-10
 
 ### Fixed

--- a/frontend/src/features/debug/components/ImagePreview.tsx
+++ b/frontend/src/features/debug/components/ImagePreview.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+
+interface ImagePreviewProps {
+  src: string | null | undefined;
+  /** Rendered size. The candidate table uses a thumbnail, the header a frame. */
+  size?: number;
+  /** Shown when there is no URL at all, as opposed to one that failed. */
+  emptyLabel?: string;
+}
+
+/**
+ * An image that says when it could not load, instead of showing a broken icon
+ * (issue #180).
+ *
+ * The debug page lists every candidate the extractor considered, including ones
+ * it rejected -- that is the point of the page. But rendering them as plain
+ * <img> meant a directory URL from JSON-LD drew the browser's broken-image
+ * glyph, which reads as the page malfunctioning rather than as the candidate
+ * being bad.
+ *
+ * Distinguishing "did not load" from "nothing here" matters on this page
+ * specifically: someone is looking at it to work out *why* a retailer is
+ * misbehaving, and "this candidate resolves to nothing" is the answer they came
+ * for rather than a rendering artefact.
+ */
+const ImagePreview: React.FC<ImagePreviewProps> = ({ src, size, emptyLabel = 'No Image' }) => {
+  const [failed, setFailed] = useState(false);
+
+  // A new URL deserves a fresh attempt; without this a candidate that failed
+  // once stays marked failed when the panel is reused for another scrape.
+  useEffect(() => setFailed(false), [src]);
+
+  const boxStyle: React.CSSProperties = size
+    ? { width: size, height: size, objectFit: 'contain', flex: '0 0 auto' }
+    : {};
+
+  if (!src) {
+    return <div className="image-placeholder" style={boxStyle}>{emptyLabel}</div>;
+  }
+
+  if (failed) {
+    return (
+      <div
+        className="image-placeholder image-placeholder-failed"
+        style={boxStyle}
+        title={`This URL did not load as an image:\n${src}`}
+      >
+        {size ? '!' : 'Did not load'}
+      </div>
+    );
+  }
+
+  return <img src={src} alt="" style={boxStyle} onError={() => setFailed(true)} />;
+};
+
+export default ImagePreview;

--- a/frontend/src/features/debug/pages/DebugPage.css
+++ b/frontend/src/features/debug/pages/DebugPage.css
@@ -295,3 +295,18 @@
 
 .fade-in { animation: fadeIn 0.4s ease-out; }
 @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+/*
+ * A candidate that did not load, distinguished from one that was never there
+ * (issue #180). Muted rather than alarming: on the debug page a failed
+ * candidate is information, not an error.
+ */
+.image-placeholder-failed {
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--border);
+  border-radius: 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.65rem;
+  cursor: help;
+}

--- a/frontend/src/features/debug/pages/ResultDisplay.tsx
+++ b/frontend/src/features/debug/pages/ResultDisplay.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { formatPrice } from '../../../utils/format';
 import PriceSelectionModal from '../../products/components/PriceSelectionModal';
 import Icon from '../../../components/Icon';
+import ImagePreview from '../components/ImagePreview';
 
 interface ResultDisplayProps {
   state: {
@@ -87,7 +88,7 @@ export default function ResultDisplay({ state, actions }: ResultDisplayProps) {
           <div className="card-body">
             <div className="product-glance" style={{ flexWrap: 'wrap' }}>
               <div className="product-image-frame">
-                {result.imageUrl ? <img src={result.imageUrl} alt="" /> : <div className="image-placeholder">No Image</div>}
+                <ImagePreview src={result.imageUrl} />
               </div>
               <div className="product-info">
                 <div className="retailer-label">{result.retailerName || 'Generic Extraction'}</div>
@@ -203,7 +204,7 @@ export default function ResultDisplay({ state, actions }: ResultDisplayProps) {
                         <td className="price-val">
                           {activeCandidateTab === 'image' && typeof c.value === 'string' ? (
                             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                              <img src={c.value} alt="" style={{ width: '24px', height: '24px', objectFit: 'contain' }} />
+                              <ImagePreview src={c.value} size={24} />
                               <small style={{ fontSize: '0.6rem', color: 'var(--text-muted)', maxWidth: '150px', overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.value}</small>
                             </div>
                           ) : isPriceTab ? (


### PR DESCRIPTION
@stevene1919 in #180, following #164.

The debug page lists every candidate the extractor considered, **including the ones it rejected** — that is the point of the page. But it rendered them as plain `<img>`, so a directory URL from JSON-LD drew the browser's broken-image glyph.

That reads as the page malfunctioning rather than as the candidate being bad, which is backwards: someone is on this page to find out *why* a retailer is misbehaving, and "this candidate resolves to nothing" is the answer they came for.

Both image spots now go through one component distinguishing three states — an image, a URL that did not load, and no URL at all. The failed state carries the URL in its `title`, since that is what you want to copy when working out which selector to change.

Muted rather than alarming: on this page a failed candidate is information, not an error.

## Two details

**The empty state keeps its current appearance.** `.image-placeholder` was never actually styled, so adding a base style would have changed how "No Image" looks today for no reason. Only the failed variant is styled.

**Resetting on URL change matters more than it looks.** Without it, a candidate that failed once stays marked failed when the panel is reused for the next scrape — a worse lie than the broken icon.

Closes #180